### PR TITLE
feat(render): update `render(..)` call compatibility and functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 > [!WARNING]
-> Ensure to install the ``0.99.7``+ version of ``xnano`` to ensure correct
+> Ensure to install the ``1.0.0b1``+ version of ``xnano`` to ensure correct
 > dependency and API resolution.
 
 ```bash
-pip install "xnano>=0.99.7"
+pip install "xnano>=1.0.0b1"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=0.99.7"
+uv add "xnano>=1.0.0b1"
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "0.99.7"
+version = "1.0.0b1"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/scripts/set_version.py
+++ b/scripts/set_version.py
@@ -59,9 +59,15 @@ _VERSION_PY_CORE = re.compile(
     r'^_COMPATIBLE_XNANO_CORE_VERSION = "(?P<version>[^"]+)"$',
     re.MULTILINE,
 )
-_README_MIN_VERSION = re.compile(r"``(\d+\.\d+\.\d+)``\+ version")
-_README_PIP_INSTALL = re.compile(r'pip install "xnano>=(\d+\.\d+\.\d+)"')
-_README_UV_ADD = re.compile(r'uv add "xnano>=(\d+\.\d+\.\d+)"')
+_README_MIN_VERSION = re.compile(
+    r"``(\d+\.\d+\.\d+(?:[a-zA-Z]+\d+)?)``\+ version"
+)
+_README_PIP_INSTALL = re.compile(
+    r'pip install "xnano>=(\d+\.\d+\.\d+(?:[a-zA-Z]+\d+)?)"'
+)
+_README_UV_ADD = re.compile(
+    r'uv add "xnano>=(\d+\.\d+\.\d+(?:[a-zA-Z]+\d+)?)"'
+)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/test_render_fallback.py
+++ b/tests/test_render_fallback.py
@@ -259,7 +259,9 @@ def test_border_title_in_top() -> None:
 
 
 def test_border_title_in_bottom() -> None:
-    result = _apply_border(["content"], "rounded", None, "", "MyTitle", "bottom")
+    result = _apply_border(
+        ["content"], "rounded", None, "", "MyTitle", "bottom"
+    )
     assert "MyTitle" in result[-1]
     assert "MyTitle" not in result[0]
 
@@ -291,7 +293,9 @@ def test_border_color_prefix_wraps_chars() -> None:
 
 
 def test_border_multiline_content() -> None:
-    result = _apply_border(["line one", "line two"], "rounded", None, "", None, None)
+    result = _apply_border(
+        ["line one", "line two"], "rounded", None, "", None, None
+    )
     assert result[0].startswith("╭")
     assert "│" in result[1]
     assert "│" in result[2]
@@ -355,7 +359,7 @@ def _call_render(**kwargs):
         text = kw.get("sep", " ").join(str(a) for a in args)
         printed.append(text)
 
-    builtins.print = fake_print # type: ignore
+    builtins.print = fake_print  # type: ignore
     try:
         renderables = kwargs.pop("renderables", ("hello",))
         _render_to_stdout(

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -602,7 +602,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -2495,7 +2495,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "0.99.7"
+version = "1.0.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-core" },

--- a/xnano/beta/core/version.py
+++ b/xnano/beta/core/version.py
@@ -8,7 +8,7 @@ from xnano_core.rust.native import __version__ as __xnano_core_version__
 
 __all__ = ("VERSION", "check_xnano_core_version")
 
-VERSION = "0.99.7"
+VERSION = "1.0.0b1"
 """The version of xnano.
 
 This version specifier is guaranteed to be compliant with the [specification],


### PR DESCRIPTION
Summary

- The render() fallback path (outside an active terminal session) previously ignored all styling arguments and called bare print(). This replaces it with a full ANSI-based renderer so every option is honoured at the terminal.
- Adds _render_to_stdout and a set of composable helpers (_build_ansi_prefix, _apply_padding, _apply_border, _join_horizontal, _renderable_to_lines) — all pure Python, no native deps in the fallback path.
- Adds tests/test_render_fallback.py — 79 tests covering every helper and the public render() API end-to-end.

What changed

xnano/beta/core/renderable.py

┌──────────────────────┬────────────────────────────────────────────────────────────────────────────────────────┐
│        Helper        │                                        Purpose                                         │
├──────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ _renderable_to_lines │ Converts any renderable (str, int, float, bool, list, tuple, arbitrary object) to      │
│                      │ list[str]                                                                              │
├──────────────────────┼───────────────────────────────────────────────────────────┤
│ _ansi_color          │ Emits a 24-bit ANSI foreground or background escape (\033[38;2;R;G;Bm)                 │
├──────────────────────┼───────────────────────────────────────────────────────────┤
│ _build_ansi_prefix   │ Builds the full ANSI prefix string from color, background, and modifiers               │
├──────────────────────┼───────────────────────────────────────────────────────────┤
│ _apply_padding       │ Applies PaddingLike whitespace around content lines, normalising all lines to the same │
│                      │  width                                                    │
├──────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ _apply_border        │ Draws box-drawingunded, double, thick, quadrant_inside,   │
│                      │ quadrant_outside) with optional side selection, border colour, and title placement     │
├──────────────────────┼───────────────────────────────────────────────────────────┤
│ _join_horizontal     │ Tiles multiple line-groups side by side, padding shorter groups to match height        │
├──────────────────────┼───────────────────────────────────────────────────────────┤
│ _render_to_stdout    │ Orchestrates the above into a single print() call                                      │
└──────────────────────┴───────────────────────────────────────────────────────────┘

The render() function's else branch now cassing all kwargs through instead of the oldtwo-liner.

Test coverage (tests/test_render_fallback.py)

- _renderable_to_lines — string, multiline string, empty string, int, float, bool, list, nested list, tuple,
arbitrary object repr, multiline repr
- _ansi_color — foreground and background variants
- _build_ansi_prefix — each of the 7 modifns, color-by-name, color-by-hex, background, combined color+modifier, invalid color silently skipped
- _apply_padding — None no-op, uniform inte, multiline content normalised to samewidth, empty input
- _apply_border — None no-op, each border fault, border_sides partial (top only,left+right only), border color prefix wrapping, multiline content
- _join_horizontal — equal heights, unequaed), empty input, single group, unequalwidths
- _render_to_stdout — plain string, bold,  border, vertical stack, horizontal join,padding, center align, title, multiple modifiers, empty renderables, int renderable, list renderable
- render() public API — bold, color name, ding+border, title, multiple vertical,multiple horizontal, hex color, background color, partial border sides, align, int, float, empty string, border color