### PR TITLE
fix(render_ir): push field background onto spans rather than flood-filling slot

### DIFF
--- a/xnano-core/Cargo.lock
+++ b/xnano-core/Cargo.lock
@@ -1038,7 +1038,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xnano-core"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "crossterm",
  "lru 0.16.4",

--- a/xnano-core/rust/src/bindings/engine/render_ir.rs
+++ b/xnano-core/rust/src/bindings/engine/render_ir.rs
@@ -765,6 +765,31 @@ fn line_width(line: &Line<'_>) -> usize {
 
 // ── Rust-internal rendering ───────────────────────────────────────────────────
 
+/// Split a style into (text-with-bg-on-spans, paragraph-without-bg).
+///
+/// Ratatui's `Paragraph::style()` calls `buf.set_style(rect, style)` which
+/// flood-fills the entire allocated rect with the background color before
+/// any characters are drawn.  Pushing `bg` down onto each span instead makes
+/// ratatui paint background behind actual character cells only, so
+/// `Field(background="violet")` covers the text span rather than the whole
+/// slot.
+///
+/// The text is cloned once (unavoidable — the caller needs an owned `Text`)
+/// and styles are patched in place, so no per-span content is re-allocated.
+fn split_bg_to_content(text: &Text<'static>, style: &Style) -> (Text<'static>, Style) {
+    let Some(bg_color) = style.bg else {
+        return (text.clone(), *style);
+    };
+    let bg_only = Style::new().bg(bg_color);
+    let mut styled = text.clone();
+    for line in &mut styled.lines {
+        for span in &mut line.spans {
+            span.style = span.style.patch(bg_only);
+        }
+    }
+    (styled, Style { bg: None, ..*style })
+}
+
 impl CoreRenderIR {
     pub(crate) fn render_to_buffer(&self, rect: Rect, buf: &mut Buffer) -> PyResult<()> {
         match &self.inner {
@@ -778,11 +803,16 @@ impl CoreRenderIR {
             }
 
             RenderIrInner::Text { text, style } => {
-                Widget::render(Paragraph::new(text.clone()).style(*style), rect, buf);
+                // Move bg off the Paragraph container (which would flood-fill the
+                // entire rect) and onto the Text content so background only covers
+                // character cells, not trailing empty space.
+                let (styled_text, para_style) = split_bg_to_content(text, style);
+                Widget::render(Paragraph::new(styled_text).style(para_style), rect, buf);
             }
 
             RenderIrInner::Paragraph { text, style, align, wrap } => {
-                let mut para = Paragraph::new(text.clone()).style(*style);
+                let (styled_text, para_style) = split_bg_to_content(text, style);
+                let mut para = Paragraph::new(styled_text).style(para_style);
                 if *wrap { para = para.wrap(Wrap { trim: true }); }
                 if let Some(a) = align { para = para.alignment(*a); }
                 Widget::render(para, rect, buf);


### PR DESCRIPTION
## Summary

- Introduces `split_bg_to_content()` in `render_ir.rs` which moves the background color off the `Paragraph` container and onto each individual span
- Ratatui's `Paragraph::style()` previously flood-filled the entire allocated rect before drawing characters; background now only covers actual glyph cells
- Applies to both `Text` and `Paragraph` IR variants

## Test plan

- [ ] `uv run pytest tests/test_grid_init.py` — `test_field_background_covers_text_span_only` verifies violet background covers only text cells, not trailing space
- [ ] `uv run pytest tests/test_terminal_render.py` — `test_field_frame_none_when_no_chrome` confirms background-only fields produce no frame

> **Merge order:** this should be merged **first** before `xnano/fix(field-background)` and `update-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)