### PR TITLE
fix(frame): restrict Field background to text cells; add TailwindColorBinding and VHS utils

### DIFF
--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from xnano.beta.frame import Frame
+from xnano.beta.fields import GridFieldInfo
+from xnano.beta.frame import Frame, frame_from_field
 
 
 def test_frame_default_is_empty() -> None:
@@ -43,6 +44,19 @@ def test_frame_is_frozen() -> None:
     f = Frame(border="plain")
     with pytest.raises((AttributeError, TypeError)):
         f.border = "rounded"  # ty: ignore[invalid-assignment]
+
+
+def test_frame_from_field_background_only_is_none() -> None:
+    assert frame_from_field(GridFieldInfo(background="violet")) is None
+
+
+def test_frame_from_field_background_with_border() -> None:
+    frame = frame_from_field(
+        GridFieldInfo(background="slate-800", border="rounded")
+    )
+    assert frame is not None
+    assert frame.background == "slate-800"
+    assert frame.border == "rounded"
 
 
 def test_frame_all_attrs_set() -> None:

--- a/tests/test_grid_init.py
+++ b/tests/test_grid_init.py
@@ -90,6 +90,66 @@ def test_grid_play_effect_targets_layout_field_area() -> None:
     assert core.is_animating()
 
 
+def test_field_text_background_does_not_paint_frame() -> None:
+    class App(Grid, direction="vertical"):
+        header: str = Field(
+            default="My App",
+            height=1,
+            color="white",
+            background="violet",
+        )
+        body: str = Field(default="Hello, world!")
+
+    grid = App()
+    core = CoreSession.offscreen(width=40, height=6)
+    session = Session(
+        core,
+        terminal_width=40,
+        terminal_height=6,
+        is_offscreen=True,
+    )
+    grid._grid_build_frame(GridArea(x=0, y=0, width=40, height=6), session)
+    session.commit_requests()
+    output = session.get_core_session_output_text()
+    lines = output.splitlines()
+    assert lines[0] == "My App"
+    assert lines[1] == "Hello, world!"
+    assert "┌" not in output
+
+
+def test_field_background_covers_text_span_only() -> None:
+    # A field background should paint behind the text glyphs only, not flood
+    # the whole slot to the right edge. "violet" == #ee82ee.
+    class App(Grid, direction="vertical"):
+        header: str = Field(
+            default="My App",
+            height=1,
+            color="white",
+            background="violet",
+        )
+        body: str = Field(default="Hello, world!")
+
+    grid = App()
+    core = CoreSession.offscreen(width=40, height=6)
+    session = Session(
+        core,
+        terminal_width=40,
+        terminal_height=6,
+        is_offscreen=True,
+    )
+    grid._grid_build_frame(GridArea(x=0, y=0, width=40, height=6), session)
+    session.commit_requests()
+
+    buffer = core.buffer_snapshot()
+    violet = native.Color.rgb(238, 130, 238)
+    # "My App" is 6 cells: every glyph cell carries the accent background.
+    for x in range(len("My App")):
+        assert buffer.cell_bg(x, 0) == violet
+    # Trailing cells stay unpainted rather than a full-width bar.
+    for x in (len("My App"), 20, 39):
+        assert buffer.cell_bg(x, 0) != violet
+
+
 def test_field_defaults_render_offscreen() -> None:
     root = Root()
     core = CoreSession.offscreen(width=40, height=8)

--- a/tests/test_terminal_render.py
+++ b/tests/test_terminal_render.py
@@ -63,6 +63,7 @@ def test_field_frame_none_when_no_chrome() -> None:
     assert dispatch.field_frame(GridFieldInfo()) is None
     assert dispatch.field_frame(None) is None
     assert dispatch.field_frame(GridFieldInfo(border="plain")) is not None
+    assert dispatch.field_frame(GridFieldInfo(background="violet")) is None
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +116,53 @@ def test_render_paints_single_line() -> None:
     assert lines[0] == "hi, how are you?"
     # Remaining rows stay blank — content is not stretched to fill the screen.
     assert all(line == "" for line in lines[1:])
+
+
+def test_render_paints_embedded_newlines() -> None:
+    terminal = Terminal.offscreen(cols=50, rows=6)
+    terminal.render("line one\n\nline three")
+    lines = [line.rstrip() for line in terminal.get_output().splitlines()]
+    assert lines[0] == "line one"
+    assert lines[1] == ""
+    assert lines[2] == "line three"
+
+
+def test_render_resolve_inline_height_grows_with_multiline_content() -> None:
+    terminal: Terminal = Terminal()
+    single = terminal._resolve_run(
+        ["hello, world!"], is_grid=False, field=None
+    )
+    multi = terminal._resolve_run(
+        ["this will be updated in 1 second: \n\nhello, world!"],
+        is_grid=False,
+        field=None,
+    )
+    assert single.inline_height == 1
+    assert multi.inline_height == 3
+
+
+def test_render_prepare_session_recreates_when_inline_height_changes() -> None:
+    from unittest import mock
+
+    terminal: Terminal = Terminal()
+    terminal._is_live = True
+    terminal._pending_enter = False
+    core_session = mock.Mock()
+    core_session.get_inline_height.return_value = 1
+    session = mock.Mock()
+    session._is_offscreen = False
+    session._core_session = core_session
+    terminal._session = session
+
+    terminal._prepare_render_session(
+        ["this will be updated in 1 second: \n\nhello, world!"],
+        None,
+    )
+
+    session.leave.assert_called_once()
+    assert terminal._session is None
+    assert terminal._inline_height == 3
+    assert terminal._pending_enter is True
 
 
 def test_render_stacks_multiple_renderables() -> None:

--- a/tests/test_vhs_recording.py
+++ b/tests/test_vhs_recording.py
@@ -1,0 +1,68 @@
+"""tests.test_vhs_recording"""
+
+import pytest
+
+from xnano_core.rust import native
+
+from xnano.beta.utils import vhs_recording
+
+
+@pytest.fixture
+def clear_vhs_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "XNANO_VHS_MONO",
+        "XNANO_VHS_DOCS_BG",
+        "XNANO_VHS_THEME",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_remap_passthrough_without_env(clear_vhs_env: None) -> None:
+    assert vhs_recording.remap_color_for_vhs("violet-500") == "violet-500"
+    assert vhs_recording.remap_color_for_vhs(
+        "violet-900",
+        role="background",
+    ) == "violet-900"
+
+
+def test_remap_mono_foreground(clear_vhs_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XNANO_VHS_MONO", "1")
+    monkeypatch.setenv("XNANO_VHS_THEME", "dark")
+    assert vhs_recording.remap_color_for_vhs("rose-500") == vhs_recording.MONO_FG_DARK
+    assert vhs_recording.remap_color_for_vhs(
+        "rose-500",
+        role="background",
+    ) == vhs_recording.DOC_BG_DARK
+
+
+def test_remap_mono_light_theme(clear_vhs_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XNANO_VHS_MONO", "1")
+    monkeypatch.setenv("XNANO_VHS_THEME", "light")
+    assert vhs_recording.remap_color_for_vhs("sky-400") == vhs_recording.MONO_FG_LIGHT
+
+
+def test_remap_docs_background_passthrough(
+    clear_vhs_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Docs-background mode leaves authored colors untouched: the renderer now
+    # paints field backgrounds behind text cells only, so accent backgrounds
+    # (e.g. a violet header) should render as designed rather than being
+    # flattened to the page color.
+    monkeypatch.setenv("XNANO_VHS_DOCS_BG", "1")
+    monkeypatch.setenv("XNANO_VHS_THEME", "light")
+    assert vhs_recording.remap_color_for_vhs("emerald-400") == "emerald-400"
+    assert (
+        vhs_recording.remap_color_for_vhs("violet-900", role="background")
+        == "violet-900"
+    )
+    assert vhs_recording.remap_color_for_vhs(None, role="background") is None
+
+
+def test_native_color_mono_mode(clear_vhs_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    from xnano.beta.utils.native_types import get_native_color_from_color_like
+
+    monkeypatch.setenv("XNANO_VHS_MONO", "1")
+    monkeypatch.setenv("XNANO_VHS_THEME", "dark")
+    color = get_native_color_from_color_like("rose-500", role="foreground")
+    expected = native.Color.rgb(222, 220, 209)
+    assert color == expected

--- a/xnano/beta/color.py
+++ b/xnano/beta/color.py
@@ -3,32 +3,42 @@
 Functional color types and utilities. This module ports many of it's
 primitives directly from the ``pydantic_extra_types.Color`` module.
 
-You can view the original source code here:
-
-[Color](https://github.com/pydantic/pydantic-extra-types/blob/main/pydantic_extra_types/color.py)
+You can view the original source code here: [Pydantic Extra Types Color](https://github.com/pydantic/pydantic-extra-types/blob/main/pydantic_extra_types/color.py)
 """
 
 from __future__ import annotations
 
 import dataclasses
 import re
-from typing import Any, ClassVar, Literal, TypeAlias, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Literal,
+    TypeAlias,
+    Union,
+    cast,
+)
 
 
 _TAILWIND_CACHE: dict[tuple[str, int], Color] = {}
 
 
-ColorLike: TypeAlias = Union["ColorName", str, "ColorTuple", "Color"]
+ColorLike: TypeAlias = Union[
+    "ColorName", "TailwindColorBinding", str, "ColorTuple", "Color"
+]
 """A color-like input.
 
 This can be any one of:
-    - A known color name.
-    - A hex color string
-    - A tuple of 3 or 4 integers representing RGB or RGBA components
-    - A ``Color`` instance
+    - A known color name (e.g. ``"red"``, ``"aliceblue"``).
+    - A Tailwind CSS binding string (e.g. ``"slate-400"``, ``"violet-900"``).
+    - A hex color string (e.g. ``"#FF0000"``).
+    - A tuple of 3 or 4 integers representing RGB or RGBA components.
+    - A ``Color`` instance.
 
 Example:
     >>> ColorLike = "red" | "aliceblue" | "black"
+    >>> ColorLike = "slate-400"
     >>> ColorLike = "#FF0000"
     >>> ColorLike = (255, 0, 0)
     >>> ColorLike = (255, 0, 0, 1.0)
@@ -231,6 +241,311 @@ TailwindColorShade: TypeAlias = Literal[
 Tailwind CSS shade values."""
 
 
+TailwindColorBinding: TypeAlias = Literal[
+    "amber-50",
+    "amber-100",
+    "amber-200",
+    "amber-300",
+    "amber-400",
+    "amber-500",
+    "amber-600",
+    "amber-700",
+    "amber-800",
+    "amber-900",
+    "amber-950",
+    "black-50",
+    "black-100",
+    "black-200",
+    "black-300",
+    "black-400",
+    "black-500",
+    "black-600",
+    "black-700",
+    "black-800",
+    "black-900",
+    "black-950",
+    "blue-50",
+    "blue-100",
+    "blue-200",
+    "blue-300",
+    "blue-400",
+    "blue-500",
+    "blue-600",
+    "blue-700",
+    "blue-800",
+    "blue-900",
+    "blue-950",
+    "cyan-50",
+    "cyan-100",
+    "cyan-200",
+    "cyan-300",
+    "cyan-400",
+    "cyan-500",
+    "cyan-600",
+    "cyan-700",
+    "cyan-800",
+    "cyan-900",
+    "cyan-950",
+    "emerald-50",
+    "emerald-100",
+    "emerald-200",
+    "emerald-300",
+    "emerald-400",
+    "emerald-500",
+    "emerald-600",
+    "emerald-700",
+    "emerald-800",
+    "emerald-900",
+    "emerald-950",
+    "fuchsia-50",
+    "fuchsia-100",
+    "fuchsia-200",
+    "fuchsia-300",
+    "fuchsia-400",
+    "fuchsia-500",
+    "fuchsia-600",
+    "fuchsia-700",
+    "fuchsia-800",
+    "fuchsia-900",
+    "fuchsia-950",
+    "gray-50",
+    "gray-100",
+    "gray-200",
+    "gray-300",
+    "gray-400",
+    "gray-500",
+    "gray-600",
+    "gray-700",
+    "gray-800",
+    "gray-900",
+    "gray-950",
+    "green-50",
+    "green-100",
+    "green-200",
+    "green-300",
+    "green-400",
+    "green-500",
+    "green-600",
+    "green-700",
+    "green-800",
+    "green-900",
+    "green-950",
+    "indigo-50",
+    "indigo-100",
+    "indigo-200",
+    "indigo-300",
+    "indigo-400",
+    "indigo-500",
+    "indigo-600",
+    "indigo-700",
+    "indigo-800",
+    "indigo-900",
+    "indigo-950",
+    "lime-50",
+    "lime-100",
+    "lime-200",
+    "lime-300",
+    "lime-400",
+    "lime-500",
+    "lime-600",
+    "lime-700",
+    "lime-800",
+    "lime-900",
+    "lime-950",
+    "neutral-50",
+    "neutral-100",
+    "neutral-200",
+    "neutral-300",
+    "neutral-400",
+    "neutral-500",
+    "neutral-600",
+    "neutral-700",
+    "neutral-800",
+    "neutral-900",
+    "neutral-950",
+    "orange-50",
+    "orange-100",
+    "orange-200",
+    "orange-300",
+    "orange-400",
+    "orange-500",
+    "orange-600",
+    "orange-700",
+    "orange-800",
+    "orange-900",
+    "orange-950",
+    "pink-50",
+    "pink-100",
+    "pink-200",
+    "pink-300",
+    "pink-400",
+    "pink-500",
+    "pink-600",
+    "pink-700",
+    "pink-800",
+    "pink-900",
+    "pink-950",
+    "purple-50",
+    "purple-100",
+    "purple-200",
+    "purple-300",
+    "purple-400",
+    "purple-500",
+    "purple-600",
+    "purple-700",
+    "purple-800",
+    "purple-900",
+    "purple-950",
+    "red-50",
+    "red-100",
+    "red-200",
+    "red-300",
+    "red-400",
+    "red-500",
+    "red-600",
+    "red-700",
+    "red-800",
+    "red-900",
+    "red-950",
+    "rose-50",
+    "rose-100",
+    "rose-200",
+    "rose-300",
+    "rose-400",
+    "rose-500",
+    "rose-600",
+    "rose-700",
+    "rose-800",
+    "rose-900",
+    "rose-950",
+    "sky-50",
+    "sky-100",
+    "sky-200",
+    "sky-300",
+    "sky-400",
+    "sky-500",
+    "sky-600",
+    "sky-700",
+    "sky-800",
+    "sky-900",
+    "sky-950",
+    "slate-50",
+    "slate-100",
+    "slate-200",
+    "slate-300",
+    "slate-400",
+    "slate-500",
+    "slate-600",
+    "slate-700",
+    "slate-800",
+    "slate-900",
+    "slate-950",
+    "stone-50",
+    "stone-100",
+    "stone-200",
+    "stone-300",
+    "stone-400",
+    "stone-500",
+    "stone-600",
+    "stone-700",
+    "stone-800",
+    "stone-900",
+    "stone-950",
+    "teal-50",
+    "teal-100",
+    "teal-200",
+    "teal-300",
+    "teal-400",
+    "teal-500",
+    "teal-600",
+    "teal-700",
+    "teal-800",
+    "teal-900",
+    "teal-950",
+    "violet-50",
+    "violet-100",
+    "violet-200",
+    "violet-300",
+    "violet-400",
+    "violet-500",
+    "violet-600",
+    "violet-700",
+    "violet-800",
+    "violet-900",
+    "violet-950",
+    "white-50",
+    "white-100",
+    "white-200",
+    "white-300",
+    "white-400",
+    "white-500",
+    "white-600",
+    "white-700",
+    "white-800",
+    "white-900",
+    "white-950",
+    "yellow-50",
+    "yellow-100",
+    "yellow-200",
+    "yellow-300",
+    "yellow-400",
+    "yellow-500",
+    "yellow-600",
+    "yellow-700",
+    "yellow-800",
+    "yellow-900",
+    "yellow-950",
+    "zinc-50",
+    "zinc-100",
+    "zinc-200",
+    "zinc-300",
+    "zinc-400",
+    "zinc-500",
+    "zinc-600",
+    "zinc-700",
+    "zinc-800",
+    "zinc-900",
+    "zinc-950",
+]
+"""Tailwind CSS color binding strings in ``"{palette}-{shade}"`` form, e.g. ``"slate-400"``.
+
+These are accepted anywhere a ``ColorLike`` is expected and resolve via
+``tailwind_color(palette, shade)`` at parse time.
+"""
+
+_TAILWIND_NAMES: frozenset[str] = frozenset(
+    [
+        "amber",
+        "black",
+        "blue",
+        "cyan",
+        "emerald",
+        "fuchsia",
+        "gray",
+        "green",
+        "indigo",
+        "lime",
+        "neutral",
+        "orange",
+        "pink",
+        "purple",
+        "red",
+        "rose",
+        "sky",
+        "slate",
+        "stone",
+        "teal",
+        "violet",
+        "white",
+        "yellow",
+        "zinc",
+    ]
+)
+_TAILWIND_SHADES: frozenset[int] = frozenset(
+    [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]
+)
+
+
 @dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class Color:
     """A color in the RGBA space that can be defined from a variety
@@ -408,23 +723,41 @@ class Color:
     a: float = dataclasses.field(default=255.0)
 
     @classmethod
-    def from_name(cls, color: ColorName, alpha: float = 255.0) -> Color:
-        """Creates a color from a known color name. All color names and
-        their associated RGB representations are ported directly from the
-        ``pydantic_extra_types.Color.COLORS_BY_NAME`` dictionary.
+    def from_name(
+        cls, color: "ColorName | TailwindColorBinding", alpha: float = 255.0
+    ) -> "Color":
+        """Creates a color from a known color name or Tailwind binding string.
+
+        Accepts CSS named colors (``"red"``, ``"aliceblue"``, …) and
+        Tailwind ``"{palette}-{shade}"`` strings (``"slate-400"``,
+        ``"violet-900"``, …).
 
         Args:
-            color: The name of the color to create.
+            color: The name or Tailwind binding to resolve.
             alpha: The alpha component of the color. (Defaults to 255.0
                 if not provided.)
 
         Returns:
             The color created from the name.
         """
+        if "-" in color:
+            parts = color.rsplit("-", 1)
+            if len(parts) == 2 and parts[0] in _TAILWIND_NAMES:
+                try:
+                    shade = int(parts[1])
+                except ValueError:
+                    pass
+                else:
+                    if shade in _TAILWIND_SHADES:
+                        return tailwind_color(
+                            cast("TailwindColorName", parts[0]),
+                            cast("TailwindColorShade", shade),
+                        )
+        name = cast("ColorName", color)
         return cls(
-            r=cls.COLORS_BY_NAME[color][0],
-            g=cls.COLORS_BY_NAME[color][1],
-            b=cls.COLORS_BY_NAME[color][2],
+            r=cls.COLORS_BY_NAME[name][0],
+            g=cls.COLORS_BY_NAME[name][1],
+            b=cls.COLORS_BY_NAME[name][2],
             a=alpha,
         )
 
@@ -482,25 +815,23 @@ class Color:
 
     @classmethod
     def parse(
-        cls, color: ColorName | str | ColorTuple | Color, alpha: float = 255.0
-    ) -> Color:
+        cls,
+        color: "ColorName | TailwindColorBinding | str | ColorTuple | Color",
+        alpha: float = 255.0,
+    ) -> "Color":
         """Parses a color from a color-like input.
 
         Args:
-            color: The color-like input to parse.
-                This can be any of the following:
-                    - A known color name.
-                    - A hex color string
-                    - A tuple of 3 or 4 integers representing RGB or RGBA components
-                    - A ``Color`` instance
-            alpha: The alpha component of the color. (Defaults to 255.0
-                if not provided.)
-
-                NOTE: This is not applied if the input is a ``Color``
-                or RGBA tuple.
+            color: The color-like input to parse. Accepted forms:
+                - A known CSS color name (``"red"``, ``"aliceblue"``).
+                - A Tailwind binding string (``"slate-400"``, ``"violet-900"``).
+                - A hex string (``"#FF0000"``).
+                - An RGB or RGBA tuple.
+                - A ``Color`` instance.
+            alpha: Alpha component, 0–255. Not applied to ``Color`` or RGBA tuple inputs.
 
         Returns:
-            The color created from the input.
+            The resolved ``Color``.
         """
         if isinstance(color, Color):
             return color
@@ -514,20 +845,30 @@ class Color:
                     raise ValueError(
                         f"Error parsing hex-like string `{repr(color)}` into a color: {e}"
                     ) from e
-            else:
-                try:
-                    return Color.from_name(color, alpha)  # type: ignore
-                except Exception as e:
-                    raise ValueError(
-                        f"{color!r} is not a known color name: {e}.\n"
-                        "You can refer to ``xnano.theme.color.ColorName`` for a list of valid"
-                        "color names."
-                    ) from e
-        else:
-            raise ValueError(
-                f"Expected a color-like input (accepted: color name, hex string, RGB(A) tuple, "
-                "or Color instance), got {type(color).__name__} instead."
-            )
+            if "-" in color:
+                parts = color.rsplit("-", 1)
+                if len(parts) == 2 and parts[0] in _TAILWIND_NAMES:
+                    try:
+                        shade = int(parts[1])
+                    except ValueError:
+                        pass
+                    else:
+                        if shade in _TAILWIND_SHADES:
+                            return tailwind_color(
+                                cast("TailwindColorName", parts[0]),
+                                cast("TailwindColorShade", shade),
+                            )
+            try:
+                return Color.from_name(cast("ColorName", color), alpha)
+            except Exception as e:
+                raise ValueError(
+                    f"{color!r} is not a known color name or Tailwind binding: {e}.\n"
+                    'Valid forms: CSS name ("red"), Tailwind binding ("slate-400"), hex ("#ff0000").'
+                ) from e
+        raise ValueError(
+            f"Expected a color-like input (color name, Tailwind binding, hex string, RGB(A) tuple, "
+            f"or Color instance), got {type(color).__name__!r} instead."
+        )
 
 
 def pydantic_color(color: ColorName) -> Color:
@@ -614,6 +955,9 @@ __all__ = (
     "ColorLike",
     "ColorTuple",
     "ColorName",
+    "TailwindColorName",
+    "TailwindColorShade",
+    "TailwindColorBinding",
     "Color",
     "pydantic_color",
     "tailwind_color",

--- a/xnano/beta/context.py
+++ b/xnano/beta/context.py
@@ -12,6 +12,8 @@ from xnano.beta.events import (
 )
 
 if TYPE_CHECKING:
+    from xnano.beta.cursor import Cursor
+    from xnano.beta.device import Device
     from xnano.beta.terminal import Terminal
 
 
@@ -52,12 +54,12 @@ class Context(Generic[StateT]):
         return self.state
 
     @property
-    def cursor(self) -> Any:
+    def cursor(self) -> Cursor | None:
         """Live cursor controller, forwarded from the active terminal."""
         return None if self.terminal is None else self.terminal.cursor
 
     @property
-    def device(self) -> Any:
+    def device(self) -> Device | None:
         """Live device controller, forwarded from the active terminal."""
         return None if self.terminal is None else self.terminal.device
 

--- a/xnano/beta/core/dispatch.py
+++ b/xnano/beta/core/dispatch.py
@@ -181,24 +181,9 @@ def field_frame(field: Any) -> Any | None:
     Returns:
         A ``Frame`` when the field defines any chrome, otherwise ``None``.
     """
-    if field is None:
-        return None
-    from xnano.beta.frame import Frame
+    from xnano.beta.frame import frame_from_field
 
-    frame = Frame(
-        background=field.background,
-        border=field.border,
-        border_color=field.border_color,
-        border_sides=(
-            list(field.border_sides)
-            if field.border_sides is not None
-            else None
-        ),
-        title=field.title,
-        title_position=field.title_position,
-        padding=field.padding,
-    )
-    return None if frame.is_empty() else frame
+    return frame_from_field(field)
 
 
 def measure_renderable_in_field(

--- a/xnano/beta/core/nodes.py
+++ b/xnano/beta/core/nodes.py
@@ -677,7 +677,15 @@ class NodeAssembler:
             get_native_color_from_color_like,
         )
 
-        return get_native_color_from_color_like(color)
+        return get_native_color_from_color_like(color, role="foreground")
+
+    @staticmethod
+    def _bg(color: "Any") -> "Any":
+        from xnano.beta.utils.native_types import (
+            get_native_color_from_color_like,
+        )
+
+        return get_native_color_from_color_like(color, role="background")
 
     @staticmethod
     def _mods(modifiers: "list[Any]") -> "list[Any]":
@@ -724,14 +732,14 @@ class NodeAssembler:
                     (
                         node.content,
                         cls._c(node.color),
-                        cls._c(node.background),
+                        cls._bg(node.background),
                         cls._mods(node.modifiers),
                     )
                 ]
             )
         # LineNode
         fg = cls._c(node.color)
-        bg = cls._c(node.background)
+        bg = cls._bg(node.background)
         mods = cls._mods(node.modifiers)
         if isinstance(node.content, str) or node.content is None:
             return IrLine.styled(node.content or "", fg, bg, mods)
@@ -739,7 +747,7 @@ class NodeAssembler:
             (
                 s.content,
                 cls._c(s.color),
-                cls._c(s.background),
+                cls._bg(s.background),
                 cls._mods(s.modifiers),
             )
             for s in node.content
@@ -772,7 +780,7 @@ class NodeAssembler:
             return CoreRenderIR.span(
                 node.content,
                 cls._c(node.color),
-                cls._c(node.background),
+                cls._bg(node.background),
                 cls._mods(node.modifiers),
             )
 
@@ -781,7 +789,7 @@ class NodeAssembler:
 
         if isinstance(node, TextNode):
             fg = cls._c(node.color)
-            bg = cls._c(node.background)
+            bg = cls._bg(node.background)
             mods = cls._mods(list(node.modifiers))
             align = cls._align(node.align)
             if node.lines:
@@ -791,7 +799,7 @@ class NodeAssembler:
 
         if isinstance(node, ParagraphNode):
             fg = cls._c(node.color)
-            bg = cls._c(node.background)
+            bg = cls._bg(node.background)
             mods = cls._mods(list(node.modifiers))
             align = cls._align(node.align)
             text = node.text
@@ -819,9 +827,9 @@ class NodeAssembler:
                 ir_items,
                 node.selected,
                 cls._c(node.color),
-                cls._c(node.background),
+                cls._bg(node.background),
                 cls._c(node.highlight_color),
-                cls._c(node.highlight_background),
+                cls._bg(node.highlight_background),
                 node.highlight_symbol,
             )
 
@@ -830,7 +838,7 @@ class NodeAssembler:
                 node.progress,
                 node.label,
                 cls._c(node.color),
-                cls._c(node.background),
+                cls._bg(node.background),
             )
 
         if isinstance(node, SparklineNode):
@@ -841,7 +849,7 @@ class NodeAssembler:
                 node.data,
                 node.max_value,
                 cls._c(node.color),
-                cls._c(node.background),
+                cls._bg(node.background),
                 cls._c(node.absent_value_color),
                 node.absent_value_symbol,
             )
@@ -851,7 +859,7 @@ class NodeAssembler:
                 node.progress,
                 node.label,
                 cls._c(node.color),
-                cls._c(node.background),
+                cls._bg(node.background),
                 cls._c(node.filled_color),
                 cls._c(node.unfilled_color),
             )
@@ -897,7 +905,7 @@ class NodeAssembler:
                         else c.content
                     ),
                     cls._c(c.color),
-                    cls._c(c.background),
+                    cls._bg(c.background),
                     cls._mods(c.modifiers),
                 )
 
@@ -905,7 +913,7 @@ class NodeAssembler:
                 return (
                     [_ir_cell(c) for c in r.cells],
                     cls._c(r.color),
-                    cls._c(r.background),
+                    cls._bg(r.background),
                     r.height,
                 )
 
@@ -919,7 +927,7 @@ class NodeAssembler:
                 node.selected_row,
                 node.selected_column,
                 cls._c(node.highlight_color),
-                cls._c(node.highlight_background),
+                cls._bg(node.highlight_background),
                 node.highlight_symbol,
             )
 
@@ -942,9 +950,9 @@ class NodeAssembler:
                 titles,
                 node.selected or 0,
                 cls._c(node.color),
-                cls._c(node.background),
+                cls._bg(node.background),
                 cls._c(node.highlight_color),
-                cls._c(node.highlight_background),
+                cls._bg(node.highlight_background),
                 node.divider,
                 node.padding_left,
                 node.padding_right,
@@ -1005,7 +1013,7 @@ class NodeAssembler:
                                 (
                                     s.content,
                                     cls._c(s.color),
-                                    cls._c(s.background),
+                                    cls._bg(s.background),
                                     cls._mods(s.modifiers),
                                 )
                                 for s in content.content
@@ -1015,7 +1023,7 @@ class NodeAssembler:
                                 (
                                     content.content or "",
                                     cls._c(content.color),
-                                    cls._c(content.background),
+                                    cls._bg(content.background),
                                     cls._mods(content.modifiers),
                                 )
                             ]
@@ -1024,7 +1032,7 @@ class NodeAssembler:
                             (
                                 content.content,
                                 cls._c(content.color),
-                                cls._c(content.background),
+                                cls._bg(content.background),
                                 cls._mods(content.modifiers),
                             )
                         ]
@@ -1033,7 +1041,7 @@ class NodeAssembler:
                 shapes,
                 node.x_bounds,
                 node.y_bounds,
-                cls._c(node.background),
+                cls._bg(node.background),
                 cls._MARKER_INT.get(node.marker) if node.marker else None,
             )
 

--- a/xnano/beta/fields.py
+++ b/xnano/beta/fields.py
@@ -70,7 +70,9 @@ class GridFieldInfo:
             including "bold", "dim", "italic", "underline", "slow_blink", "rapid_blink",
             "reversed".
         color: The foreground color of content within this field.
-        background: The background color of this field's frame area.
+        background: The background color behind this field's text cells. Pair
+            with a filling ``width`` for a full-width bar; fills the framed
+            content area when the field also defines border/title/padding chrome.
         width: Horizontal extent sizing (``10``, ``"50%"``, ``"1fr"``, ``"fit"``,
             or a ``Sizing``). Drives the split constraint in horizontal layouts;
             shrinks the slot along the cross axis otherwise.
@@ -123,7 +125,14 @@ class GridFieldInfo:
     color: ColorLike | None = None
     """The foreground color of content within this field."""
     background: ColorLike | None = None
-    """The background color of this field's frame area."""
+    """The background color of content within this field.
+
+    Paints behind the field's text cells only, not the whole slot — so a plain
+    ``background`` reads as an accent behind the content. Pair it with a filling
+    ``width`` (e.g. ``width="1fr"``) for a full-width bar such as a header or
+    status line. When the field also defines border, title, or padding chrome,
+    this color fills the framed content area instead.
+    """
     width: "Sizing | None" = None
     """Sizing intent for the field's horizontal extent.
 
@@ -311,7 +320,9 @@ def Field(
             including "bold", "dim", "italic", "underline", "slow_blink", "rapid_blink",
             "reversed".
         color: The foreground color of content within this field.
-        background: The background color of this field's frame area.
+        background: The background color behind this field's text cells. Pair
+            with a filling ``width`` for a full-width bar; fills the framed
+            content area when the field also defines border/title/padding chrome.
         width: Horizontal extent sizing (``10``, ``"50%"``, ``"1fr"``, ``"fit"``,
             or a ``Sizing``). Drives the split constraint in horizontal layouts;
             shrinks the slot along the cross axis otherwise.

--- a/xnano/beta/frame.py
+++ b/xnano/beta/frame.py
@@ -64,7 +64,56 @@ class Frame:
         )
 
 
+def field_has_frame_chrome(field: object) -> bool:
+    """Whether a field defines border, title, or padding chrome.
+
+    Args:
+        field: A ``GridFieldInfo``-like object with optional frame attributes.
+
+    Returns:
+        True when the field has structural frame chrome beyond text styling.
+    """
+    return (
+        getattr(field, "border", None) is not None
+        or getattr(field, "title", None) is not None
+        or getattr(field, "padding", None) is not None
+    )
+
+
+def frame_from_field(field: object | None) -> Frame | None:
+    """Build a ``Frame`` from a field's chrome, or ``None`` when absent.
+
+    Text-only ``background`` on a field styles rendered content and is not
+    promoted to frame fill unless border, title, or padding chrome is present.
+
+    Args:
+        field: The field describing border, padding, title, and optional fill.
+
+    Returns:
+        A ``Frame`` when the field defines any chrome, otherwise ``None``.
+    """
+    if field is None:
+        return None
+
+    has_frame_chrome = field_has_frame_chrome(field)
+    border_sides = getattr(field, "border_sides", None)
+    frame = Frame(
+        background=getattr(field, "background", None)
+        if has_frame_chrome
+        else None,
+        border=getattr(field, "border", None),
+        border_color=getattr(field, "border_color", None),
+        border_sides=list(border_sides) if border_sides is not None else None,
+        title=getattr(field, "title", None),
+        title_position=getattr(field, "title_position", None),
+        padding=getattr(field, "padding", None),
+    )
+    return None if frame.is_empty() else frame
+
+
 __all__ = (
     "Frame",
     "FrameTitlePosition",
+    "field_has_frame_chrome",
+    "frame_from_field",
 )

--- a/xnano/beta/grid.py
+++ b/xnano/beta/grid.py
@@ -1167,18 +1167,9 @@ class Grid(metaclass=_GridMeta):
         return bool(field.visible)
 
     def _grid_field_frame(self, field: GridFieldInfo) -> Frame | None:
-        f = Frame(
-            background=field.background,
-            border=field.border,
-            border_color=field.border_color,
-            border_sides=list(field.border_sides)
-            if field.border_sides is not None
-            else None,
-            title=field.title,
-            title_position=field.title_position,
-            padding=field.padding,
-        )
-        return None if f.is_empty() else f
+        from xnano.beta.frame import frame_from_field
+
+        return frame_from_field(field)
 
     def _grid_register_field_hit(
         self,

--- a/xnano/beta/terminal.py
+++ b/xnano/beta/terminal.py
@@ -480,6 +480,43 @@ class Terminal(Generic[StateT]):
         self._inline_height = resolved.inline_height
         self._root_width_sizing = resolved.root_width_sizing
 
+    def _recreate_session(self, resolved: _ResolvedRun) -> None:
+        """Tear down the live session so the next access recreates it.
+
+        Used when a one-shot :meth:`render` needs a different inline viewport
+        height than the session that is already open.
+        """
+        if self._session is not None:
+            self._session.leave()
+            self._session = None
+        self._apply_resolved_run(resolved)
+        self._pending_enter = True
+
+    def _prepare_render_session(
+        self,
+        renderables: Sequence[Any],
+        field: Any,
+    ) -> None:
+        """Resolve viewport sizing for a one-shot render and prepare the session.
+
+        Each :meth:`render` call is content-sized. When an inline session is
+        already open but the new content needs a different inline viewport
+        height, the existing session is torn down and recreated on the next
+        paint.
+        """
+        resolved = self._resolve_run(renderables, is_grid=False, field=field)
+        if self._session is None:
+            self._apply_resolved_run(resolved)
+            return
+        if self._session._is_offscreen:
+            self._root_width_sizing = resolved.root_width_sizing
+            return
+        current_inline = self._session._core_session.get_inline_height()
+        if resolved.inline_height != current_inline:
+            self._recreate_session(resolved)
+        else:
+            self._root_width_sizing = resolved.root_width_sizing
+
     def render(
         self,
         *renderables: Any,
@@ -525,13 +562,7 @@ class Terminal(Generic[StateT]):
         auto_entered = not self._is_live
         if auto_entered:
             self.__enter__()
-        # Resolve the viewport/root sizing when the underlying session has not
-        # been created yet — either from the auto-enter above or a deferred
-        # context-manager entry that has not rendered anything.
-        if self._session is None:
-            self._apply_resolved_run(
-                self._resolve_run(items, is_grid=False, field=field)
-            )
+        self._prepare_render_session(items, field)
         try:
             self._render_frame(renderables=items, field=field)
         finally:

--- a/xnano/beta/utils/native_types.py
+++ b/xnano/beta/utils/native_types.py
@@ -24,6 +24,11 @@ from xnano.beta.types import (
     PaddingLike,
     Side,
 )
+from xnano.beta.utils.vhs_recording import (
+    ColorRole,
+    get_vhs_color_cache_token,
+    remap_color_for_vhs,
+)
 
 if TYPE_CHECKING:
     from xnano.beta.cursor import CursorStyle
@@ -143,20 +148,25 @@ def get_area_from_native_rect(rect: native.Rect) -> Area:
 
 def get_native_color_from_color_like(
     color: ColorLike | None,
+    *,
+    role: ColorRole = "foreground",
 ) -> native.Color | None:
     """Parses a ``ColorLike`` input into a ratatui native ``Color``
     binding.
 
     Args:
         color: The color to parse.
+        role: Whether the color is used as foreground or background.
 
     Returns:
         The parsed ``native.Color`` binding.
     """
+    color = remap_color_for_vhs(color, role=role)
     if color is None:
         return None
 
-    key = ("xnano", color)
+    cache_token = get_vhs_color_cache_token()
+    key = ("xnano", color, role, cache_token)
     if key in _NATIVE_COLOR_CACHE:
         return _NATIVE_COLOR_CACHE[key]
 
@@ -239,8 +249,11 @@ def get_native_style_from_kwargs(
     Returns:
         The built ``native.Style`` binding.
     """
-    native_color = get_native_color_from_color_like(color)
-    native_background = get_native_color_from_color_like(background)
+    native_color = get_native_color_from_color_like(color, role="foreground")
+    native_background = get_native_color_from_color_like(
+        background,
+        role="background",
+    )
     native_modifier = get_native_modifier_from_modifiers(modifiers)
 
     if (
@@ -271,7 +284,11 @@ def get_native_block_from_frame(frame: Frame) -> native.Block | None:
     """
     if frame.is_empty():
         return None
-    block = native.Block.bordered()
+    block = (
+        native.Block.bordered()
+        if frame.border is not None
+        else native.Block.new()
+    )
     if frame.border_sides is not None:
         sides = native.Borders.NONE
         for side in frame.border_sides:

--- a/xnano/beta/utils/vhs_recording.py
+++ b/xnano/beta/utils/vhs_recording.py
@@ -1,0 +1,97 @@
+"""xnano.beta.utils.vhs_recording"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal, TypeAlias
+
+from xnano.beta.color import ColorLike
+
+ColorRole: TypeAlias = Literal["foreground", "background"]
+"""Whether a color is applied as foreground or background during VHS remaps."""
+
+DOC_BG_DARK = "#141519"
+"""Docs dark page background — matches ``extras.css`` slate scheme."""
+
+DOC_BG_LIGHT = "#F4F4ED"
+"""Docs light page background — matches ``extras.css`` default scheme."""
+
+MONO_FG_DARK = "#DEDCD1"
+"""Single-tone foreground for dark showcase monotone recordings."""
+
+MONO_FG_LIGHT = "#102044"
+"""Single-tone foreground for light showcase monotone recordings."""
+
+
+def get_vhs_theme_key() -> str:
+    """Return the active docs theme key for VHS recordings.
+
+    Returns:
+        ``"dark"`` or ``"light"`` (defaults to ``"dark"``).
+    """
+    theme_key = os.environ.get("XNANO_VHS_THEME", "dark")
+    if theme_key in ("dark", "light"):
+        return theme_key
+    return "dark"
+
+
+def is_vhs_mono_mode() -> bool:
+    """Return whether showcase monotone remapping is enabled."""
+    return os.environ.get("XNANO_VHS_MONO") == "1"
+
+
+def is_vhs_docs_background_mode() -> bool:
+    """Return whether widget backgrounds should match the docs page."""
+    return (
+        os.environ.get("XNANO_VHS_DOCS_BG") == "1"
+        or is_vhs_mono_mode()
+    )
+
+
+def get_vhs_color_cache_token() -> str:
+    """Return a cache-busting token for native color memoization."""
+    if is_vhs_mono_mode():
+        return f"mono:{get_vhs_theme_key()}"
+    if is_vhs_docs_background_mode():
+        return f"docs_bg:{get_vhs_theme_key()}"
+    return ""
+
+
+def get_vhs_docs_background() -> str:
+    """Return the docs-page background hex for the active VHS theme key."""
+    if get_vhs_theme_key() == "light":
+        return DOC_BG_LIGHT
+    return DOC_BG_DARK
+
+
+def get_vhs_mono_foreground() -> str:
+    """Return the single-tone foreground hex for the active VHS theme key."""
+    if get_vhs_theme_key() == "light":
+        return MONO_FG_LIGHT
+    return MONO_FG_DARK
+
+
+def remap_color_for_vhs(
+    color: ColorLike | None,
+    *,
+    role: ColorRole = "foreground",
+) -> ColorLike | None:
+    """Remap a color for VHS demo recordings when env flags are set.
+
+    Args:
+        color: Original color literal or ``Color`` instance.
+        role: Whether the color is used as foreground or background.
+
+    Returns:
+        Remapped color, or the original when no VHS mode is active.
+    """
+    if is_vhs_mono_mode():
+        if role == "background":
+            return get_vhs_docs_background()
+        return get_vhs_mono_foreground()
+
+    # Docs-background mode intentionally leaves authored colors untouched.
+    # The renderer now paints field backgrounds behind text cells only (not
+    # the whole slot), so accent backgrounds such as a violet header read as
+    # designed against the docs page and no longer need to be flattened.
+    return color


### PR DESCRIPTION
## Summary

- `frame_from_field()` now skips promoting a plain `background` to frame fill unless `border`, `title`, or `padding` chrome is also set — `Field(background="violet")` paints behind text glyphs only
- Adds `_bg()` helper in `NodeAssembler` so all background colors pass through the `"background"` `ColorRole` path in `remap_color_for_vhs`
- Fixes `get_native_block_from_frame` to only create a bordered `Block` when a border is actually configured
- Adds `TailwindColorBinding` literal type (all `color-shade` strings) to the `ColorLike` union
- Adds `vhs_recording.py` with color-remap utilities (`remap_color_for_vhs`, `is_vhs_mono_mode`, etc.) used for docs demo recordings
- `Terminal._prepare_render_session` recreates the inline session when viewport height changes between `render()` calls
- Types `Context.cursor` and `Context.device` properties correctly

## Test plan

- [ ] `uv run pytest tests/test_frame.py` — `frame_from_field` background-only → `None`
- [ ] `uv run pytest tests/test_grid_init.py` — field background covers text span only, no frame border painted
- [ ] `uv run pytest tests/test_terminal_render.py` — inline session recreated on height change
- [ ] `uv run pytest tests/test_vhs_recording.py` — VHS color-remap utilities

> **Merge order:** merge **after** `xnano-core/fix(span-bg-paint)` (#8), before `update-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)