### PR TITLE
fix(render_tree): clamp absolute rect to buffer bounds on terminal resize

### DIFF
--- a/xnano-core/rust/src/bindings/engine/render_tree.rs
+++ b/xnano-core/rust/src/bindings/engine/render_tree.rs
@@ -252,10 +252,18 @@ pub(crate) fn render_node_to_buffer(
     }
 
     let rect = if node.has_absolute_geometry() {
-        node.absolute_rect()
+        // Clamp to the buffer's current bounds so that a terminal resize
+        // occurring between layout and commit never causes an out-of-bounds
+        // buffer index (the ratatui panic "index outside of buffer").
+        let abs = node.absolute_rect();
+        abs.intersection(buffer.area)
     } else {
         area
     };
+
+    if rect.is_empty() {
+        return Ok(None);
+    }
 
     if let Some(key) = &node.effect_key {
         ctx.record_effect_area(key.clone(), rect);
@@ -278,7 +286,10 @@ pub(crate) fn render_node_to_buffer(
 
         let child_areas: Vec<Rect> =
             if node.children.iter().all(|c| c.has_absolute_geometry()) {
-                node.children.iter().map(|c| c.absolute_rect()).collect()
+                node.children
+                    .iter()
+                    .map(|c| c.absolute_rect().intersection(buffer.area))
+                    .collect()
             } else {
                 Layout::default()
                     .direction(


### PR DESCRIPTION
## Summary

- Intersects absolute-geometry rects with `buffer.area` before rendering, so a terminal resize between layout and commit never produces an out-of-bounds buffer index
- Adds an early `return Ok(None)` when the intersection is empty (no pixels to draw)
- Applies the same clamp to child rect collection when all children use absolute geometry

## Test plan

- [ ] Rapidly resize the terminal while a Grid app is running — confirm no ratatui "index outside of buffer" panic
- [ ] `uv run pytest` — existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)