### PR TITLE
feat: field focus, editable text input, and on_focus/on_field/on_poll hooks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "uv",
     "pytest",
     "pytest-asyncio",
+    "pytest-benchmark>=5.1.0",
     "pytest-cov",
     "twine>=6.1.0",
     # type checking!

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, Iterable, cast
 
 from xnano.beta.fields import Field, UNSET
+
+if TYPE_CHECKING:
+    from xnano.beta.components.abstract import AbstractComponent
+    from xnano.beta.core.nodes import RenderNode
+    from xnano.beta.grid import Grid
+    from xnano.beta.terminal import Terminal
 
 
 def invalid_field(default: Any) -> Any:
@@ -15,3 +21,226 @@ def invalid_field(default: Any) -> Any:
 def assign_attr(instance: object, name: str, value: object) -> None:
     """Assign an attribute while bypassing static type checks in tests."""
     setattr(instance, name, value)
+
+
+# ---------------------------------------------------------------------------
+# Usage-test harness — fake input events + offscreen terminal helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeKeyboard:
+    """Duck-typed keyboard payload accepted by dispatch/focus paths."""
+
+    def __init__(
+        self,
+        *,
+        character: str | None = None,
+        matches: Iterable[str] = (),
+        kind: str = "press",
+    ) -> None:
+        self.character = character
+        self.kind = kind
+        self._matches = set(matches)
+
+    def matches(self, *bindings: str) -> bool:
+        return any(binding in self._matches for binding in bindings)
+
+
+class FakeEvent:
+    """Minimal event shell for ``dispatch_hooks`` / ``Context`` tests."""
+
+    def __init__(
+        self,
+        *,
+        keyboard: FakeKeyboard | None = None,
+        clipboard_text: str | None = None,
+        focus_kind: str | None = None,
+        focus_field: str | None = None,
+    ) -> None:
+        self._keyboard = keyboard
+        self._clipboard_text = clipboard_text
+        self._focus_kind = focus_kind
+        self._focus_field = focus_field
+
+    def is_keyboard_event(self) -> bool:
+        return self._keyboard is not None
+
+    def is_mouse_event(self) -> bool:
+        return False
+
+    def is_resize_event(self) -> bool:
+        return False
+
+    def is_clipboard_event(self) -> bool:
+        return self._clipboard_text is not None
+
+    def is_focus_event(self) -> bool:
+        return self._focus_kind is not None
+
+    @property
+    def keyboard_event(self) -> FakeKeyboard | None:
+        return self._keyboard
+
+    @property
+    def clipboard_event(self) -> Any:
+        if self._clipboard_text is None:
+            return None
+
+        class _Clip:
+            text: str
+
+            def __init__(self, text: str) -> None:
+                self.text = text
+
+        return _Clip(self._clipboard_text)
+
+    @property
+    def focus_event(self) -> Any:
+        if self._focus_kind is None:
+            return None
+
+        class _Focus:
+            kind: str | None
+            field: str | None
+
+            def __init__(self, kind: str, field: str | None) -> None:
+                self.kind = kind
+                self.field = field
+
+        return _Focus(self._focus_kind, self._focus_field)
+
+    @property
+    def mouse_event(self) -> None:
+        return None
+
+
+def key_char(character: str) -> FakeKeyboard:
+    """Printable character keypress."""
+    return FakeKeyboard(character=character)
+
+
+def key_binding(*names: str) -> FakeKeyboard:
+    """Named key (enter, tab, backspace, …)."""
+    return FakeKeyboard(matches=names)
+
+
+def open_offscreen_app(
+    grid: "Grid",
+    *,
+    cols: int = 48,
+    rows: int = 14,
+    state: Any = None,
+) -> "Terminal[Any]":
+    """Open an offscreen terminal, attach ``grid``, paint one frame.
+
+    Caller should call :func:`close_offscreen_app` when finished.
+    """
+    from xnano.beta.terminal import Terminal
+
+    terminal = Terminal.offscreen(cols=cols, rows=rows, state=state)
+    terminal.attach_grid(grid)
+    terminal._render_frame(grid)
+    return terminal
+
+
+def close_offscreen_app(terminal: "Terminal[Any]") -> None:
+    """Reset the active-terminal context var for an offscreen session."""
+    from xnano.beta import terminal as terminal_mod
+
+    token = getattr(terminal, "_terminal_token", None)
+    if token is not None:
+        terminal_mod._ACTIVE_TERMINAL.reset(token)
+        terminal._terminal_token = None
+    terminal._is_live = False
+    terminal._session = None
+
+
+def paint(terminal: "Terminal[Any]", grid: "Grid") -> str:
+    """Re-render ``grid`` and return the offscreen buffer text."""
+    terminal._render_frame(grid)
+    return terminal.get_output()
+
+
+def dispatch_key(terminal: "Terminal[Any]", keyboard: FakeKeyboard) -> None:
+    """Run the full keyboard dispatch path for ``keyboard``."""
+    from xnano.beta.context import Context
+    from xnano.beta.core.dispatch import dispatch_hooks
+
+    event = FakeEvent(keyboard=keyboard)
+    ctx = Context(
+        event=cast(Any, event), terminal=terminal, state=terminal.state
+    )
+    dispatch_hooks(terminal, ctx)
+
+
+def type_text(terminal: "Terminal[Any]", text: str) -> None:
+    """Type each character of ``text`` through dispatch."""
+    for character in text:
+        dispatch_key(terminal, key_char(character))
+
+
+def press(terminal: "Terminal[Any]", *bindings: str) -> None:
+    """Press a named key (or chord label) through dispatch."""
+    dispatch_key(terminal, key_binding(*bindings))
+
+
+def render_node_to_text(
+    node: "RenderNode",
+    *,
+    width: int = 40,
+    height: int = 10,
+) -> str:
+    """Render a single render-IR node offscreen and return the buffer text.
+
+    Args:
+        node: The ``RenderNode`` to lower and render.
+        width: Offscreen viewport width in cells.
+        height: Offscreen viewport height in cells.
+
+    Returns:
+        The rendered buffer as a newline-joined string.
+    """
+    from xnano_core.core import CoreSession
+
+    from xnano.beta.core.session import Session
+    from xnano.beta.types import Area
+
+    core = CoreSession.offscreen(width=width, height=height)
+    session = Session(
+        core,
+        terminal_width=width,
+        terminal_height=height,
+        is_offscreen=True,
+    )
+    session.begin_frame()
+    session.paint_node(node, Area(x=0, y=0, width=width, height=height))
+    session.commit_requests()
+    return session.get_core_session_output_text()
+
+
+def render_component_to_text(
+    component: "AbstractComponent",
+    *,
+    width: int = 40,
+    height: int = 10,
+) -> str:
+    """Render a component offscreen via ``get_node`` and return the buffer text.
+
+    Args:
+        component: The ``AbstractComponent`` to render.
+        width: Offscreen viewport width in cells.
+        height: Offscreen viewport height in cells.
+
+    Returns:
+        The rendered buffer as a newline-joined string. Empty when the
+        component yields no node (e.g. ``visible=False``).
+    """
+    from xnano.beta.components.abstract import ComponentRenderContext
+    from xnano.beta.types import Area
+
+    area = Area(x=0, y=0, width=width, height=height)
+    ctx = ComponentRenderContext(area=area)
+    node = component.get_node(ctx)
+    if node is None:
+        return ""
+    return render_node_to_text(node, width=width, height=height)

--- a/tests/test_field_focus.py
+++ b/tests/test_field_focus.py
@@ -1,0 +1,252 @@
+"""Tests for field-level focus and @on_focus(field=...) hooks."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from xnano.beta import Field, Grid, on_focus, on_keyboard
+from xnano.beta.components.text import Text
+from xnano.beta.context import Context
+from xnano.beta.core.dispatch import (
+    _handle_focus_navigation,
+    _handle_focused_text_input,
+    dispatch_hooks,
+)
+from xnano.beta.focus import (
+    FieldFocus,
+    collect_focusable_fields,
+    cycle_field_focus,
+    set_field_focus,
+    clear_field_focus,
+)
+from xnano.beta.hooks import _EventHooksRegistry, _OnFocusHookFunctionEntry
+
+
+# ---------------------------------------------------------------------------
+# Decorator
+# ---------------------------------------------------------------------------
+
+
+class _Form(Grid):
+    name: Text = Field(default=Text("", input=True, placeholder="name"))
+    email: Text = Field(default=Text("", input=True, placeholder="email"))
+    status: str = Field(default="")
+    name_gains: int = Field(default=0, state=True)
+    name_losses: int = Field(default=0, state=True)
+
+    @on_focus("name")
+    def _on_name(self) -> None:
+        self.name_gains += 1
+        self.status = "name"
+
+    @on_focus("name", kind="lost")
+    def _on_name_lost(self) -> None:
+        self.name_losses += 1
+
+    @on_keyboard("enter")
+    def _submit(self) -> None:
+        self.status = f"hi {self.name.value}"
+
+
+def test_on_focus_field_attributes() -> None:
+    method = _Form.__dict__["_on_name"]
+    assert hasattr(method, _EventHooksRegistry.ON_FOCUS_HOOK_ATTR)
+    assert getattr(method, _EventHooksRegistry.ON_FOCUS_FIELD_ATTR) == "name"
+
+
+def test_on_focus_kind_lost_attribute() -> None:
+    method = _Form.__dict__["_on_name_lost"]
+    assert getattr(method, _EventHooksRegistry.ON_FOCUS_KIND_ATTR) == "lost"
+
+
+def test_from_component_class_collects_field_focus() -> None:
+    registry = _EventHooksRegistry.from_component_class(_Form)
+    fields = {entry["field"] for entry in registry.on_focus_hooks}
+    assert "name" in fields
+
+
+# ---------------------------------------------------------------------------
+# Focus cycling
+# ---------------------------------------------------------------------------
+
+
+def _terminal_with_form(form: _Form | None = None) -> tuple[Any, _Form]:
+    grid = form if form is not None else _Form()
+    terminal = MagicMock()
+    terminal.state = None
+    terminal._field_focus = None
+    terminal._field_focus_announced = False
+    terminal._last_field_focus_event = None
+    terminal._attached_frame_grids = [grid]
+    registry = _EventHooksRegistry.from_component_class(_Form)
+    # Bind focus handlers to instance
+    bound: list[_OnFocusHookFunctionEntry] = []
+    for entry in registry.on_focus_hooks:
+        handler = entry["handler"]
+        name = getattr(handler, "__name__", None)
+        if name and hasattr(grid, name):
+            handler = getattr(grid, name)
+        bound.append(
+            _OnFocusHookFunctionEntry(
+                field=entry["field"],
+                kind=entry["kind"],
+                handler=handler,
+            )
+        )
+    terminal._hooks = MagicMock()
+    terminal._hooks.on_focus_hooks = bound
+    terminal._hooks.on_event_hooks = []
+    terminal._hooks.on_keyboard_hooks = []
+    terminal._hooks.on_mouse_hooks = []
+    terminal._hooks.on_resize_hooks = []
+    terminal._hooks.on_clipboard_hooks = []
+    return terminal, grid
+
+
+def test_collect_focusable_fields_order() -> None:
+    terminal, grid = _terminal_with_form()
+    targets = collect_focusable_fields(terminal)
+    assert [t.field_name for t in targets] == ["name", "email"]
+
+
+def test_set_field_focus_marks_text() -> None:
+    terminal, grid = _terminal_with_form()
+    assert set_field_focus(terminal, grid, "name") is True
+    assert grid.name._input_focused is True
+    assert grid.email._input_focused is False
+    assert terminal._field_focus.field_name == "name"
+
+
+def test_set_field_focus_fires_gained_hook() -> None:
+    terminal, grid = _terminal_with_form()
+    set_field_focus(terminal, grid, "name")
+    assert grid.name_gains == 1
+    assert grid.status == "name"
+
+
+def test_cycle_focus_moves_and_fires_lost() -> None:
+    terminal, grid = _terminal_with_form()
+    set_field_focus(terminal, grid, "name")
+    assert grid.name_gains == 1
+    cycle_field_focus(terminal, reverse=False)
+    assert terminal._field_focus.field_name == "email"
+    assert grid.name._input_focused is False
+    assert grid.email._input_focused is True
+    assert grid.name_losses == 1
+
+
+def test_clear_field_focus() -> None:
+    terminal, grid = _terminal_with_form()
+    set_field_focus(terminal, grid, "name")
+    clear_field_focus(terminal)
+    assert terminal._field_focus is None
+    assert grid.name._input_focused is False
+    assert grid.name_losses == 1
+
+
+# ---------------------------------------------------------------------------
+# Keyboard routing
+# ---------------------------------------------------------------------------
+
+
+def _nav_kbd(binding: str) -> Any:
+    class _K:
+        kind = "press"
+        character = None
+
+        def matches(self, *bindings: str) -> bool:
+            return binding in bindings
+
+    return _K()
+
+
+def test_tab_navigation_handler() -> None:
+    terminal, grid = _terminal_with_form()
+    set_field_focus(terminal, grid, "name")
+    assert _handle_focus_navigation(terminal, _nav_kbd("tab"))
+    assert terminal._field_focus.field_name == "email"
+
+
+def test_backtab_navigation_handler() -> None:
+    terminal, grid = _terminal_with_form()
+    set_field_focus(terminal, grid, "email")
+    assert _handle_focus_navigation(terminal, _nav_kbd("backtab"))
+    assert terminal._field_focus.field_name == "name"
+
+
+def test_focused_text_receives_characters() -> None:
+    terminal, grid = _terminal_with_form()
+    set_field_focus(terminal, grid, "name")
+
+    class _K:
+        kind = "press"
+        character = "a"
+
+        def matches(self, *bindings: str) -> bool:
+            return False
+
+    assert _handle_focused_text_input(terminal, _K()) is True
+    assert grid.name.value == "a"
+
+
+def test_enter_still_available_to_hooks() -> None:
+    """Enter is not consumed by Text input, so @on_keyboard('enter') works."""
+    terminal, grid = _terminal_with_form()
+    set_field_focus(terminal, grid, "name")
+    grid.name.content = "Ada"
+
+    class _K:
+        kind = "press"
+        character = None
+
+        def matches(self, *bindings: str) -> bool:
+            return "enter" in bindings
+
+    assert _handle_focused_text_input(terminal, _K()) is False
+    # Manually invoke submit the way dispatch would for enter
+    grid.status = f"hi {grid.name.value}"
+    assert grid.status == "hi Ada"
+
+
+# ---------------------------------------------------------------------------
+# Terminal API surface
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_focus_helpers() -> None:
+    from xnano.beta.terminal import Terminal
+
+    term = Terminal.__new__(Terminal)
+    term._field_focus = None
+    term._field_focus_announced = False
+    term._last_field_focus_event = None
+    term._hooks = _EventHooksRegistry()
+    term.state = None
+    term._attached_frame_grids = []
+
+    grid = _Form()
+    term._attached_frame_grids = [grid]
+    # Bind hooks
+    for entry in _EventHooksRegistry.from_component_class(_Form).on_focus_hooks:
+        handler = entry["handler"]
+        name = getattr(handler, "__name__", None)
+        if name and hasattr(grid, name):
+            handler = getattr(grid, name)
+        term._hooks.on_focus_hooks.append(
+            _OnFocusHookFunctionEntry(
+                field=entry["field"],
+                kind=entry["kind"],
+                handler=handler,
+            )
+        )
+
+    assert term.focus_field(grid, "name") is True
+    assert term.field_focus is not None
+    assert term.field_focus.field_name == "name"
+    assert term.focus_next() is True
+    assert term.field_focus.field_name == "email"
+    assert term.focus_previous() is True
+    assert term.field_focus.field_name == "name"
+    term.blur_field()
+    assert term.field_focus is None

--- a/tests/test_hook_async_and_exceptions.py
+++ b/tests/test_hook_async_and_exceptions.py
@@ -1,0 +1,192 @@
+"""Tests for async @on_* hooks and the hook exception policy."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from xnano.beta import Field, Grid, on_tick
+from xnano.beta.context import Context
+from xnano.beta.core.dispatch import invoke_hook, pump_tick, run_awaitable
+from xnano.beta.exceptions import Exit, HookError
+from xnano.beta.hooks import _EventHooksRegistry
+
+
+def _ctx() -> Context[Any]:
+    return Context(event=None, terminal=cast(Any, None), state=None)
+
+
+# ---------------------------------------------------------------------------
+# run_awaitable
+# ---------------------------------------------------------------------------
+
+
+async def _async_value(value: int) -> int:
+    await asyncio.sleep(0)
+    return value
+
+
+def test_run_awaitable_resolves_coroutine() -> None:
+    assert run_awaitable(_async_value(7)) == 7
+
+
+def test_run_awaitable_rejects_nested_loop() -> None:
+    async def _inner() -> None:
+        coro = _async_value(1)
+        try:
+            run_awaitable(coro)
+        finally:
+            # run_awaitable raises before scheduling; close to avoid warnings.
+            coro.close()
+
+    with pytest.raises(RuntimeError, match="already active"):
+        asyncio.run(_inner())
+
+
+# ---------------------------------------------------------------------------
+# invoke_hook — async handlers
+# ---------------------------------------------------------------------------
+
+
+class _AsyncTickGrid(Grid):
+    count: int = Field(default=0, state=True)
+
+    @on_tick
+    async def _tick(self) -> None:
+        await asyncio.sleep(0)
+        self.count += 1
+
+
+def test_invoke_hook_awaits_async_bound_method() -> None:
+    grid = _AsyncTickGrid()
+    invoke_hook(grid._tick, grid, _ctx())
+    assert grid.count == 1
+
+
+def test_pump_tick_awaits_async_handler() -> None:
+    grid = _AsyncTickGrid()
+    terminal = MagicMock()
+    terminal.state = None
+    terminal._hooks = MagicMock()
+    terminal._hooks.on_tick_hooks = [
+        {
+            "interval": 0,
+            "handler": grid._tick,
+            "last_fire_ms": 0.0,
+        }
+    ]
+    terminal._hooks.on_state_hooks = []
+    terminal._hooks.on_field_hooks = []
+    terminal._attached_frame_grids = [grid]
+
+    pump_tick(cast(Any, terminal))
+    assert grid.count == 1
+
+
+async def _free_async_hook(ctx: Context[Any]) -> str:
+    await asyncio.sleep(0)
+    return "ok"
+
+
+def test_invoke_hook_awaits_free_async_function() -> None:
+    result = invoke_hook(_free_async_hook, None, _ctx())
+    assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Exception policy — log + re-raise; Exit propagates cleanly
+# ---------------------------------------------------------------------------
+
+
+class _BoomGrid(Grid):
+    @on_tick
+    def _explode(self) -> None:
+        raise ValueError("boom")
+
+
+class _ExitGrid(Grid):
+    @on_tick
+    def _leave(self) -> None:
+        raise Exit()
+
+
+def test_invoke_hook_logs_and_reraises() -> None:
+    grid = _BoomGrid()
+    with pytest.raises(ValueError, match="boom"):
+        invoke_hook(grid._explode, grid, _ctx())
+
+
+def test_invoke_hook_logs_exception_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    grid = _BoomGrid()
+    with caplog.at_level(logging.ERROR, logger="xnano.hooks"):
+        with pytest.raises(ValueError):
+            invoke_hook(grid._explode, grid, _ctx())
+    assert any(
+        "Uncaught exception in hook" in record.message
+        for record in caplog.records
+    )
+
+
+def test_invoke_hook_propagates_exit_without_logging(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    grid = _ExitGrid()
+    with caplog.at_level(logging.ERROR, logger="xnano.hooks"):
+        with pytest.raises(Exit):
+            invoke_hook(grid._leave, grid, _ctx())
+    assert not any(
+        "Uncaught exception" in record.message for record in caplog.records
+    )
+
+
+def test_async_hook_exception_is_logged_and_reraised(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _AsyncBoom(Grid):
+        @on_tick
+        async def _explode(self) -> None:
+            await asyncio.sleep(0)
+            raise RuntimeError("async boom")
+
+    grid = _AsyncBoom()
+    with caplog.at_level(logging.ERROR, logger="xnano.hooks"):
+        with pytest.raises(RuntimeError, match="async boom"):
+            invoke_hook(grid._explode, grid, _ctx())
+    assert any(
+        "Uncaught exception in hook" in record.message
+        for record in caplog.records
+    )
+
+
+def test_hook_error_wraps_cause() -> None:
+    cause = ValueError("inner")
+    error = HookError("MyGrid._on_tick", cause)
+    assert error.hook_name == "MyGrid._on_tick"
+    assert error.cause is cause
+    assert error.__cause__ is cause
+    assert "MyGrid._on_tick" in str(error)
+
+
+def test_async_hook_can_raise_exit() -> None:
+    class _Ready(Grid):
+        ready: bool = Field(default=True, state=True)
+
+        @on_tick
+        async def _leave(self) -> None:
+            await asyncio.sleep(0)
+            raise Exit()
+
+    grid = _Ready()
+    with pytest.raises(Exit):
+        invoke_hook(grid._leave, grid, _ctx())
+
+
+def test_registry_collects_async_tick() -> None:
+    registry = _EventHooksRegistry.from_component_class(_AsyncTickGrid)
+    assert len(registry.on_tick_hooks) == 1

--- a/tests/test_hook_interop.py
+++ b/tests/test_hook_interop.py
@@ -1,0 +1,1363 @@
+"""Tests for complex interactions between hook types.
+
+Sections:
+  1.  Shared stub terminal
+  2.  Keyboard → on_field chains
+  3.  Mutual exclusion and repeated firing
+  4.  Cascading field hooks
+  5.  on_tick + on_field interaction (with interval gating)
+  6.  Compound / boolean expressions
+  7.  Python field-type diversity
+      - Optional[str], set[str], tuple, float, nested dict,
+        string operators, list membership, chained comparisons,
+        built-ins (max/min/abs/isinstance/hasattr/getattr)
+  8.  Expression using the implicit ``state`` variable
+  9.  Safe-eval resilience (bad expressions never crash)
+  10. Duplicate hooks — two handlers on the same expression
+  11. Fire-count tracking over multiple ticks
+  12. Inheritance patterns (parent hooks, child hooks, override)
+  13. Multi-grid isolation and cross-grid independence
+  14. on_state / on_field source separation
+  15. Dict state field (the test.py scenario formalised)
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+from typing import Any, cast
+
+from xnano.beta import Field, Grid, on_field, on_keyboard, on_tick
+from xnano.beta.context import Context
+from xnano.beta.core.dispatch import invoke_hook, pump_tick
+from xnano.beta.hooks import (
+    _EventHooksRegistry,
+    _OnFieldHookFunctionEntry,
+    _OnKeyboardHookFunctionEntry,
+    _OnStateHookFunctionEntry,
+    _OnTickHookFunctionEntry,
+)
+from xnano.beta.hooks import on_state
+from xnano.beta.state import State
+from xnano.beta.utils.core import evaluate_state_expression
+
+
+# ---------------------------------------------------------------------------
+# 1. Shared stub terminal
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class _StubTerminal:
+    """Minimal terminal stub for dispatch tests without a real session."""
+
+    state: Any = None
+    _hooks: _EventHooksRegistry = dataclasses.field(
+        default_factory=_EventHooksRegistry
+    )
+    _attached_frame_grids: list[Any] = dataclasses.field(
+        default_factory=list
+    )
+
+    def attach(self, grid: Any) -> None:
+        collected = _EventHooksRegistry.from_component_class(type(grid))
+
+        for entry in collected.on_field_hooks:
+            name = getattr(entry["handler"], "__name__", None)
+            bound = (
+                getattr(grid, name)
+                if name and hasattr(grid, name)
+                else entry["handler"]
+            )
+            self._hooks.on_field_hooks.append(
+                _OnFieldHookFunctionEntry(
+                    expression=entry["expression"], handler=bound
+                )
+            )
+
+        for entry in collected.on_tick_hooks:
+            name = getattr(entry["handler"], "__name__", None)
+            bound = (
+                getattr(grid, name)
+                if name and hasattr(grid, name)
+                else entry["handler"]
+            )
+            self._hooks.on_tick_hooks.append(
+                _OnTickHookFunctionEntry(
+                    interval=entry["interval"],
+                    handler=bound,
+                    last_fire_ms=0.0,
+                )
+            )
+
+        for entry in collected.on_keyboard_hooks:
+            name = getattr(entry["handler"], "__name__", None)
+            bound = (
+                getattr(grid, name)
+                if name and hasattr(grid, name)
+                else entry["handler"]
+            )
+            self._hooks.on_keyboard_hooks.append(
+                _OnKeyboardHookFunctionEntry(
+                    bindings=entry["bindings"],
+                    kind=entry["kind"],
+                    handler=bound,
+                )
+            )
+
+        for entry in collected.on_state_hooks:
+            name = getattr(entry["handler"], "__name__", None)
+            bound = (
+                getattr(grid, name)
+                if name and hasattr(grid, name)
+                else entry["handler"]
+            )
+            self._hooks.on_state_hooks.append(
+                _OnStateHookFunctionEntry(
+                    expression=entry["expression"], handler=bound
+                )
+            )
+
+        self._attached_frame_grids.append(grid)
+
+    def fire_keyboard(self, handler_name: str) -> None:
+        """Directly invoke a keyboard handler by name (skips event routing)."""
+        ctx = Context(
+            event=None, terminal=cast(Any, self), state=self.state
+        )
+        for entry in self._hooks.on_keyboard_hooks:
+            h = entry["handler"]
+            if getattr(h, "__name__", None) == handler_name:
+                invoke_hook(h, None, ctx)
+                return
+        raise KeyError(f"no keyboard hook named {handler_name!r}")
+
+
+# ---------------------------------------------------------------------------
+# 2. Keyboard → on_field chains
+# ---------------------------------------------------------------------------
+
+
+class _SwitcherGrid(Grid):
+    mode: str = Field(default="idle", state=True)
+    label: str = Field(default="idle mode")
+    john_count: int = Field(default=0, state=True)
+    jane_count: int = Field(default=0, state=True)
+
+    @on_keyboard("a")
+    def _press_a(self) -> None:
+        self.mode = "john"
+
+    @on_keyboard("d")
+    def _press_d(self) -> None:
+        self.mode = "jane"
+
+    @on_field("mode == 'john'")
+    def _on_john(self) -> None:
+        self.label = "Hello, John!"
+        self.john_count += 1
+
+    @on_field("mode == 'jane'")
+    def _on_jane(self) -> None:
+        self.label = "Hello, Jane!"
+        self.jane_count += 1
+
+
+def test_keyboard_then_field_hook_fires() -> None:
+    grid = _SwitcherGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    terminal.fire_keyboard("_press_a")
+    pump_tick(cast(Any, terminal))
+
+    assert grid.label == "Hello, John!"
+    assert grid.john_count == 1
+    assert grid.jane_count == 0
+
+
+def test_keyboard_switches_which_field_hook_fires() -> None:
+    grid = _SwitcherGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    terminal.fire_keyboard("_press_a")
+    pump_tick(cast(Any, terminal))
+    assert grid.label == "Hello, John!"
+
+    terminal.fire_keyboard("_press_d")
+    pump_tick(cast(Any, terminal))
+    assert grid.label == "Hello, Jane!"
+    assert grid.john_count == 1
+    assert grid.jane_count == 1
+
+
+def test_no_key_press_means_no_field_hook() -> None:
+    grid = _SwitcherGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert grid.label == "idle mode"
+    assert grid.john_count == 0
+
+
+def test_multiple_keyboard_presses_before_tick_last_wins() -> None:
+    """Back-to-back key presses before a tick — only the final state matters."""
+    grid = _SwitcherGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    terminal.fire_keyboard("_press_a")
+    terminal.fire_keyboard("_press_d")
+    terminal.fire_keyboard("_press_a")
+    pump_tick(cast(Any, terminal))
+
+    assert grid.mode == "john"
+    assert grid.john_count == 1
+    assert grid.jane_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Mutual exclusion and repeated firing
+# ---------------------------------------------------------------------------
+
+
+class _TrafficLightGrid(Grid):
+    color: str = Field(default="green", state=True)
+    red_fires: int = Field(default=0, state=True)
+    yellow_fires: int = Field(default=0, state=True)
+    green_fires: int = Field(default=0, state=True)
+
+    @on_field("color == 'red'")
+    def _on_red(self) -> None:
+        self.red_fires += 1
+
+    @on_field("color == 'yellow'")
+    def _on_yellow(self) -> None:
+        self.yellow_fires += 1
+
+    @on_field("color == 'green'")
+    def _on_green(self) -> None:
+        self.green_fires += 1
+
+
+def test_only_matching_field_hook_fires() -> None:
+    grid = _TrafficLightGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert grid.green_fires == 1
+    assert grid.red_fires == 0
+    assert grid.yellow_fires == 0
+
+    grid.color = "red"
+    pump_tick(cast(Any, terminal))
+    assert grid.red_fires == 1
+    assert grid.green_fires == 1
+    assert grid.yellow_fires == 0
+
+
+def test_field_hook_fires_every_tick_while_condition_holds() -> None:
+    grid = _TrafficLightGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    for _ in range(5):
+        pump_tick(cast(Any, terminal))
+
+    assert grid.green_fires == 5
+    assert grid.red_fires == 0
+
+
+def test_field_hook_stops_when_condition_becomes_false() -> None:
+    grid = _TrafficLightGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert grid.green_fires == 1
+
+    grid.color = "red"
+    pump_tick(cast(Any, terminal))
+    assert grid.green_fires == 1  # did not increment again
+    assert grid.red_fires == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Cascading field hooks
+# ---------------------------------------------------------------------------
+
+
+class _CascadeGrid(Grid):
+    step: int = Field(default=0, state=True)
+    stage_a_reached: bool = Field(default=False, state=True)
+    stage_b_reached: bool = Field(default=False, state=True)
+
+    @on_field("step == 1")
+    def _on_step_one(self) -> None:
+        self.stage_a_reached = True
+        self.step = 2
+
+    @on_field("step == 2")
+    def _on_step_two(self) -> None:
+        self.stage_b_reached = True
+
+
+def test_cascade_second_step_fires_on_next_tick() -> None:
+    grid = _CascadeGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.step = 1
+    pump_tick(cast(Any, terminal))
+    assert grid.stage_a_reached
+
+    pump_tick(cast(Any, terminal))
+    assert grid.stage_b_reached
+
+
+# ---------------------------------------------------------------------------
+# 5. on_tick + on_field interaction (with interval gating)
+# ---------------------------------------------------------------------------
+
+
+class _CountdownGrid(Grid):
+    ticks: int = Field(default=0, state=True)
+    threshold_reached: bool = Field(default=False, state=True)
+
+    @on_tick
+    def _increment(self) -> None:
+        self.ticks += 1
+
+    @on_field("ticks >= 3")
+    def _on_threshold(self) -> None:
+        self.threshold_reached = True
+
+
+def test_tick_increments_then_field_hook_fires_at_threshold() -> None:
+    grid = _CountdownGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert grid.ticks == 1 and not grid.threshold_reached
+
+    pump_tick(cast(Any, terminal))
+    assert grid.ticks == 2 and not grid.threshold_reached
+
+    pump_tick(cast(Any, terminal))
+    assert grid.ticks == 3 and grid.threshold_reached
+
+
+class _IntervalGrid(Grid):
+    """on_tick with a huge interval fires only once (first call starts from
+    last_fire_ms=0, so elapsed is large enough to trip the interval gate
+    immediately). on_field fires on every tick regardless.
+    """
+
+    slow_ticks: int = Field(default=0, state=True)
+    field_ticks: int = Field(default=0, state=True)
+
+    @on_tick(9_999_999)  # only fires once: first pump_tick has elapsed≥interval
+    def _slow(self) -> None:
+        self.slow_ticks += 1
+
+    @on_field("slow_ticks >= 0")  # always true — not gated by tick interval
+    def _on_always(self) -> None:
+        self.field_ticks += 1
+
+
+def test_interval_tick_fires_once_field_hook_fires_every_tick() -> None:
+    """Interval tick fires on tick #1 (last_fire_ms=0 → large elapsed).
+    Subsequent ticks: interval not elapsed, tick hook skipped.
+    Field hook fires on all 3 ticks because it has no interval.
+    """
+    grid = _IntervalGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    for _ in range(3):
+        pump_tick(cast(Any, terminal))
+
+    assert grid.slow_ticks == 1   # fired once on first pump_tick
+    assert grid.field_ticks == 3  # fired on every tick
+
+
+# ---------------------------------------------------------------------------
+# 6. Compound / boolean expressions
+# ---------------------------------------------------------------------------
+
+
+class _CompoundGrid(Grid):
+    count: int = Field(default=0, state=True)
+    active: bool = Field(default=False, state=True)
+    fired: bool = Field(default=False, state=True)
+    negation_fired: bool = Field(default=False, state=True)
+    or_fired: bool = Field(default=False, state=True)
+
+    @on_field("count > 2 and active")
+    def _on_compound_and(self) -> None:
+        self.fired = True
+
+    @on_field("not active")
+    def _on_negation(self) -> None:
+        self.negation_fired = True
+
+    @on_field("count > 100 or active")
+    def _on_or(self) -> None:
+        self.or_fired = True
+
+
+def test_compound_and_requires_both_conditions() -> None:
+    grid = _CompoundGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.count = 5
+    pump_tick(cast(Any, terminal))
+    assert not grid.fired  # active is still False
+
+    grid.active = True
+    pump_tick(cast(Any, terminal))
+    assert grid.fired
+
+
+def test_negation_expression_fires_when_field_is_false() -> None:
+    grid = _CompoundGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert grid.negation_fired  # active starts False
+
+    grid.negation_fired = False
+    grid.active = True
+    pump_tick(cast(Any, terminal))
+    assert not grid.negation_fired
+
+
+def test_or_expression_fires_on_either_condition() -> None:
+    grid = _CompoundGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert not grid.or_fired  # count=0, active=False
+
+    grid.active = True
+    pump_tick(cast(Any, terminal))
+    assert grid.or_fired
+
+
+def test_chained_comparison_expression() -> None:
+    class _RangeGrid(Grid):
+        value: int = Field(default=0, state=True)
+        in_range: bool = Field(default=False, state=True)
+
+        @on_field("0 < value < 100")
+        def _on_in_range(self) -> None:
+            self.in_range = True
+
+    grid = _RangeGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.value = 50
+    pump_tick(cast(Any, terminal))
+    assert grid.in_range
+
+    grid.in_range = False
+    grid.value = 150
+    pump_tick(cast(Any, terminal))
+    assert not grid.in_range
+
+
+# ---------------------------------------------------------------------------
+# 7. Python field-type diversity
+# ---------------------------------------------------------------------------
+
+
+# 7a. Optional[str] — truthiness and None check
+class _OptionalGrid(Grid):
+    username: str | None = Field(default=None, state=True)
+    logged_in: bool = Field(default=False, state=True)
+    logged_out: bool = Field(default=False, state=True)
+
+    @on_field("username is not None")
+    def _on_login(self) -> None:
+        self.logged_in = True
+
+    @on_field("username is None")
+    def _on_logout(self) -> None:
+        self.logged_out = True
+
+
+def test_optional_field_none_check() -> None:
+    grid = _OptionalGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert not grid.logged_in
+    assert grid.logged_out
+
+    grid.username = "alice"
+    grid.logged_out = False
+    pump_tick(cast(Any, terminal))
+    assert grid.logged_in
+    assert not grid.logged_out
+
+
+# 7b. set[str] — membership test
+class _PermissionsGrid(Grid):
+    roles: set[str] = Field(default_factory=set, state=True)
+    is_admin: bool = Field(default=False, state=True)
+    is_editor: bool = Field(default=False, state=True)
+    no_roles: bool = Field(default=False, state=True)
+
+    @on_field("'admin' in roles")
+    def _on_admin(self) -> None:
+        self.is_admin = True
+
+    @on_field("'editor' in roles")
+    def _on_editor(self) -> None:
+        self.is_editor = True
+
+    @on_field("len(roles) == 0")
+    def _on_empty(self) -> None:
+        self.no_roles = True
+
+
+def test_set_membership_expression() -> None:
+    grid = _PermissionsGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert not grid.is_admin
+    assert grid.no_roles
+
+    grid.roles.add("admin")
+    grid.no_roles = False
+    pump_tick(cast(Any, terminal))
+    assert grid.is_admin
+    assert not grid.no_roles
+
+
+def test_set_multiple_memberships() -> None:
+    grid = _PermissionsGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.roles = {"admin", "editor"}
+    pump_tick(cast(Any, terminal))
+    assert grid.is_admin
+    assert grid.is_editor
+
+
+# 7c. tuple — index access
+class _CoordGrid(Grid):
+    position: tuple[int, int] = Field(default=(0, 0), state=True)
+    in_positive_quadrant: bool = Field(default=False, state=True)
+    at_origin: bool = Field(default=False, state=True)
+
+    @on_field("position[0] > 0 and position[1] > 0")
+    def _on_positive(self) -> None:
+        self.in_positive_quadrant = True
+
+    @on_field("position[0] == 0 and position[1] == 0")
+    def _on_origin(self) -> None:
+        self.at_origin = True
+
+
+def test_tuple_index_expression() -> None:
+    grid = _CoordGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert grid.at_origin
+    assert not grid.in_positive_quadrant
+
+    grid.position = (5, 10)
+    grid.at_origin = False
+    pump_tick(cast(Any, terminal))
+    assert grid.in_positive_quadrant
+    assert not grid.at_origin
+
+
+# 7d. float — threshold and abs comparison
+class _ProgressGrid(Grid):
+    progress: float = Field(default=0.0, state=True)
+    complete: bool = Field(default=False, state=True)
+    near_half: bool = Field(default=False, state=True)
+
+    @on_field("progress >= 1.0")
+    def _on_complete(self) -> None:
+        self.complete = True
+
+    @on_field("abs(progress - 0.5) < 0.05")
+    def _on_near_half(self) -> None:
+        self.near_half = True
+
+
+def test_float_threshold_expression() -> None:
+    grid = _ProgressGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.progress = 0.999
+    pump_tick(cast(Any, terminal))
+    assert not grid.complete
+
+    grid.progress = 1.0
+    pump_tick(cast(Any, terminal))
+    assert grid.complete
+
+
+def test_float_abs_proximity_expression() -> None:
+    grid = _ProgressGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.progress = 0.52
+    pump_tick(cast(Any, terminal))
+    assert grid.near_half
+
+    grid.near_half = False
+    grid.progress = 0.9
+    pump_tick(cast(Any, terminal))
+    assert not grid.near_half
+
+
+# 7e. Nested dict — deep key access
+class _ConfigGrid(Grid):
+    config: dict[str, Any] = Field(default_factory=dict, state=True)
+    is_admin: bool = Field(default=False, state=True)
+    theme_dark: bool = Field(default=False, state=True)
+
+    def __post_init__(self) -> None:
+        self.config = {
+            "user": {"role": "guest"},
+            "ui": {"theme": "light"},
+        }
+
+    @on_field("config.get('user', {}).get('role') == 'admin'")
+    def _on_admin(self) -> None:
+        self.is_admin = True
+
+    @on_field("config.get('ui', {}).get('theme') == 'dark'")
+    def _on_dark(self) -> None:
+        self.theme_dark = True
+
+
+def test_nested_dict_expression() -> None:
+    grid = _ConfigGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert not grid.is_admin
+    assert not grid.theme_dark
+
+    grid.config["user"]["role"] = "admin"
+    grid.config["ui"]["theme"] = "dark"
+    pump_tick(cast(Any, terminal))
+    assert grid.is_admin
+    assert grid.theme_dark
+
+
+# 7f. String operators — in, len, str() conversion
+class _StringFieldGrid(Grid):
+    message: str = Field(default="", state=True)
+    count: int = Field(default=0, state=True)
+    has_error: bool = Field(default=False, state=True)
+    long_message: bool = Field(default=False, state=True)
+    count_starts_with_1: bool = Field(default=False, state=True)
+
+    @on_field("'error' in message")
+    def _on_error(self) -> None:
+        self.has_error = True
+
+    @on_field("len(message) > 20")
+    def _on_long(self) -> None:
+        self.long_message = True
+
+    @on_field("str(count).startswith('1')")
+    def _on_starts_one(self) -> None:
+        self.count_starts_with_1 = True
+
+
+def test_string_in_operator_expression() -> None:
+    grid = _StringFieldGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.message = "connection error occurred"
+    pump_tick(cast(Any, terminal))
+    assert grid.has_error
+
+
+def test_string_len_expression() -> None:
+    grid = _StringFieldGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.message = "this message is definitely longer than twenty chars"
+    pump_tick(cast(Any, terminal))
+    assert grid.long_message
+
+
+def test_str_conversion_expression() -> None:
+    grid = _StringFieldGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.count = 100
+    pump_tick(cast(Any, terminal))
+    assert grid.count_starts_with_1
+
+    grid.count_starts_with_1 = False
+    grid.count = 200
+    pump_tick(cast(Any, terminal))
+    assert not grid.count_starts_with_1
+
+
+# 7g. List membership and truthiness
+class _LogGrid(Grid):
+    log: list[str] = Field(default_factory=list, state=True)
+    has_warning: bool = Field(default=False, state=True)
+    is_empty: bool = Field(default=False, state=True)
+    overflow: bool = Field(default=False, state=True)
+
+    @on_field("'WARNING' in log")
+    def _on_warning(self) -> None:
+        self.has_warning = True
+
+    @on_field("not log")
+    def _on_empty(self) -> None:
+        self.is_empty = True
+
+    @on_field("len(log) > 10")
+    def _on_overflow(self) -> None:
+        self.overflow = True
+
+
+def test_list_membership_expression() -> None:
+    grid = _LogGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert grid.is_empty
+    assert not grid.has_warning
+
+    grid.log.append("WARNING")
+    grid.is_empty = False
+    pump_tick(cast(Any, terminal))
+    assert grid.has_warning
+    assert not grid.is_empty
+
+
+def test_list_truthiness_and_len() -> None:
+    grid = _LogGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.log = [f"line {i}" for i in range(11)]
+    pump_tick(cast(Any, terminal))
+    assert grid.overflow
+    assert not grid.is_empty
+
+
+# 7h. max / min built-in expressions
+class _ScoreGrid(Grid):
+    scores: list[int] = Field(default_factory=list, state=True)
+    high_score: bool = Field(default=False, state=True)
+    low_score: bool = Field(default=False, state=True)
+
+    @on_field("bool(scores) and max(scores) >= 90")
+    def _on_high(self) -> None:
+        self.high_score = True
+
+    @on_field("bool(scores) and min(scores) <= 10")
+    def _on_low(self) -> None:
+        self.low_score = True
+
+
+def test_max_builtin_expression() -> None:
+    grid = _ScoreGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.scores = [70, 80, 95]
+    pump_tick(cast(Any, terminal))
+    assert grid.high_score
+
+
+def test_min_builtin_expression() -> None:
+    grid = _ScoreGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.scores = [5, 50, 70]
+    pump_tick(cast(Any, terminal))
+    assert grid.low_score
+
+
+# 7i. isinstance and hasattr
+class _TypeCheckGrid(Grid):
+    value: Any = Field(default=None, state=True)
+    is_int: bool = Field(default=False, state=True)
+    has_name: bool = Field(default=False, state=True)
+
+    @on_field("isinstance(value, int)")
+    def _on_int(self) -> None:
+        self.is_int = True
+
+    @on_field("hasattr(value, '__len__')")
+    def _on_has_len(self) -> None:
+        self.has_name = True
+
+
+def test_isinstance_expression() -> None:
+    grid = _TypeCheckGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.value = 42
+    pump_tick(cast(Any, terminal))
+    assert grid.is_int
+
+    grid.is_int = False
+    grid.value = "not an int"
+    pump_tick(cast(Any, terminal))
+    assert not grid.is_int
+
+
+def test_hasattr_expression() -> None:
+    grid = _TypeCheckGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.value = [1, 2, 3]
+    pump_tick(cast(Any, terminal))
+    assert grid.has_name
+
+
+# ---------------------------------------------------------------------------
+# 8. Expression using the implicit ``state`` variable
+#    evaluate_state_expression binds ``state`` to the grid instance itself.
+# ---------------------------------------------------------------------------
+
+
+class _StateVarGrid(Grid):
+    count: int = Field(default=0, state=True)
+    via_state: bool = Field(default=False, state=True)
+    has_count_attr: bool = Field(default=False, state=True)
+    via_getattr: bool = Field(default=False, state=True)
+
+    @on_field("state.count > 5")
+    def _on_via_state(self) -> None:
+        self.via_state = True
+
+    @on_field("hasattr(state, 'count')")
+    def _on_hasattr(self) -> None:
+        self.has_count_attr = True
+
+    @on_field("getattr(state, 'count', 0) == 10")
+    def _on_via_getattr(self) -> None:
+        self.via_getattr = True
+
+
+def test_state_variable_attribute_access() -> None:
+    grid = _StateVarGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.count = 6
+    pump_tick(cast(Any, terminal))
+    assert grid.via_state
+
+
+def test_state_variable_hasattr() -> None:
+    grid = _StateVarGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert grid.has_count_attr
+
+
+def test_state_variable_getattr() -> None:
+    grid = _StateVarGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.count = 10
+    pump_tick(cast(Any, terminal))
+    assert grid.via_getattr
+
+
+# ---------------------------------------------------------------------------
+# 9. Safe-eval resilience
+# ---------------------------------------------------------------------------
+
+
+class _SafeGrid(Grid):
+    count: int = Field(default=5, state=True)
+    denominator: int = Field(default=0, state=True)
+
+
+def test_missing_field_returns_false() -> None:
+    grid = _SafeGrid()
+    assert not evaluate_state_expression("nonexistent_field > 0", grid)
+
+
+def test_division_by_zero_returns_false() -> None:
+    grid = _SafeGrid()
+    # denominator is 0 — expression would raise ZeroDivisionError
+    assert not evaluate_state_expression(
+        "count / denominator > 1", grid
+    )
+
+
+def test_syntax_error_returns_false() -> None:
+    grid = _SafeGrid()
+    assert not evaluate_state_expression(
+        "this is definitely not valid python !!", grid
+    )
+
+
+def test_attribute_error_on_int_returns_false() -> None:
+    grid = _SafeGrid()
+    # int has no .nonexistent
+    assert not evaluate_state_expression("count.nonexistent", grid)
+
+
+def test_invalid_index_returns_false() -> None:
+    grid = _SafeGrid()
+    # count is an int, not subscriptable
+    assert not evaluate_state_expression("count['key']", grid)
+
+
+def test_bad_expression_does_not_fire_hook() -> None:
+    class _BadExprGrid(Grid):
+        count: int = Field(default=5, state=True)
+        fired: bool = Field(default=False, state=True)
+
+        @on_field("count / 0 > 1")
+        def _on_bad(self) -> None:
+            self.fired = True
+
+    grid = _BadExprGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert not grid.fired
+
+
+# ---------------------------------------------------------------------------
+# 10. Duplicate hooks — two handlers watching the same expression
+# ---------------------------------------------------------------------------
+
+
+class _TwoHandlerGrid(Grid):
+    active: bool = Field(default=False, state=True)
+    handler_a_count: int = Field(default=0, state=True)
+    handler_b_count: int = Field(default=0, state=True)
+
+    @on_field("active")
+    def _handler_a(self) -> None:
+        self.handler_a_count += 1
+
+    @on_field("active")
+    def _handler_b(self) -> None:
+        self.handler_b_count += 1
+
+
+def test_two_handlers_same_expression_both_fire() -> None:
+    grid = _TwoHandlerGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.active = True
+    pump_tick(cast(Any, terminal))
+
+    assert grid.handler_a_count == 1
+    assert grid.handler_b_count == 1
+
+
+def test_two_handlers_neither_fires_when_false() -> None:
+    grid = _TwoHandlerGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert grid.handler_a_count == 0
+    assert grid.handler_b_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 11. Fire-count tracking over multiple ticks
+# ---------------------------------------------------------------------------
+
+
+class _FireCountGrid(Grid):
+    active: bool = Field(default=True, state=True)
+    fire_count: int = Field(default=0, state=True)
+
+    @on_field("active")
+    def _on_active(self) -> None:
+        self.fire_count += 1
+
+
+def test_hook_fires_once_per_tick_while_true() -> None:
+    grid = _FireCountGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    for _ in range(7):
+        pump_tick(cast(Any, terminal))
+
+    assert grid.fire_count == 7
+
+
+def test_hook_fire_count_matches_true_ticks_only() -> None:
+    grid = _FireCountGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))  # true → fires
+    grid.active = False
+    pump_tick(cast(Any, terminal))  # false → no fire
+    grid.active = True
+    pump_tick(cast(Any, terminal))  # true → fires
+    pump_tick(cast(Any, terminal))  # true → fires
+
+    assert grid.fire_count == 3
+
+
+# ---------------------------------------------------------------------------
+# 12. Inheritance patterns
+# ---------------------------------------------------------------------------
+
+
+class _ParentGrid(Grid):
+    base_flag: bool = Field(default=False, state=True)
+    parent_fired: bool = Field(default=False, state=True)
+
+    @on_field("base_flag")
+    def _on_base(self) -> None:
+        self.parent_fired = True
+
+
+class _ChildGrid(_ParentGrid):
+    child_flag: bool = Field(default=False, state=True)
+    child_fired: bool = Field(default=False, state=True)
+
+    @on_field("child_flag")
+    def _on_child(self) -> None:
+        self.child_fired = True
+
+
+class _GrandchildGrid(_ChildGrid):
+    grand_flag: bool = Field(default=False, state=True)
+    grand_fired: bool = Field(default=False, state=True)
+
+    @on_field("grand_flag")
+    def _on_grand(self) -> None:
+        self.grand_fired = True
+
+
+def test_child_inherits_parent_on_field_hooks() -> None:
+    grid = _ChildGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.base_flag = True
+    pump_tick(cast(Any, terminal))
+    assert grid.parent_fired
+
+
+def test_child_own_hook_also_fires() -> None:
+    grid = _ChildGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.child_flag = True
+    pump_tick(cast(Any, terminal))
+    assert grid.child_fired
+
+
+def test_child_parent_and_own_hooks_fire_independently() -> None:
+    grid = _ChildGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.base_flag = True
+    grid.child_flag = True
+    pump_tick(cast(Any, terminal))
+    assert grid.parent_fired
+    assert grid.child_fired
+
+
+def test_grandchild_inherits_all_three_hook_layers() -> None:
+    grid = _GrandchildGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.base_flag = True
+    grid.child_flag = True
+    grid.grand_flag = True
+    pump_tick(cast(Any, terminal))
+    assert grid.parent_fired
+    assert grid.child_fired
+    assert grid.grand_fired
+
+
+def test_grandchild_only_grand_fires_when_others_false() -> None:
+    grid = _GrandchildGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    grid.grand_flag = True
+    pump_tick(cast(Any, terminal))
+    assert grid.grand_fired
+    assert not grid.parent_fired
+    assert not grid.child_fired
+
+
+def test_parent_used_alone_has_only_parent_hook() -> None:
+    registry = _EventHooksRegistry.from_component_class(_ParentGrid)
+    assert len(registry.on_field_hooks) == 1
+
+    registry_child = _EventHooksRegistry.from_component_class(_ChildGrid)
+    assert len(registry_child.on_field_hooks) == 2
+
+    registry_grand = _EventHooksRegistry.from_component_class(
+        _GrandchildGrid
+    )
+    assert len(registry_grand.on_field_hooks) == 3
+
+
+# ---------------------------------------------------------------------------
+# 13. Multi-grid isolation and cross-grid independence
+# ---------------------------------------------------------------------------
+
+
+class _IsolatedGrid(Grid):
+    value: int = Field(default=0, state=True)
+    fired: bool = Field(default=False, state=True)
+    fire_count: int = Field(default=0, state=True)
+
+    @on_field("value == 99")
+    def _on_trigger(self) -> None:
+        self.fired = True
+        self.fire_count += 1
+
+
+def test_field_hooks_isolated_across_instances() -> None:
+    grid_a = _IsolatedGrid()
+    grid_b = _IsolatedGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid_a)
+    terminal.attach(grid_b)
+
+    grid_a.value = 99
+    pump_tick(cast(Any, terminal))
+
+    assert grid_a.fired
+    assert not grid_b.fired
+
+
+def test_both_grids_fire_independently() -> None:
+    grid_a = _IsolatedGrid()
+    grid_b = _IsolatedGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid_a)
+    terminal.attach(grid_b)
+
+    grid_a.value = 99
+    grid_b.value = 99
+    pump_tick(cast(Any, terminal))
+
+    assert grid_a.fired and grid_b.fired
+
+
+def test_three_grids_only_one_matching() -> None:
+    grids = [_IsolatedGrid() for _ in range(3)]
+    terminal = _StubTerminal()
+    for g in grids:
+        terminal.attach(g)
+
+    grids[1].value = 99
+    pump_tick(cast(Any, terminal))
+
+    assert not grids[0].fired
+    assert grids[1].fired
+    assert not grids[2].fired
+
+
+def test_mixed_grid_types_do_not_contaminate() -> None:
+    grid_isolated = _IsolatedGrid()
+    grid_countdown = _CountdownGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid_isolated)
+    terminal.attach(grid_countdown)
+
+    pump_tick(cast(Any, terminal))
+
+    assert not grid_isolated.fired  # value is 0, not 99
+    assert grid_countdown.ticks == 1  # tick hook incremented
+
+
+# ---------------------------------------------------------------------------
+# 14. on_state / on_field source separation
+# ---------------------------------------------------------------------------
+
+
+class _DualSourceGrid(Grid):
+    grid_flag: bool = Field(default=False, state=True)
+    field_hook_fired: bool = Field(default=False, state=True)
+    state_hook_fired: bool = Field(default=False, state=True)
+
+    @on_field("grid_flag")
+    def _on_grid_flag(self) -> None:
+        self.field_hook_fired = True
+
+    @on_state("terminal_flag")
+    def _on_terminal_flag(self) -> None:
+        self.state_hook_fired = True
+
+
+def test_on_field_fires_without_terminal_state() -> None:
+    grid = _DualSourceGrid()
+    terminal = _StubTerminal(state=None)
+    terminal.attach(grid)
+
+    grid.grid_flag = True
+    pump_tick(cast(Any, terminal))
+
+    assert grid.field_hook_fired
+    assert not grid.state_hook_fired
+
+
+def test_on_state_fires_from_terminal_state_not_grid() -> None:
+    grid = _DualSourceGrid()
+    terminal = _StubTerminal(state=State(terminal_flag=True))
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+
+    assert grid.state_hook_fired
+    assert not grid.field_hook_fired
+
+
+def test_on_field_and_on_state_fire_independently() -> None:
+    grid = _DualSourceGrid()
+    terminal = _StubTerminal(state=State(terminal_flag=True))
+    terminal.attach(grid)
+
+    grid.grid_flag = True
+    pump_tick(cast(Any, terminal))
+
+    assert grid.field_hook_fired
+    assert grid.state_hook_fired
+
+
+def test_on_field_not_confused_by_terminal_state_attribute() -> None:
+    """on_field must evaluate against the grid, not terminal.state,
+    even if terminal.state has a same-named attribute."""
+
+    class _AmbiguousGrid(Grid):
+        count: int = Field(default=10, state=True)
+        correct: bool = Field(default=False, state=True)
+
+        @on_field("count == 10")
+        def _on_ten(self) -> None:
+            self.correct = True
+
+    grid = _AmbiguousGrid()
+    # terminal state also has count, but with a different value
+    terminal = _StubTerminal(state=State(count=999))
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    # hook must fire because grid.count == 10, ignoring state.count == 999
+    assert grid.correct
+
+
+# ---------------------------------------------------------------------------
+# 15. Dict state field (test.py scenario formalised)
+# ---------------------------------------------------------------------------
+
+
+class _DictStateGrid(Grid):
+    config: dict[str, Any] = Field(default_factory=dict, state=True)
+    display: str = Field(default="waiting")
+
+    def __post_init__(self) -> None:
+        self.config["name"] = "nobody"
+
+    @on_keyboard("a")
+    def _set_alice(self) -> None:
+        self.config["name"] = "alice"
+
+    @on_keyboard("b")
+    def _set_bob(self) -> None:
+        self.config["name"] = "bob"
+
+    @on_field("config.get('name') == 'alice'")
+    def _on_alice(self) -> None:
+        self.display = "Hello, Alice!"
+
+    @on_field("config.get('name') == 'bob'")
+    def _on_bob(self) -> None:
+        self.display = "Hello, Bob!"
+
+
+def test_dict_state_keyboard_to_display_alice() -> None:
+    grid = _DictStateGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    terminal.fire_keyboard("_set_alice")
+    pump_tick(cast(Any, terminal))
+    assert grid.display == "Hello, Alice!"
+
+
+def test_dict_state_keyboard_to_display_bob() -> None:
+    grid = _DictStateGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    terminal.fire_keyboard("_set_bob")
+    pump_tick(cast(Any, terminal))
+    assert grid.display == "Hello, Bob!"
+
+
+def test_dict_state_display_unchanged_without_keypress() -> None:
+    grid = _DictStateGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    pump_tick(cast(Any, terminal))
+    assert grid.display == "waiting"
+
+
+def test_dict_state_switches_correctly() -> None:
+    grid = _DictStateGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    terminal.fire_keyboard("_set_alice")
+    pump_tick(cast(Any, terminal))
+    assert grid.display == "Hello, Alice!"
+
+    terminal.fire_keyboard("_set_bob")
+    pump_tick(cast(Any, terminal))
+    assert grid.display == "Hello, Bob!"

--- a/tests/test_hook_perf.py
+++ b/tests/test_hook_perf.py
@@ -1,0 +1,670 @@
+"""Performance benchmarks for hook dispatch and frame rendering.
+
+Run with:
+    uv run pytest tests/test_hook_perf.py -v --benchmark-sort=mean
+    uv run pytest tests/test_hook_perf.py --benchmark-histogram
+
+Sections:
+  1.  Shared helpers and grid fixtures
+  2.  pump_tick throughput — varying hook counts (non-firing)
+  3.  pump_tick throughput — hooks that FIRE (handler runs every iteration)
+  4.  Expression evaluation — all field-type variants
+  5.  Frame render at multiple viewport sizes
+  6.  Frame-to-frame loop (render + pump_tick)
+  7.  Multi-grid pump_tick scaling
+  8.  Mixed hook types (field + tick + state active simultaneously)
+  9.  Registry collection (from_component_class) — simple and inherited
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, cast
+
+from xnano_core.core import CoreSession
+
+from xnano.beta import Field, Grid, on_field, on_tick
+from xnano.beta.core.dispatch import pump_tick
+from xnano.beta.core.session import Session
+from xnano.beta.hooks import (
+    _EventHooksRegistry,
+    _OnFieldHookFunctionEntry,
+    _OnStateHookFunctionEntry,
+    _OnTickHookFunctionEntry,
+)
+from xnano.beta.state import State
+from xnano.beta.types import Area
+from xnano.beta.utils.core import evaluate_state_expression
+
+
+# ---------------------------------------------------------------------------
+# 1. Shared helpers and grid fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class _StubTerminal:
+    state: Any = None
+    _hooks: _EventHooksRegistry = dataclasses.field(
+        default_factory=_EventHooksRegistry
+    )
+    _attached_frame_grids: list[Any] = dataclasses.field(
+        default_factory=list
+    )
+
+    def attach(self, grid: Any) -> None:
+        collected = _EventHooksRegistry.from_component_class(type(grid))
+        for entry in collected.on_field_hooks:
+            name = getattr(entry["handler"], "__name__", None)
+            bound = (
+                getattr(grid, name)
+                if name and hasattr(grid, name)
+                else entry["handler"]
+            )
+            self._hooks.on_field_hooks.append(
+                _OnFieldHookFunctionEntry(
+                    expression=entry["expression"], handler=bound
+                )
+            )
+        for entry in collected.on_tick_hooks:
+            name = getattr(entry["handler"], "__name__", None)
+            bound = (
+                getattr(grid, name)
+                if name and hasattr(grid, name)
+                else entry["handler"]
+            )
+            self._hooks.on_tick_hooks.append(
+                _OnTickHookFunctionEntry(
+                    interval=entry["interval"],
+                    handler=bound,
+                    last_fire_ms=0.0,
+                )
+            )
+        for entry in collected.on_state_hooks:
+            name = getattr(entry["handler"], "__name__", None)
+            bound = (
+                getattr(grid, name)
+                if name and hasattr(grid, name)
+                else entry["handler"]
+            )
+            self._hooks.on_state_hooks.append(
+                _OnStateHookFunctionEntry(
+                    expression=entry["expression"], handler=bound
+                )
+            )
+        self._attached_frame_grids.append(grid)
+
+
+def _make_offscreen(
+    width: int = 80, height: int = 24
+) -> tuple[CoreSession, Session]:
+    core = CoreSession.offscreen(width=width, height=height)
+    sess = Session(
+        core, terminal_width=width, terminal_height=height, is_offscreen=True
+    )
+    return core, sess
+
+
+def _one_frame(grid: Grid, sess: Session, area: Area) -> None:
+    sess.begin_frame()
+    grid._grid_build_frame(area, sess)
+    sess.commit_requests()
+
+
+def _frame_and_tick(
+    grid: Grid,
+    sess: Session,
+    area: Area,
+    terminal: _StubTerminal,
+) -> None:
+    sess.begin_frame()
+    grid._grid_build_frame(area, sess)
+    sess.commit_requests()
+    pump_tick(cast(Any, terminal))
+
+
+# ---------------------------------------------------------------------------
+# Grid fixtures
+# ---------------------------------------------------------------------------
+
+
+class _CounterGrid(Grid):
+    count: int = Field(default=0, state=True)
+    active: bool = Field(default=True, state=True)
+    label: str = Field(default="running")
+
+    @on_field("count > 1_000_000")  # never true in benchmarks
+    def _on_high(self) -> None:
+        self.label = "high"
+
+    @on_field("not active")  # never true in benchmarks
+    def _on_inactive(self) -> None:
+        self.label = "inactive"
+
+    @on_tick
+    def _tick(self) -> None:
+        self.count += 1
+
+
+class _AlwaysFiringGrid(Grid):
+    """All on_field hooks evaluate to true every tick."""
+
+    count: int = Field(default=5, state=True)
+    active: bool = Field(default=True, state=True)
+    name: str = Field(default="alice", state=True)
+    calls: int = Field(default=0, state=True)
+
+    @on_field("count > 0")
+    def _on_count(self) -> None:
+        self.calls += 1
+
+    @on_field("active")
+    def _on_active(self) -> None:
+        self.calls += 1
+
+    @on_field("name == 'alice'")
+    def _on_name(self) -> None:
+        self.calls += 1
+
+
+class _RenderGrid(Grid):
+    title: str = Field(default="Benchmark Grid", height=1)
+    body: str = Field(
+        default=(
+            "frame content goes here — this simulates a typical "
+            "terminal application layout with a title, body, and status"
+        )
+    )
+    status: str = Field(default="ok", height=1)
+
+
+class _NestedRenderGrid(Grid):
+    header: str = Field(default="Header", height=1)
+    left: _RenderGrid = Field(default_factory=_RenderGrid)
+    right: _RenderGrid = Field(default_factory=_RenderGrid)
+    footer: str = Field(default="Footer", height=1)
+
+
+class _ExprGrid(Grid):
+    count: int = Field(default=42, state=True)
+    active: bool = Field(default=True, state=True)
+    name: str = Field(default="alice", state=True)
+    progress: float = Field(default=0.52, state=True)
+    config: dict[str, Any] = Field(
+        default_factory=lambda: {"user": {"role": "admin"}}, state=True
+    )
+    roles: set[str] = Field(
+        default_factory=lambda: {"admin", "editor"}, state=True
+    )
+    position: tuple[int, int] = Field(default=(5, 10), state=True)
+    log: list[str] = Field(
+        default_factory=lambda: ["INFO", "WARNING", "ERROR"], state=True
+    )
+    scores: list[int] = Field(
+        default_factory=lambda: [70, 85, 95], state=True
+    )
+    username: str | None = Field(default="alice", state=True)
+    denominator: int = Field(default=2, state=True)
+
+
+# ---------------------------------------------------------------------------
+# 2. pump_tick throughput — non-firing hooks (expression always false)
+# ---------------------------------------------------------------------------
+
+
+def _make_nonfiring_terminal(n: int) -> _StubTerminal:
+    grid = _CounterGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+    bound_noop = (lambda self: None).__get__(grid, type(grid))
+    for i in range(n):
+        terminal._hooks.on_field_hooks.append(
+            _OnFieldHookFunctionEntry(
+                expression=f"count > {10_000_000 + i}",
+                handler=bound_noop,
+            )
+        )
+    return terminal
+
+
+def test_bench_pump_tick_baseline(benchmark) -> None:
+    """Baseline: 2 non-firing field hooks + 1 tick hook."""
+    terminal = _make_nonfiring_terminal(0)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_pump_tick_10_nonfiring(benchmark) -> None:
+    terminal = _make_nonfiring_terminal(10)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_pump_tick_50_nonfiring(benchmark) -> None:
+    terminal = _make_nonfiring_terminal(50)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_pump_tick_100_nonfiring(benchmark) -> None:
+    terminal = _make_nonfiring_terminal(100)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_pump_tick_500_nonfiring(benchmark) -> None:
+    terminal = _make_nonfiring_terminal(500)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 3. pump_tick throughput — hooks that FIRE (handler runs every call)
+# ---------------------------------------------------------------------------
+
+
+def test_bench_pump_tick_all_firing(benchmark) -> None:
+    """3 on_field hooks all evaluate true and run their handlers."""
+    grid = _AlwaysFiringGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def _make_firing_terminal(n: int) -> _StubTerminal:
+    grid = _AlwaysFiringGrid()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+
+    def noop(self) -> None:  # type: ignore[misc]
+        pass
+
+    bound_noop = noop.__get__(grid, type(grid))
+    for i in range(n):
+        terminal._hooks.on_field_hooks.append(
+            _OnFieldHookFunctionEntry(
+                expression="active",  # always true
+                handler=bound_noop,
+            )
+        )
+    return terminal
+
+
+def test_bench_pump_tick_10_firing(benchmark) -> None:
+    terminal = _make_firing_terminal(10)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_pump_tick_50_firing(benchmark) -> None:
+    terminal = _make_firing_terminal(50)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_pump_tick_100_firing(benchmark) -> None:
+    terminal = _make_firing_terminal(100)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 4. Expression evaluation — all field-type variants
+# ---------------------------------------------------------------------------
+
+
+def test_bench_expr_bool_field(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(evaluate_state_expression, "active", grid)
+
+
+def test_bench_expr_int_comparison(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(evaluate_state_expression, "count > 10", grid)
+
+
+def test_bench_expr_chained_comparison(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(evaluate_state_expression, "0 < count < 100", grid)
+
+
+def test_bench_expr_compound_and(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(
+        evaluate_state_expression,
+        "count > 10 and active and name == 'alice'",
+        grid,
+    )
+
+
+def test_bench_expr_float_abs(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(
+        evaluate_state_expression, "abs(progress - 0.5) < 0.05", grid
+    )
+
+
+def test_bench_expr_float_threshold(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(evaluate_state_expression, "progress >= 0.5", grid)
+
+
+def test_bench_expr_dict_get_flat(benchmark) -> None:
+    grid = _ExprGrid()
+    grid.config["name"] = "john"
+    benchmark(
+        evaluate_state_expression, "config.get('name') == 'john'", grid
+    )
+
+
+def test_bench_expr_dict_get_nested(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(
+        evaluate_state_expression,
+        "config.get('user', {}).get('role') == 'admin'",
+        grid,
+    )
+
+
+def test_bench_expr_set_membership(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(evaluate_state_expression, "'admin' in roles", grid)
+
+
+def test_bench_expr_list_membership(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(evaluate_state_expression, "'WARNING' in log", grid)
+
+
+def test_bench_expr_list_len(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(evaluate_state_expression, "len(log) > 2", grid)
+
+
+def test_bench_expr_tuple_index(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(
+        evaluate_state_expression,
+        "position[0] > 0 and position[1] > 0",
+        grid,
+    )
+
+
+def test_bench_expr_optional_none_check(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(
+        evaluate_state_expression, "username is not None", grid
+    )
+
+
+def test_bench_expr_max_builtin(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(
+        evaluate_state_expression,
+        "bool(scores) and max(scores) >= 90",
+        grid,
+    )
+
+
+def test_bench_expr_str_conversion(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(
+        evaluate_state_expression, "str(count).startswith('4')", grid
+    )
+
+
+def test_bench_expr_isinstance(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(evaluate_state_expression, "isinstance(count, int)", grid)
+
+
+def test_bench_expr_state_variable(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(evaluate_state_expression, "state.count > 10", grid)
+
+
+def test_bench_expr_getattr_builtin(benchmark) -> None:
+    grid = _ExprGrid()
+    benchmark(
+        evaluate_state_expression,
+        "getattr(state, 'count', 0) > 10",
+        grid,
+    )
+
+
+def test_bench_expr_bad_expression_resilience(benchmark) -> None:
+    """Safe-eval error path: expression fails, returns False."""
+    grid = _ExprGrid()
+    benchmark(
+        evaluate_state_expression, "count / 0 > 1", grid
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Frame render at multiple viewport sizes
+# ---------------------------------------------------------------------------
+
+
+def test_bench_frame_render_40x10(benchmark) -> None:
+    grid = _RenderGrid()
+    _, sess = _make_offscreen(40, 10)
+    area = Area(x=0, y=0, width=40, height=10)
+    benchmark(_one_frame, grid, sess, area)
+
+
+def test_bench_frame_render_80x24(benchmark) -> None:
+    grid = _RenderGrid()
+    _, sess = _make_offscreen(80, 24)
+    area = Area(x=0, y=0, width=80, height=24)
+    benchmark(_one_frame, grid, sess, area)
+
+
+def test_bench_frame_render_120x40(benchmark) -> None:
+    grid = _RenderGrid()
+    _, sess = _make_offscreen(120, 40)
+    area = Area(x=0, y=0, width=120, height=40)
+    benchmark(_one_frame, grid, sess, area)
+
+
+def test_bench_frame_render_220x50_fullhd(benchmark) -> None:
+    grid = _RenderGrid()
+    _, sess = _make_offscreen(220, 50)
+    area = Area(x=0, y=0, width=220, height=50)
+    benchmark(_one_frame, grid, sess, area)
+
+
+def test_bench_frame_render_nested_80x24(benchmark) -> None:
+    """Nested grid: header + two child RenderGrids + footer."""
+    grid = _NestedRenderGrid()
+    _, sess = _make_offscreen(80, 24)
+    area = Area(x=0, y=0, width=80, height=24)
+    benchmark(_one_frame, grid, sess, area)
+
+
+def test_bench_frame_render_nested_220x50(benchmark) -> None:
+    grid = _NestedRenderGrid()
+    _, sess = _make_offscreen(220, 50)
+    area = Area(x=0, y=0, width=220, height=50)
+    benchmark(_one_frame, grid, sess, area)
+
+
+# ---------------------------------------------------------------------------
+# 6. Frame-to-frame loop (render + pump_tick back-to-back)
+# ---------------------------------------------------------------------------
+
+
+def test_bench_frame_and_tick_80x24(benchmark) -> None:
+    grid = _CounterGrid()
+    _, sess = _make_offscreen(80, 24)
+    area = Area(x=0, y=0, width=80, height=24)
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+    benchmark(_frame_and_tick, grid, sess, area, terminal)
+
+
+def test_bench_frame_and_tick_220x50(benchmark) -> None:
+    grid = _CounterGrid()
+    _, sess = _make_offscreen(220, 50)
+    area = Area(x=0, y=0, width=220, height=50)
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+    benchmark(_frame_and_tick, grid, sess, area, terminal)
+
+
+def test_bench_frame_and_tick_nested_80x24(benchmark) -> None:
+    grid = _NestedRenderGrid()
+    _, sess = _make_offscreen(80, 24)
+    area = Area(x=0, y=0, width=80, height=24)
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+    benchmark(_frame_and_tick, grid, sess, area, terminal)
+
+
+def test_bench_frame_and_tick_always_firing(benchmark) -> None:
+    """Hot path with hooks that actually invoke handlers each frame."""
+    grid = _AlwaysFiringGrid()
+    _, sess = _make_offscreen(80, 24)
+    area = Area(x=0, y=0, width=80, height=24)
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+    benchmark(_frame_and_tick, grid, sess, area, terminal)
+
+
+# ---------------------------------------------------------------------------
+# 7. Multi-grid pump_tick scaling
+# ---------------------------------------------------------------------------
+
+
+def test_bench_pump_tick_1_grid(benchmark) -> None:
+    terminal = _StubTerminal()
+    terminal.attach(_CounterGrid())
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_pump_tick_5_grids(benchmark) -> None:
+    terminal = _StubTerminal()
+    for _ in range(5):
+        terminal.attach(_CounterGrid())
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_pump_tick_20_grids(benchmark) -> None:
+    terminal = _StubTerminal()
+    for _ in range(20):
+        terminal.attach(_CounterGrid())
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_pump_tick_50_grids(benchmark) -> None:
+    terminal = _StubTerminal()
+    for _ in range(50):
+        terminal.attach(_CounterGrid())
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_pump_tick_mixed_grid_types(benchmark) -> None:
+    """Mix of CounterGrid and AlwaysFiringGrid — realistic diversity."""
+    terminal = _StubTerminal()
+    for _ in range(5):
+        terminal.attach(_CounterGrid())
+    for _ in range(5):
+        terminal.attach(_AlwaysFiringGrid())
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 8. Mixed hook types (field + tick + state all active)
+# ---------------------------------------------------------------------------
+
+
+class _MixedHookGrid(Grid):
+    count: int = Field(default=5, state=True)
+    active: bool = Field(default=True, state=True)
+    label: str = Field(default="running")
+
+    @on_tick
+    def _tick(self) -> None:
+        pass
+
+    @on_field("count > 0")
+    def _on_count(self) -> None:
+        pass
+
+    @on_field("active")
+    def _on_active(self) -> None:
+        pass
+
+
+def test_bench_mixed_hooks_no_terminal_state(benchmark) -> None:
+    grid = _MixedHookGrid()
+    terminal = _StubTerminal(state=None)
+    terminal.attach(grid)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+def test_bench_mixed_hooks_with_terminal_state(benchmark) -> None:
+    grid = _MixedHookGrid()
+
+    from xnano.beta.hooks import on_state
+
+    class _WithStateGrid(_MixedHookGrid):
+        state_fired: bool = Field(default=False, state=True)
+
+        @on_state("flag")
+        def _on_state(self) -> None:
+            self.state_fired = True
+
+    grid2 = _WithStateGrid()
+    terminal = _StubTerminal(state=State(flag=True))
+    terminal.attach(grid2)
+    benchmark(pump_tick, terminal)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 9. Registry collection (from_component_class) — simple and inherited
+# ---------------------------------------------------------------------------
+
+
+def test_bench_registry_simple(benchmark) -> None:
+    benchmark(
+        _EventHooksRegistry.from_component_class, _CounterGrid
+    )
+
+
+def test_bench_registry_few_hooks(benchmark) -> None:
+    benchmark(
+        _EventHooksRegistry.from_component_class, _AlwaysFiringGrid
+    )
+
+
+class _DeepGrid(_GrandchildGrid if False else Grid):
+    pass
+
+
+# Re-define inline to avoid forward-reference to test_hook_interop
+class _L0(Grid):
+    f0: bool = Field(default=False, state=True)
+
+    @on_field("f0")
+    def _h0(self) -> None:
+        pass
+
+
+class _L1(_L0):
+    f1: bool = Field(default=False, state=True)
+
+    @on_field("f1")
+    def _h1(self) -> None:
+        pass
+
+
+class _L2(_L1):
+    f2: bool = Field(default=False, state=True)
+
+    @on_field("f2")
+    def _h2(self) -> None:
+        pass
+
+
+class _L3(_L2):
+    f3: bool = Field(default=False, state=True)
+
+    @on_field("f3")
+    def _h3(self) -> None:
+        pass
+
+
+def test_bench_registry_deep_inheritance(benchmark) -> None:
+    benchmark(_EventHooksRegistry.from_component_class, _L3)

--- a/tests/test_on_field_hook.py
+++ b/tests/test_on_field_hook.py
@@ -1,0 +1,198 @@
+"""Tests for the @on_field hook decorator."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, cast
+
+from xnano.beta import Field, Grid, on_field
+from xnano.beta.context import Context
+from xnano.beta.core.dispatch import pump_tick
+from xnano.beta.hooks import _EventHooksRegistry, _OnFieldHookFunctionEntry
+from xnano.beta.utils.core import evaluate_state_expression
+
+
+# ---------------------------------------------------------------------------
+# Decorator registration
+# ---------------------------------------------------------------------------
+
+
+class _SimpleLabelGrid(Grid):
+    label: str = Field(default="initial")
+    active: bool = Field(default=False, state=True)
+    fired: bool = Field(default=False, state=True)
+
+    @on_field("active")
+    def _on_active(self) -> None:
+        self.fired = True
+
+
+def test_on_field_sets_hook_attribute() -> None:
+    method = _SimpleLabelGrid.__dict__["_on_active"]
+    assert hasattr(method, _EventHooksRegistry.ON_FIELD_HOOK_ATTR)
+
+
+def test_on_field_sets_expression_attribute() -> None:
+    method = _SimpleLabelGrid.__dict__["_on_active"]
+    expression = getattr(method, _EventHooksRegistry.ON_FIELD_EXPRESSION_ATTR)
+    assert expression == "active"
+
+
+def test_from_component_class_collects_on_field_hook() -> None:
+    registry = _EventHooksRegistry.from_component_class(_SimpleLabelGrid)
+    assert len(registry.on_field_hooks) == 1
+    entry: _OnFieldHookFunctionEntry = registry.on_field_hooks[0]
+    assert entry["expression"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_state_expression against a grid instance
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_against_grid_simple_bool_field() -> None:
+    grid = _SimpleLabelGrid()
+    assert not evaluate_state_expression("active", grid)
+    grid.active = True
+    assert evaluate_state_expression("active", grid)
+
+
+def test_evaluate_against_grid_string_comparison() -> None:
+    grid = _SimpleLabelGrid()
+    grid.label = "hello"
+    assert evaluate_state_expression("label == 'hello'", grid)
+    assert not evaluate_state_expression("label == 'world'", grid)
+
+
+# ---------------------------------------------------------------------------
+# Dict-valued state field (matches the test.py scenario)
+# ---------------------------------------------------------------------------
+
+
+class _NameSwitcherGrid(Grid):
+    config: dict[str, Any] = Field(default_factory=dict, state=True)
+    current_text: str = Field(default="choose a name")
+    john_fired: bool = Field(default=False, state=True)
+    jane_fired: bool = Field(default=False, state=True)
+
+    def __post_init__(self) -> None:
+        self.config["name"] = "nobody"
+
+    @on_field("config.get('name') == 'john'")
+    def _on_john(self) -> None:
+        self.current_text = "Hello, John!"
+        self.john_fired = True
+
+    @on_field("config.get('name') == 'jane'")
+    def _on_jane(self) -> None:
+        self.current_text = "Hello, Jane!"
+        self.jane_fired = True
+
+
+def test_evaluate_dict_field_expression_true() -> None:
+    grid = _NameSwitcherGrid()
+    grid.config["name"] = "john"
+    assert evaluate_state_expression("config.get('name') == 'john'", grid)
+
+
+def test_evaluate_dict_field_expression_false_for_other_name() -> None:
+    grid = _NameSwitcherGrid()
+    grid.config["name"] = "jane"
+    assert not evaluate_state_expression("config.get('name') == 'john'", grid)
+
+
+def test_from_component_class_collects_multiple_on_field_hooks() -> None:
+    registry = _EventHooksRegistry.from_component_class(_NameSwitcherGrid)
+    assert len(registry.on_field_hooks) == 2
+    expressions = {e["expression"] for e in registry.on_field_hooks}
+    assert "config.get('name') == 'john'" in expressions
+    assert "config.get('name') == 'jane'" in expressions
+
+
+# ---------------------------------------------------------------------------
+# pump_tick dispatch via a minimal stub terminal
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class _StubTerminal:
+    """Minimal terminal stub for testing pump_tick without a real session."""
+
+    state: Any = None
+    _hooks: _EventHooksRegistry = dataclasses.field(
+        default_factory=_EventHooksRegistry
+    )
+    _attached_frame_grids: list[Any] = dataclasses.field(
+        default_factory=list
+    )
+
+    def _attach_grid(self, grid: Any) -> None:
+        """Register a grid so resolve_hook_grid can find it."""
+        collected = _EventHooksRegistry.from_component_class(type(grid))
+        for entry in collected.on_field_hooks:
+            handler_name = getattr(entry["handler"], "__name__", None)
+            bound = (
+                getattr(grid, handler_name)
+                if handler_name and hasattr(grid, handler_name)
+                else entry["handler"]
+            )
+            self._hooks.on_field_hooks.append(
+                _OnFieldHookFunctionEntry(
+                    expression=entry["expression"],
+                    handler=bound,
+                )
+            )
+        self._attached_frame_grids.append(grid)
+
+
+def test_pump_tick_fires_on_field_hook_when_expression_true() -> None:
+    grid = _NameSwitcherGrid()
+    terminal = _StubTerminal()
+    terminal._attach_grid(grid)
+
+    grid.config["name"] = "john"
+    pump_tick(cast(Any, terminal))
+
+    assert grid.john_fired
+    assert not grid.jane_fired
+    assert grid.current_text == "Hello, John!"
+
+
+def test_pump_tick_fires_correct_hook_for_second_name() -> None:
+    grid = _NameSwitcherGrid()
+    terminal = _StubTerminal()
+    terminal._attach_grid(grid)
+
+    grid.config["name"] = "jane"
+    pump_tick(cast(Any, terminal))
+
+    assert grid.jane_fired
+    assert not grid.john_fired
+    assert grid.current_text == "Hello, Jane!"
+
+
+def test_pump_tick_does_not_fire_when_expression_false() -> None:
+    grid = _NameSwitcherGrid()
+    terminal = _StubTerminal()
+    terminal._attach_grid(grid)
+
+    # config["name"] starts as "nobody" — neither hook should fire
+    pump_tick(cast(Any, terminal))
+
+    assert not grid.john_fired
+    assert not grid.jane_fired
+    assert grid.current_text == "choose a name"
+
+
+def test_pump_tick_switches_hooks_on_name_change() -> None:
+    grid = _NameSwitcherGrid()
+    terminal = _StubTerminal()
+    terminal._attach_grid(grid)
+
+    grid.config["name"] = "john"
+    pump_tick(cast(Any, terminal))
+    assert grid.current_text == "Hello, John!"
+
+    grid.config["name"] = "jane"
+    pump_tick(cast(Any, terminal))
+    assert grid.current_text == "Hello, Jane!"

--- a/tests/test_on_poll_hook.py
+++ b/tests/test_on_poll_hook.py
@@ -1,0 +1,168 @@
+"""Tests for the @on_poll hook decorator and pump_poll dispatch."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from xnano.beta import Field, Grid, on_poll
+from xnano.beta.core.dispatch import pump_events, pump_poll
+from xnano.beta.hooks import (
+    PollWhen,
+    _EventHooksRegistry,
+    _OnPollHookFunctionEntry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Decorator registration
+# ---------------------------------------------------------------------------
+
+
+class _IdleGrid(Grid):
+    idle_count: int = Field(default=0, state=True)
+    frame_count: int = Field(default=0, state=True)
+
+    @on_poll
+    def _on_idle(self) -> None:
+        self.idle_count += 1
+
+    @on_poll("frame")
+    def _on_frame(self) -> None:
+        self.frame_count += 1
+
+
+class _KeywordIdleGrid(Grid):
+    hits: int = Field(default=0, state=True)
+
+    @on_poll(when="idle")
+    def _on_idle(self) -> None:
+        self.hits += 1
+
+
+def test_on_poll_bare_defaults_to_idle() -> None:
+    method = _IdleGrid.__dict__["_on_idle"]
+    assert hasattr(method, _EventHooksRegistry.ON_POLL_HOOK_ATTR)
+    assert getattr(method, _EventHooksRegistry.ON_POLL_WHEN_ATTR) == "idle"
+
+
+def test_on_poll_positional_frame() -> None:
+    method = _IdleGrid.__dict__["_on_frame"]
+    assert getattr(method, _EventHooksRegistry.ON_POLL_WHEN_ATTR) == "frame"
+
+
+def test_on_poll_keyword_when() -> None:
+    method = _KeywordIdleGrid.__dict__["_on_idle"]
+    assert getattr(method, _EventHooksRegistry.ON_POLL_WHEN_ATTR) == "idle"
+
+
+def test_from_component_class_collects_poll_hooks() -> None:
+    registry = _EventHooksRegistry.from_component_class(_IdleGrid)
+    assert len(registry.on_poll_hooks) == 2
+    by_when = {entry["when"]: entry for entry in registry.on_poll_hooks}
+    assert set(by_when) == {"idle", "frame"}
+
+
+def test_invalid_when_raises() -> None:
+    with pytest.raises(TypeError, match="idle"):
+        # Bypass overloads so the runtime validation path is exercised.
+        cast(Any, on_poll)("nope")
+
+
+# ---------------------------------------------------------------------------
+# pump_poll dispatch
+# ---------------------------------------------------------------------------
+
+
+def _stub_terminal(grid: Grid) -> Any:
+    terminal = MagicMock()
+    terminal.state = None
+    registry = _EventHooksRegistry.from_component_class(type(grid))
+    bound: list[_OnPollHookFunctionEntry] = []
+    for entry in registry.on_poll_hooks:
+        handler = entry["handler"]
+        name = getattr(handler, "__name__", None)
+        if name and hasattr(grid, name):
+            handler = getattr(grid, name)
+        bound.append(
+            _OnPollHookFunctionEntry(when=entry["when"], handler=handler)
+        )
+    terminal._hooks = MagicMock()
+    terminal._hooks.on_poll_hooks = bound
+    terminal._attached_frame_grids = [grid]
+    return terminal
+
+
+def test_pump_poll_idle_fires_only_idle_handlers() -> None:
+    grid = _IdleGrid()
+    terminal = _stub_terminal(grid)
+    pump_poll(terminal, "idle")
+    assert grid.idle_count == 1
+    assert grid.frame_count == 0
+
+
+def test_pump_poll_frame_fires_only_frame_handlers() -> None:
+    grid = _IdleGrid()
+    terminal = _stub_terminal(grid)
+    pump_poll(terminal, "frame")
+    assert grid.idle_count == 0
+    assert grid.frame_count == 1
+
+
+def test_pump_events_idle_when_poll_returns_none() -> None:
+    grid = _IdleGrid()
+    terminal = _stub_terminal(grid)
+    session = MagicMock()
+    session.poll_core_event.return_value = None
+    terminal.session = session
+    terminal.tick_interval = 16
+
+    pump_events(terminal)
+
+    assert grid.idle_count == 1
+    assert grid.frame_count == 0
+    session.poll_core_event.assert_called_once_with(timeout=16)
+
+
+def test_pump_events_skips_idle_when_event_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    grid = _IdleGrid()
+    terminal = _stub_terminal(grid)
+    session = MagicMock()
+    fake_event = MagicMock()
+    session.poll_core_event.side_effect = [fake_event, None]
+    terminal.session = session
+    terminal.tick_interval = 16
+    terminal._mouse_geometry_active = False
+
+    from xnano.beta import events as events_mod
+
+    class _FakeEvent:
+        def is_mouse_event(self) -> bool:
+            return False
+
+        def is_keyboard_event(self) -> bool:
+            return False
+
+        def is_resize_event(self) -> bool:
+            return False
+
+        def is_clipboard_event(self) -> bool:
+            return False
+
+        def is_focus_event(self) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        events_mod, "Event", lambda core: _FakeEvent(), raising=True
+    )
+    pump_events(terminal)
+    assert grid.idle_count == 0
+
+
+def test_poll_when_values() -> None:
+    values: list[PollWhen] = ["idle", "frame"]
+    assert values == ["idle", "frame"]

--- a/tests/test_text_input.py
+++ b/tests/test_text_input.py
@@ -1,0 +1,152 @@
+"""Tests for editable Text(input=True) and display helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from xnano.beta.components.abstract import ComponentRenderContext
+from xnano.beta.components.text import Text
+from xnano.beta.core.nodes import ParagraphNode
+from xnano.beta.focus import apply_text_keyboard
+from xnano.beta.types import Area
+
+
+def _ctx() -> ComponentRenderContext:
+    return ComponentRenderContext(area=Area(x=0, y=0, width=40, height=3))
+
+
+def _kbd(**kwargs: Any) -> Any:
+    """Build a duck-typed keyboard event for apply_text_keyboard."""
+    character = kwargs.get("character")
+    matches = set(kwargs.get("matches", ()))
+    kind = kwargs.get("kind", "press")
+
+    class _K:
+        def __init__(self) -> None:
+            self.kind = kind
+            self.character = character
+
+        def matches(self, *bindings: str) -> bool:
+            return any(binding in matches for binding in bindings)
+
+    return _K()
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_input_defaults() -> None:
+    text = Text("hi", input=True, placeholder="name")
+    assert text.input is True
+    assert text.placeholder == "name"
+    assert text.cursor is None
+    assert text._input_focused is False
+
+
+def test_value_property() -> None:
+    text = Text("abc", input=True)
+    assert text.value == "abc"
+    text.value = "xyz"
+    assert text.content == "xyz"
+
+
+# ---------------------------------------------------------------------------
+# Keyboard editing
+# ---------------------------------------------------------------------------
+
+
+def test_insert_character_at_end() -> None:
+    text = Text("ab", input=True)
+    assert apply_text_keyboard(text, _kbd(character="c")) is True
+    assert text.content == "abc"
+    assert text.cursor == 3
+
+
+def test_insert_character_in_middle() -> None:
+    text = Text("ac", input=True, cursor=1)
+    assert apply_text_keyboard(text, _kbd(character="b")) is True
+    assert text.content == "abc"
+    assert text.cursor == 2
+
+
+def test_backspace() -> None:
+    text = Text("abc", input=True)
+    assert apply_text_keyboard(text, _kbd(matches={"backspace"})) is True
+    assert text.content == "ab"
+
+
+def test_delete_forward() -> None:
+    text = Text("abc", input=True, cursor=1)
+    assert apply_text_keyboard(text, _kbd(matches={"delete"})) is True
+    assert text.content == "ac"
+    assert text.cursor == 1
+
+
+def test_left_right_home_end() -> None:
+    text = Text("abc", input=True, cursor=1)
+    assert apply_text_keyboard(text, _kbd(matches={"left"})) is True
+    assert text.cursor == 0
+    assert apply_text_keyboard(text, _kbd(matches={"right"})) is True
+    assert text.cursor == 1
+    assert apply_text_keyboard(text, _kbd(matches={"end"})) is True
+    assert text.cursor == 3
+    assert apply_text_keyboard(text, _kbd(matches={"home"})) is True
+    assert text.cursor == 0
+
+
+def test_enter_and_tab_not_consumed() -> None:
+    text = Text("x", input=True)
+    assert apply_text_keyboard(text, _kbd(matches={"enter"})) is False
+    assert apply_text_keyboard(text, _kbd(matches={"tab"})) is False
+    assert text.content == "x"
+
+
+def test_non_input_ignores_keys() -> None:
+    text = Text("x", input=False)
+    assert apply_text_keyboard(text, _kbd(character="a")) is False
+    assert text.content == "x"
+
+
+def test_handle_keyboard_delegates() -> None:
+    text = Text("", input=True)
+    assert text.handle_keyboard(_kbd(character="z")) is True
+    assert text.content == "z"
+
+
+# ---------------------------------------------------------------------------
+# Display / get_node
+# ---------------------------------------------------------------------------
+
+
+def test_placeholder_when_empty_unfocused() -> None:
+    text = Text("", input=True, placeholder="type here")
+    node = text.get_node(_ctx())
+    assert isinstance(node, ParagraphNode)
+    assert node.text == "type here"
+    assert node.color == "gray"
+
+
+def test_placeholder_hidden_when_focused() -> None:
+    text = Text("", input=True, placeholder="type here")
+    text._input_focused = True
+    node = text.get_node(_ctx())
+    assert isinstance(node, ParagraphNode)
+    assert "▌" in str(node.text)
+
+
+def test_caret_inserted_when_focused() -> None:
+    text = Text("hi", input=True, cursor=1)
+    text._input_focused = True
+    node = text.get_node(_ctx())
+    assert isinstance(node, ParagraphNode)
+    assert node.text == "h▌i"
+
+
+def test_content_shown_when_unfocused_nonempty() -> None:
+    text = Text("hello", input=True, placeholder="x")
+    node = text.get_node(_ctx())
+    assert isinstance(node, ParagraphNode)
+    assert node.text == "hello"

--- a/uv.lock
+++ b/uv.lock
@@ -1519,6 +1519,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1724,6 +1733,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]
@@ -2529,6 +2551,7 @@ dev = [
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "termynal" },
@@ -2559,6 +2582,7 @@ dev = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "termynal", specifier = ">=0.14.0" },

--- a/xnano/beta/__init__.py
+++ b/xnano/beta/__init__.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
         on_focus,
         on_clipboard,
         on_state,
+        on_field,
+        on_poll,
         on_keyboard,
         on_mouse,
         on_click,
@@ -91,6 +93,16 @@ def __getattr__(name: str):
 
         return on_state
 
+    if name == "on_field":
+        from xnano.beta.hooks import on_field
+
+        return on_field
+
+    if name == "on_poll":
+        from xnano.beta.hooks import on_poll
+
+        return on_poll
+
     if name == "on_keyboard":
         from xnano.beta.hooks import on_keyboard
 
@@ -131,6 +143,8 @@ __all__ = (
     "on_focus",
     "on_clipboard",
     "on_state",
+    "on_field",
+    "on_poll",
     "on_keyboard",
     "on_mouse",
     "on_click",

--- a/xnano/beta/components/text.py
+++ b/xnano/beta/components/text.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from xnano.beta.color import ColorLike
     from xnano.beta.components.abstract import ComponentRenderContext
     from xnano.beta.core.nodes import AbstractRenderNode, LineNode
+    from xnano.beta.events import KeyboardEventData
 
 
 @dataclasses.dataclass
@@ -39,6 +40,14 @@ class Text(AbstractComponent):
             Text("Second line", color="blue"),
         ])
 
+    **Input** — set ``input=True`` on a leaf ``Text`` placed in a grid field
+    to make it focusable and editable (tab order, caret, placeholder):
+
+        class Form(Grid):
+            name: Text = Field(
+                default=Text("", input=True, placeholder="your name"),
+            )
+
     All modes share the same styling params: ``color``, ``background``,
     ``modifiers``.  ``align`` and ``wrap`` apply at the paragraph level.
     """
@@ -49,10 +58,91 @@ class Text(AbstractComponent):
     modifiers: tuple[CharacterModifier, ...] = ()
     align: Alignment | None = None
     wrap: bool = True
+    input: bool = False
+    """When ``True`` on a leaf ``Text``, the component is an editable field
+    that participates in field focus (tab order) and receives keyboard input
+    while focused."""
+    placeholder: str | Text | None = None
+    """Shown when ``input`` is enabled, the content is empty, and the field
+    is not focused.  A string is rendered dim; a ``Text`` keeps its styling."""
+    cursor: int | None = None
+    """Caret index into ``content`` when ``input`` is enabled; ``None`` means
+    the end of the string."""
+    _input_focused: bool = dataclasses.field(
+        default=False, init=False, repr=False, compare=False
+    )
 
     def _is_leaf(self) -> bool:
         """True when this node holds a plain string (no nested Text children)."""
         return isinstance(self.content, str)
+
+    @property
+    def value(self) -> str:
+        """Plain-string content for leaf ``Text``; empty string otherwise."""
+        if isinstance(self.content, str):
+            return self.content
+        return ""
+
+    @value.setter
+    def value(self, text: str) -> None:
+        self.content = text
+        if self.cursor is not None:
+            self.cursor = max(0, min(self.cursor, len(text)))
+
+    def handle_keyboard(self, keyboard: KeyboardEventData) -> bool:
+        """Apply a keyboard event when this is an editable input.
+
+        Args:
+            keyboard: The keyboard sub-event to apply.
+
+        Returns:
+            ``True`` when the event was consumed by this input.
+        """
+        from xnano.beta.focus import apply_text_keyboard
+
+        return apply_text_keyboard(self, keyboard)
+
+    def _placeholder_string(self) -> str | None:
+        if self.placeholder is None:
+            return None
+        if isinstance(self.placeholder, str):
+            return self.placeholder
+        if isinstance(self.placeholder, Text) and isinstance(
+            self.placeholder.content, str
+        ):
+            return self.placeholder.content
+        return None
+
+    def _input_display_content(self) -> tuple[str, ColorLike | None, bool]:
+        """Return ``(text, color_override, is_placeholder)`` for input mode."""
+        if not isinstance(self.content, str):
+            return ("", None, False)
+        if (
+            self.content == ""
+            and not self._input_focused
+            and self.placeholder is not None
+        ):
+            if isinstance(self.placeholder, Text):
+                if isinstance(self.placeholder.content, str):
+                    return (
+                        self.placeholder.content,
+                        self.placeholder.color or "gray",
+                        True,
+                    )
+            else:
+                return (self.placeholder, "gray", True)
+        if self._input_focused and self.input:
+            position = (
+                self.cursor if self.cursor is not None else len(self.content)
+            )
+            position = max(0, min(position, len(self.content)))
+            # Visible caret between characters (hardware cursor is also moved).
+            return (
+                self.content[:position] + "▌" + self.content[position:],
+                None,
+                False,
+            )
+        return (self.content, None, False)
 
     def _as_children(self) -> list[Text]:
         """Normalize content to a flat list of Text children."""
@@ -153,11 +243,22 @@ class Text(AbstractComponent):
 
         # Leaf: single string — paragraph wrapping plain text
         if isinstance(self.content, str):
+            text_str = self.content
+            color = self.color
+            modifiers = self.modifiers
+            if self.input:
+                text_str, color_override, is_placeholder = (
+                    self._input_display_content()
+                )
+                if color_override is not None:
+                    color = color_override
+                if is_placeholder and not modifiers:
+                    modifiers = ("dim",)
             return ParagraphNode(
-                text=self.content,
-                color=self.color,
+                text=text_str,
+                color=color,
                 background=self.background,
-                modifiers=self.modifiers,
+                modifiers=modifiers,
                 align=self.align,
                 wrap=self.wrap,
             )

--- a/xnano/beta/core/dispatch.py
+++ b/xnano/beta/core/dispatch.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import asyncio
+import inspect
+import logging
 import time
-from typing import Any, Sequence, TYPE_CHECKING
+from typing import Any, Awaitable, Coroutine, Sequence, cast, TYPE_CHECKING
 
+from xnano.beta.exceptions import Exit
 from xnano.beta.hooks import (
     _EventHooksRegistry,
+    _OnFieldHookFunctionEntry,
+    _OnFocusHookFunctionEntry,
     _OnKeyboardHookFunctionEntry,
     _OnMouseHookFunctionEntry,
+    _OnPollHookFunctionEntry,
     _OnStateHookFunctionEntry,
     _OnTickHookFunctionEntry,
 )
@@ -22,12 +29,48 @@ from xnano.beta.utils.native_types import get_area_from_native_rect
 if TYPE_CHECKING:
     from xnano.beta.context import Context
     from xnano.beta.grid import Grid, _GridSlideCapture
+    from xnano.beta.hooks import PollWhen
     from xnano.beta.terminal import Terminal
     from xnano.beta.types import Area, Coordinate
 
 
-def invoke_hook(handler: Any, bound_self: Any, ctx: "Context[Any]") -> Any:
-    """Invoke ``handler`` with the right arity."""
+_logger = logging.getLogger("xnano.hooks")
+
+
+def run_awaitable(awaitable: Awaitable[Any]) -> Any:
+    """Drive an async hook result to completion on a free event loop.
+
+    Args:
+        awaitable: A coroutine or other awaitable returned by a hook.
+
+    Returns:
+        The awaitable's result.
+
+    Raises:
+        RuntimeError: If called while an asyncio event loop is already
+            running on this thread (the sync TUI loop cannot nest
+            ``asyncio.run``).
+        TypeError: If ``awaitable`` is not a coroutine object.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        if inspect.iscoroutine(awaitable):
+            return asyncio.run(cast(Coroutine[Any, Any, Any], awaitable))
+
+        async def _drain() -> Any:
+            return await awaitable
+
+        return asyncio.run(_drain())
+    raise RuntimeError(
+        "async @on_* hooks cannot run while an asyncio event loop is "
+        "already active on this thread; call Terminal.run() from a "
+        "sync context, or wrap it with asyncio.to_thread(...)."
+    )
+
+
+def _call_hook(handler: Any, bound_self: Any, ctx: "Context[Any]") -> Any:
+    """Invoke ``handler`` with the right arity (sync call only)."""
     from xnano.beta.context import Context as ContextClass
 
     bound_instance = getattr(handler, "__self__", None)
@@ -43,6 +86,28 @@ def invoke_hook(handler: Any, bound_self: Any, ctx: "Context[Any]") -> Any:
     if bound_self is not None:
         return handler(bound_self, ctx)
     return handler(ctx)
+
+
+def invoke_hook(handler: Any, bound_self: Any, ctx: "Context[Any]") -> Any:
+    """Invoke ``handler`` with the right arity, awaiting async results.
+
+    Uncaught exceptions (other than ``Exit`` / ``KeyboardInterrupt`` /
+    ``SystemExit``) are logged at ERROR and re-raised so the terminal
+    run loop can restore the host terminal on the way out.
+    """
+    name = getattr(handler, "__qualname__", repr(handler))
+    try:
+        result = _call_hook(handler, bound_self, ctx)
+        if inspect.isawaitable(result):
+            return run_awaitable(result)
+        return result
+    except Exit:
+        raise
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except Exception:
+        _logger.exception("Uncaught exception in hook %s", name)
+        raise
 
 
 def grid_clamp_slide_position(
@@ -323,9 +388,43 @@ def render_frame(
     viewport = get_area_from_native_rect(sess.get_native_viewport_area())
 
     if is_grid:
+        from xnano.beta.focus import (
+            FieldFocus,
+            ensure_default_field_focus,
+            is_input_text,
+            place_cursor_for_focus,
+            sync_input_focus_flags,
+        )
+
+        # Re-register the root after the per-frame clear so focus walking and
+        # hook grid resolution still see the live tree. Nested grids re-attach
+        # from ``Session.grid_paint_slot`` while painting.
+        track_frame_grid(terminal, root)
+
+        # Seed focus before paint so the caret/placeholder render correctly
+        # on the first frame.
+        if getattr(terminal, "_field_focus", None) is None:
+            fields = getattr(type(root), "_grid_fields", {}) or {}
+            for field_name in fields:
+                value = getattr(root, field_name, None)
+                if is_input_text(value):
+                    terminal._field_focus = FieldFocus(
+                        grid=root, field_name=field_name
+                    )
+                    cast(Any, value)._input_focused = True
+                    break
+        else:
+            current = terminal._field_focus
+            text = getattr(current.grid, current.field_name, None)
+            if is_input_text(text):
+                cast(Any, text)._input_focused = True
+
         root_area = resolve_root_area(terminal, viewport)
         root._grid_build_frame(root_area, sess)
         sess.commit_requests()
+        ensure_default_field_focus(terminal)
+        sync_input_focus_flags(terminal)
+        place_cursor_for_focus(terminal)
         return
 
     # Inline content: the root box may be offset from the screen origin (inline
@@ -362,6 +461,26 @@ def render_frame(
     sess.commit_requests()
 
 
+def pump_poll(
+    terminal: "Terminal[Any]",
+    when: "PollWhen",
+) -> None:
+    """Fire ``@on_poll`` handlers registered for ``when``."""
+    from xnano.beta.context import Context
+
+    if not terminal._hooks.on_poll_hooks:
+        return
+    ctx = Context(event=None, terminal=terminal, state=terminal.state)
+    for entry in terminal._hooks.on_poll_hooks:
+        if entry["when"] != when:
+            continue
+        handler = entry["handler"]
+        grid = getattr(handler, "__self__", None)
+        if grid is None:
+            grid = resolve_hook_grid(terminal, handler)
+        invoke_hook(handler, grid, ctx)
+
+
 def pump_events(terminal: "Terminal[Any]") -> None:
     from xnano.beta.context import Context
     from xnano.beta.events import Event
@@ -369,6 +488,10 @@ def pump_events(terminal: "Terminal[Any]") -> None:
     core_event = terminal.session.poll_core_event(
         timeout=terminal.tick_interval
     )
+    if core_event is None:
+        # Idle: the blocking poll returned no input within the tick window.
+        pump_poll(terminal, "idle")
+        return
     while core_event is not None:
         wrapped = Event(core_event)
         ctx = Context(event=wrapped, terminal=terminal, state=terminal.state)
@@ -399,6 +522,42 @@ def pump_tick(terminal: "Terminal[Any]") -> None:
         if evaluate_state_expression(expression, terminal.state):
             grid = resolve_hook_grid(terminal, handler)
             invoke_hook(handler, grid, ctx)
+    for entry in terminal._hooks.on_field_hooks:
+        expression = entry["expression"]
+        handler = entry["handler"]
+        # Prefer the bound instance over resolve_hook_grid — the latter
+        # matches by class name and can't distinguish multiple instances of
+        # the same grid class registered on the same terminal.
+        grid = getattr(handler, "__self__", None)
+        if grid is None:
+            grid = resolve_hook_grid(terminal, handler)
+        if grid is not None and evaluate_state_expression(expression, grid):
+            invoke_hook(handler, grid, ctx)
+
+
+def _handle_focus_navigation(terminal: "Terminal[Any]", keyboard: Any) -> bool:
+    """Handle tab / backtab for field focus. Returns True if consumed."""
+    from xnano.beta.focus import cycle_field_focus
+
+    if keyboard.matches("tab"):
+        cycle_field_focus(terminal, reverse=False)
+        return True
+    if keyboard.matches("backtab"):
+        cycle_field_focus(terminal, reverse=True)
+        return True
+    return False
+
+
+def _handle_focused_text_input(
+    terminal: "Terminal[Any]", keyboard: Any
+) -> bool:
+    """Feed a key to the focused editable Text. Returns True if consumed."""
+    from xnano.beta.focus import apply_text_keyboard, focused_input_text
+
+    text = focused_input_text(terminal)
+    if text is None:
+        return False
+    return apply_text_keyboard(text, keyboard)
 
 
 def dispatch_hooks(terminal: "Terminal[Any]", ctx: "Context[Any]") -> None:
@@ -413,6 +572,12 @@ def dispatch_hooks(terminal: "Terminal[Any]", ctx: "Context[Any]") -> None:
     if event.is_keyboard_event():
         kbd = event.keyboard_event
         if kbd is not None:
+            # Field focus navigation (tab) is reserved by the framework.
+            if _handle_focus_navigation(terminal, kbd):
+                return
+            # Editable Text consumes character/edit keys while focused.
+            if _handle_focused_text_input(terminal, kbd):
+                return
             for entry in terminal._hooks.on_keyboard_hooks:
                 if not keyboard_matches(kbd, entry):
                     continue
@@ -436,12 +601,44 @@ def dispatch_hooks(terminal: "Terminal[Any]", ctx: "Context[Any]") -> None:
             invoke_hook(handler, grid, ctx)
 
     elif event.is_clipboard_event():
+        from xnano.beta.focus import focused_input_text
+
+        text = focused_input_text(terminal)
+        if text is not None and isinstance(text.content, str):
+            paste = (
+                event.clipboard_event.text
+                if event.clipboard_event is not None
+                else None
+            )
+            if paste:
+                position = (
+                    text.cursor
+                    if text.cursor is not None
+                    else len(text.content)
+                )
+                position = max(0, min(position, len(text.content)))
+                text.content = (
+                    text.content[:position] + paste + text.content[position:]
+                )
+                text.cursor = position + len(paste)
         for handler in terminal._hooks.on_clipboard_hooks:
             grid = resolve_hook_grid(terminal, handler)
             invoke_hook(handler, grid, ctx)
 
     elif event.is_focus_event():
-        for handler in terminal._hooks.on_focus_hooks:
+        focus = event.focus_event
+        focus_kind = focus.kind if focus is not None else None
+        for entry in terminal._hooks.on_focus_hooks:
+            # Terminal-window focus hooks only (field is None).
+            if entry["field"] is not None:
+                continue
+            kind_filter = entry["kind"]
+            if kind_filter is not None:
+                if focus_kind == "gained" and kind_filter != "gained":
+                    continue
+                if focus_kind == "lost" and kind_filter != "lost":
+                    continue
+            handler = entry["handler"]
             grid = resolve_hook_grid(terminal, handler)
             invoke_hook(handler, grid, ctx)
 
@@ -480,6 +677,12 @@ def dispatch_field_mouse(
                 grab_y=mouse.y - hit.area.y,
                 slide_axes=hit.slide_axes,
             )
+        if mouse.kind == "press":
+            from xnano.beta.focus import is_input_text, set_field_focus
+
+            value = getattr(hit.grid, hit.field_name, None)
+            if is_input_text(value):
+                set_field_focus(terminal, hit.grid, hit.field_name)
         handler = resolve_grid_mouse_handler(hit.grid, hit.field_name)
         if handler is not None and field_mouse_handler_matches(handler, mouse):
             invoke_hook(handler, hit.grid, ctx)
@@ -517,26 +720,60 @@ def track_frame_grid(terminal: "Terminal[Any]", grid: Any) -> None:
     terminal._attached_grids.add(id(grid))
 
 
+def rebind_hook_handler(handler: Any, grid: Any) -> Any:
+    """Rebind an unbound handler to its ``grid`` instance method by name.
+
+    Hooks declared on a ``Grid`` subclass are captured as unbound functions
+    at class-creation time; once a live ``grid`` instance exists, the same
+    handler must be looked up as a bound method on that instance so ``self``
+    resolves correctly.
+
+    Args:
+        handler: The hook handler collected from the component class.
+        grid: The live grid instance to rebind against, or ``None``.
+
+    Returns:
+        The bound method when ``grid`` declares an attribute of the same
+        name as ``handler``; otherwise ``handler`` unchanged.
+    """
+    if grid is None:
+        return handler
+    name = getattr(handler, "__name__", None)
+    if name and hasattr(grid, name):
+        return getattr(grid, name)
+    return handler
+
+
 def merge_hooks(
     terminal: "Terminal[Any]", other: _EventHooksRegistry, grid: Any = None
 ) -> None:
     terminal._hooks.on_event_hooks.extend(other.on_event_hooks)
     terminal._hooks.on_resize_hooks.extend(other.on_resize_hooks)
     terminal._hooks.on_clipboard_hooks.extend(other.on_clipboard_hooks)
-    terminal._hooks.on_focus_hooks.extend(other.on_focus_hooks)
-    terminal._hooks.on_poll_hooks.extend(other.on_poll_hooks)
+
+    for entry in other.on_focus_hooks:
+        terminal._hooks.on_focus_hooks.append(
+            _OnFocusHookFunctionEntry(
+                field=entry["field"],
+                kind=entry["kind"],
+                handler=rebind_hook_handler(entry["handler"], grid),
+            )
+        )
+
+    for entry in other.on_poll_hooks:
+        terminal._hooks.on_poll_hooks.append(
+            _OnPollHookFunctionEntry(
+                when=entry["when"],
+                handler=rebind_hook_handler(entry["handler"], grid),
+            )
+        )
 
     for entry in other.on_keyboard_hooks:
-        handler = entry["handler"]
-        if grid is not None:
-            name = getattr(handler, "__name__", None)
-            if name and hasattr(grid, name):
-                handler = getattr(grid, name)
         terminal._hooks.on_keyboard_hooks.append(
             _OnKeyboardHookFunctionEntry(
                 bindings=entry["bindings"],
                 kind=entry["kind"],
-                handler=handler,
+                handler=rebind_hook_handler(entry["handler"], grid),
             )
         )
 
@@ -547,42 +784,36 @@ def merge_hooks(
             is not None
         ):
             continue
-        if grid is not None:
-            name = getattr(handler, "__name__", None)
-            if name and hasattr(grid, name):
-                handler = getattr(grid, name)
         terminal._hooks.on_mouse_hooks.append(
             _OnMouseHookFunctionEntry(
                 buttons=entry["buttons"],
                 kind=entry["kind"],
-                handler=handler,
+                handler=rebind_hook_handler(handler, grid),
             )
         )
 
     for entry in other.on_tick_hooks:
-        handler = entry["handler"]
-        if grid is not None:
-            name = getattr(handler, "__name__", None)
-            if name and hasattr(grid, name):
-                handler = getattr(grid, name)
         terminal._hooks.on_tick_hooks.append(
             _OnTickHookFunctionEntry(
                 interval=entry["interval"],
-                handler=handler,
+                handler=rebind_hook_handler(entry["handler"], grid),
                 last_fire_ms=0.0,
             )
         )
 
     for entry in other.on_state_hooks:
-        handler = entry["handler"]
-        if grid is not None:
-            name = getattr(handler, "__name__", None)
-            if name and hasattr(grid, name):
-                handler = getattr(grid, name)
         terminal._hooks.on_state_hooks.append(
             _OnStateHookFunctionEntry(
                 expression=entry["expression"],
-                handler=handler,
+                handler=rebind_hook_handler(entry["handler"], grid),
+            )
+        )
+
+    for entry in other.on_field_hooks:
+        terminal._hooks.on_field_hooks.append(
+            _OnFieldHookFunctionEntry(
+                expression=entry["expression"],
+                handler=rebind_hook_handler(entry["handler"], grid),
             )
         )
 

--- a/xnano/beta/core/session.py
+++ b/xnano/beta/core/session.py
@@ -561,6 +561,13 @@ class Session(Generic[StateT]):
         from xnano.beta.grid import Grid
 
         if isinstance(value, Grid):
+            # Re-register nested grids every frame (the render path clears
+            # ``_attached_frame_grids`` at the start of each paint).
+            terminal = _ACTIVE_TERMINAL.get()
+            if terminal is not None:
+                from xnano.beta.core.dispatch import track_frame_grid
+
+                track_frame_grid(terminal, value)
             value._grid_build_frame(area, self)
             return
 

--- a/xnano/beta/events.py
+++ b/xnano/beta/events.py
@@ -140,14 +140,38 @@ class ClipboardEventData(AbstractEventData):
     """The text that was pasted."""
 
 
+FocusEventKind: TypeAlias = Literal[
+    "gained",
+    "lost",
+    "field_gained",
+    "field_lost",
+]
+"""How a focus change was triggered.
+
+Values:
+    ``"gained"`` / ``"lost"``: The terminal window gained or lost OS focus.
+    ``"field_gained"`` / ``"field_lost"``: A grid field gained or lost
+        application focus (editable ``Text`` input).
+"""
+
+
 @dataclasses.dataclass(slots=True, frozen=True)
 class FocusEventData(AbstractEventData):
-    """Marker sub-event for terminal focus events."""
+    """Focus change event — terminal window or grid field.
+
+    Attributes:
+        kind: Terminal gained/lost, or field gained/lost.
+        field: Layout field name when ``kind`` is a field focus change.
+    """
 
     type: ClassVar[Literal["focus"]] = "focus"
     """The type of event this sub-event represents. Always "focus" for
     ``FocusEvent``.
     """
+    kind: FocusEventKind | None = None
+    """Terminal or field focus transition kind."""
+    field: str | None = None
+    """Layout field name for field-level focus changes."""
 
 
 def _set_keyboard_event_data_binding_tuple(

--- a/xnano/beta/exceptions.py
+++ b/xnano/beta/exceptions.py
@@ -14,6 +14,21 @@ class Exit(BaseException):
     """
 
 
+class HookError(RuntimeError):
+    """Raised when an ``@on_*`` hook fails in a way that needs a clear surface.
+
+    The default dispatch policy logs the original exception and re-raises it
+    unchanged so callers see the real traceback.  ``HookError`` is available
+    for libraries that want to wrap hook failures explicitly.
+    """
+
+    def __init__(self, hook_name: str, cause: BaseException) -> None:
+        self.hook_name = hook_name
+        self.cause = cause
+        super().__init__(f"Hook {hook_name!r} raised: {cause!r}")
+        self.__cause__ = cause
+
+
 class FieldValidationError(ValueError):
     """Exception raised when a ``pydantic-core`` validation error occurs during
     the strict validation of a grid field attribute(s).
@@ -46,6 +61,7 @@ class TerminalNotActiveError(RuntimeError):
 
 __all__ = (
     "Exit",
+    "HookError",
     "FieldValidationError",
     "TerminalNotActiveError",
 )

--- a/xnano/beta/focus.py
+++ b/xnano/beta/focus.py
@@ -1,0 +1,384 @@
+"""xnano.beta.focus
+
+---
+
+Field-level focus and editable ``Text`` input helpers.
+
+Terminal focus (OS window gained/lost) stays on ``@on_focus`` without a field
+name.  Field focus is the grid-field equivalent of a caret — tab order walks
+``Text(input=True)`` fields in declaration order, and the focused field
+receives printable keys / backspace / arrows.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from xnano.beta.components.text import Text
+    from xnano.beta.events import KeyboardEventData
+    from xnano.beta.grid import Grid
+    from xnano.beta.hooks import FocusHookKind
+    from xnano.beta.terminal import Terminal
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FieldFocus:
+    """Identity of the currently focused layout field.
+
+    Attributes:
+        grid: The grid instance that owns the field.
+        field_name: Layout field name on ``grid``.
+    """
+
+    grid: Any
+    field_name: str
+
+
+def is_input_text(value: Any) -> bool:
+    """Return whether ``value`` is an editable ``Text`` component."""
+    from xnano.beta.components.text import Text
+
+    return isinstance(value, Text) and bool(value.input)
+
+
+def get_input_text(grid: Any, field_name: str) -> Text | None:
+    """Return the editable ``Text`` stored on ``grid.field_name``, if any."""
+    value = getattr(grid, field_name, None)
+    if is_input_text(value):
+        return value  # type: ignore[return-value]
+    return None
+
+
+def collect_focusable_fields(terminal: Terminal[Any]) -> list[FieldFocus]:
+    """Collect focusable input fields in paint/declaration order.
+
+    Walks ``terminal._attached_frame_grids`` (outer-most first, then nested
+    grids as they appear during the last frame) and, for each grid, its
+    ``_grid_fields`` declaration order.
+    """
+    result: list[FieldFocus] = []
+    seen: set[tuple[int, str]] = set()
+    for grid in terminal._attached_frame_grids:
+        fields = getattr(type(grid), "_grid_fields", None) or getattr(
+            grid, "_grid_fields", {}
+        )
+        for field_name in fields:
+            value = getattr(grid, field_name, None)
+            if is_input_text(value):
+                key = (id(grid), field_name)
+                if key not in seen:
+                    seen.add(key)
+                    result.append(
+                        FieldFocus(grid=grid, field_name=field_name)
+                    )
+            elif hasattr(value, "_grid_fields"):
+                # Nested grids are also listed in _attached_frame_grids when
+                # painted; no need to recurse here.
+                pass
+    return result
+
+
+def sync_input_focus_flags(terminal: Terminal[Any]) -> None:
+    """Set ``Text._input_focused`` on every attached input to match focus."""
+    current = getattr(terminal, "_field_focus", None)
+    for target in collect_focusable_fields(terminal):
+        text = get_input_text(target.grid, target.field_name)
+        if text is None:
+            continue
+        text._input_focused = (
+            current is not None
+            and current.grid is target.grid
+            and current.field_name == target.field_name
+        )
+
+
+def focused_input_text(terminal: Terminal[Any]) -> Text | None:
+    """Return the editable ``Text`` for the current field focus, if any."""
+    current = getattr(terminal, "_field_focus", None)
+    if current is None:
+        return None
+    return get_input_text(current.grid, current.field_name)
+
+
+def apply_text_keyboard(text: Text, keyboard: KeyboardEventData) -> bool:
+    """Apply a keyboard event to an editable ``Text``.
+
+    Consumes printable characters, backspace/delete, and left/right/home/end.
+    Leaves tab, enter, escape, and arrows up/down for application hooks.
+
+    Args:
+        text: The input ``Text`` to mutate.
+        keyboard: The keyboard sub-event.
+
+    Returns:
+        ``True`` when the event was handled (and should not fire other
+        character-level keyboard hooks).
+    """
+    if not text.input or not isinstance(text.content, str):
+        return False
+    kind = keyboard.kind
+    if kind is not None and kind not in ("press", "repeat"):
+        return False
+
+    content = text.content
+    position = text.cursor if text.cursor is not None else len(content)
+    position = max(0, min(position, len(content)))
+
+    if keyboard.matches("backspace"):
+        if position > 0:
+            text.content = content[: position - 1] + content[position:]
+            text.cursor = position - 1
+        return True
+    if keyboard.matches("delete"):
+        if position < len(content):
+            text.content = content[:position] + content[position + 1 :]
+            text.cursor = position
+        return True
+    if keyboard.matches("left"):
+        text.cursor = max(0, position - 1)
+        return True
+    if keyboard.matches("right"):
+        text.cursor = min(len(content), position + 1)
+        return True
+    if keyboard.matches("home"):
+        text.cursor = 0
+        return True
+    if keyboard.matches("end"):
+        text.cursor = len(content)
+        return True
+    # Navigation / submit keys stay available to @on_keyboard hooks.
+    if keyboard.matches(
+        "tab",
+        "backtab",
+        "enter",
+        "esc",
+        "up",
+        "down",
+        "pageup",
+        "pagedown",
+    ):
+        return False
+
+    character = keyboard.character
+    if (
+        character is not None
+        and len(character) == 1
+        and character.isprintable()
+        and character not in ("\n", "\r", "\t")
+    ):
+        text.content = content[:position] + character + content[position:]
+        text.cursor = position + 1
+        return True
+    return False
+
+
+def _mark_text_focused(text: Text | None, focused: bool) -> None:
+    if text is not None:
+        text._input_focused = focused
+
+
+def set_field_focus(
+    terminal: Terminal[Any],
+    grid: Any,
+    field_name: str,
+    *,
+    fire_hooks: bool = True,
+) -> bool:
+    """Focus ``grid.field_name`` when it holds an editable ``Text``.
+
+    Args:
+        terminal: The live terminal.
+        grid: Owner grid.
+        field_name: Layout field name.
+        fire_hooks: Whether to fire field ``@on_focus`` handlers.
+
+    Returns:
+        ``True`` when focus was set (or already there).
+    """
+    text = get_input_text(grid, field_name)
+    if text is None:
+        return False
+    previous = getattr(terminal, "_field_focus", None)
+    target = FieldFocus(grid=grid, field_name=field_name)
+    # Compared by identity (not ``==``) so focus tracking never depends on a
+    # Grid subclass overriding equality.
+    if (
+        previous is not None
+        and previous.grid is grid
+        and previous.field_name == field_name
+    ):
+        _mark_text_focused(text, True)
+        sync_input_focus_flags(terminal)
+        return True
+
+    if previous is not None:
+        prev_text = get_input_text(previous.grid, previous.field_name)
+        _mark_text_focused(prev_text, False)
+        if fire_hooks:
+            _fire_field_focus_hooks(terminal, previous, kind="lost")
+
+    terminal._field_focus = target
+    _mark_text_focused(text, True)
+    sync_input_focus_flags(terminal)
+    terminal._field_focus_announced = True
+
+    if fire_hooks:
+        _fire_field_focus_hooks(terminal, target, kind="gained")
+    return True
+
+
+def clear_field_focus(
+    terminal: Terminal[Any],
+    *,
+    fire_hooks: bool = True,
+) -> None:
+    """Clear field focus on ``terminal``."""
+    previous = getattr(terminal, "_field_focus", None)
+    if previous is None:
+        return
+    prev_text = get_input_text(previous.grid, previous.field_name)
+    _mark_text_focused(prev_text, False)
+    if fire_hooks:
+        _fire_field_focus_hooks(terminal, previous, kind="lost")
+    terminal._field_focus = None
+    terminal._field_focus_announced = False
+    sync_input_focus_flags(terminal)
+
+
+def cycle_field_focus(
+    terminal: Terminal[Any],
+    *,
+    reverse: bool = False,
+) -> bool:
+    """Move field focus to the next (or previous) input field.
+
+    Returns:
+        ``True`` when focus moved or was established.
+    """
+    targets = collect_focusable_fields(terminal)
+    if not targets:
+        return False
+    current = getattr(terminal, "_field_focus", None)
+    if current is None:
+        pick = targets[-1] if reverse else targets[0]
+        return set_field_focus(terminal, pick.grid, pick.field_name)
+
+    index = 0
+    # Identity comparison, as in ``set_field_focus`` above.
+    for i, target in enumerate(targets):
+        if (
+            target.grid is current.grid
+            and target.field_name == current.field_name
+        ):
+            index = i
+            break
+    if reverse:
+        index = (index - 1) % len(targets)
+    else:
+        index = (index + 1) % len(targets)
+    pick = targets[index]
+    return set_field_focus(terminal, pick.grid, pick.field_name)
+
+
+def ensure_default_field_focus(terminal: Terminal[Any]) -> None:
+    """Focus the first input field when nothing is focused yet."""
+    current = getattr(terminal, "_field_focus", None)
+    if current is not None:
+        sync_input_focus_flags(terminal)
+        # Seeded pre-paint focus still needs a one-shot ``gained`` announce.
+        if not getattr(terminal, "_field_focus_announced", False):
+            terminal._field_focus_announced = True
+            _fire_field_focus_hooks(terminal, current, kind="gained")
+        return
+    targets = collect_focusable_fields(terminal)
+    if targets:
+        set_field_focus(
+            terminal,
+            targets[0].grid,
+            targets[0].field_name,
+            fire_hooks=True,
+        )
+
+
+def place_cursor_for_focus(terminal: Terminal[Any]) -> None:
+    """Move the hardware cursor into the focused input field, if any."""
+    current = getattr(terminal, "_field_focus", None)
+    if current is None:
+        return
+    text = get_input_text(current.grid, current.field_name)
+    if text is None or not isinstance(text.content, str):
+        return
+    slots = getattr(current.grid, "_grid_last_slot_areas", None) or {}
+    area = slots.get(current.field_name)
+    if area is None:
+        return
+    position = text.cursor if text.cursor is not None else len(text.content)
+    position = max(0, min(position, len(text.content)))
+    # Clamp caret into the painted slot width.
+    column = min(position, max(0, area.width - 1))
+    try:
+        terminal.cursor.visible = True
+        terminal.cursor.move_to(area.x + column, area.y)
+    except Exception:
+        pass
+
+
+def _fire_field_focus_hooks(
+    terminal: Terminal[Any],
+    target: FieldFocus,
+    *,
+    kind: "FocusHookKind",
+) -> None:
+    from xnano.beta.context import Context
+    from xnano.beta.core.dispatch import invoke_hook, resolve_hook_grid
+    from xnano.beta.events import FocusEventData
+
+    focus_data = FocusEventData(
+        kind="field_gained" if kind == "gained" else "field_lost",
+        field=target.field_name,
+    )
+    ctx = Context(event=None, terminal=terminal, state=terminal.state)
+    terminal._last_field_focus_event = focus_data
+
+    for entry in terminal._hooks.on_focus_hooks:
+        field_filter = entry["field"]
+        kind_filter = entry["kind"]
+        handler = entry["handler"]
+
+        if field_filter is None:
+            # Terminal-only focus hooks ignore field focus transitions.
+            continue
+        if field_filter != target.field_name:
+            continue
+        if kind_filter is not None and kind_filter != kind:
+            continue
+
+        grid = target.grid
+        bound = getattr(handler, "__self__", None)
+        if bound is None:
+            name = getattr(handler, "__name__", None)
+            if name and hasattr(grid, name):
+                handler = getattr(grid, name)
+            else:
+                resolved = resolve_hook_grid(terminal, handler)
+                if resolved is not None:
+                    grid = resolved
+        invoke_hook(handler, grid, ctx)
+
+
+__all__ = (
+    "FieldFocus",
+    "is_input_text",
+    "get_input_text",
+    "collect_focusable_fields",
+    "sync_input_focus_flags",
+    "focused_input_text",
+    "apply_text_keyboard",
+    "set_field_focus",
+    "clear_field_focus",
+    "cycle_field_focus",
+    "ensure_default_field_focus",
+    "place_cursor_for_focus",
+)

--- a/xnano/beta/grid.py
+++ b/xnano/beta/grid.py
@@ -1046,6 +1046,10 @@ class Grid(metaclass=_GridMeta):
             value = getattr(self, field_name, None)
             if isinstance(value, Grid) and value._grid_needs_mouse_geometry():
                 return True
+            from xnano.beta.focus import is_input_text
+
+            if is_input_text(value):
+                return True
         return False
 
     def _grid_field_position(self, name: str) -> tuple[int, int]:
@@ -1081,7 +1085,11 @@ class Grid(metaclass=_GridMeta):
     ) -> bool:
         if field.slide:
             return True
-        return _resolve_grid_mouse_handler(self, field_name) is not None
+        if _resolve_grid_mouse_handler(self, field_name) is not None:
+            return True
+        from xnano.beta.focus import is_input_text
+
+        return is_input_text(getattr(self, field_name, None))
 
     def grid_set_field(
         self,

--- a/xnano/beta/hooks.py
+++ b/xnano/beta/hooks.py
@@ -96,6 +96,36 @@ class _OnStateHookFunctionEntry(TypedDict):
     handler: EventHookFunction
 
 
+class _OnFieldHookFunctionEntry(TypedDict):
+    expression: str
+    handler: EventHookFunction
+
+
+PollWhen: TypeAlias = Literal["idle", "frame"]
+"""When an ``@on_poll`` hook fires.
+
+Values:
+    ``"idle"``: Fires when an event poll returns no input within the tick
+        interval — an idle hook, distinct from the interval-gated ``on_tick``.
+    ``"frame"``: Fires once per render-loop iteration, regardless of events.
+"""
+
+
+class _OnPollHookFunctionEntry(TypedDict):
+    when: PollWhen
+    handler: EventHookFunction
+
+
+FocusHookKind: TypeAlias = Literal["gained", "lost"]
+"""Whether a field ``@on_focus`` hook fires on gain, loss, or both (``None``)."""
+
+
+class _OnFocusHookFunctionEntry(TypedDict):
+    field: str | None
+    kind: FocusHookKind | None
+    handler: EventHookFunction
+
+
 @dataclasses.dataclass(slots=True)
 class _EventHooksRegistry:
     """Internal utility class for managing event hook registration within
@@ -108,7 +138,10 @@ class _EventHooksRegistry:
     ON_RESIZE_HOOK_ATTR: ClassVar[str] = "__xnano_on_resize__"
     ON_CLIPBOARD_HOOK_ATTR: ClassVar[str] = "__xnano_on_clipboard__"
     ON_FOCUS_HOOK_ATTR: ClassVar[str] = "__xnano_on_focus__"
+    ON_FOCUS_FIELD_ATTR: ClassVar[str] = "__xnano_on_focus_field__"
+    ON_FOCUS_KIND_ATTR: ClassVar[str] = "__xnano_on_focus_kind__"
     ON_POLL_HOOK_ATTR: ClassVar[str] = "__xnano_on_poll__"
+    ON_POLL_WHEN_ATTR: ClassVar[str] = "__xnano_on_poll_when__"
     ON_TICK_HOOK_ATTR: ClassVar[str] = "__xnano_on_tick__"
     ON_STATE_HOOK_ATTR: ClassVar[str] = "__xnano_on_state__"
     ON_KEYBOARD_FILTER_ATTR: ClassVar[str] = "__xnano_on_keyboard_filter__"
@@ -116,6 +149,8 @@ class _EventHooksRegistry:
     ON_MOUSE_FIELD_ATTR: ClassVar[str] = "__xnano_on_mouse_field__"
     ON_TICK_INTERVAL_ATTR: ClassVar[str] = "__xnano_on_tick_interval__"
     ON_STATE_EXPRESSION_ATTR: ClassVar[str] = "__xnano_on_state_expression__"
+    ON_FIELD_HOOK_ATTR: ClassVar[str] = "__xnano_on_field__"
+    ON_FIELD_EXPRESSION_ATTR: ClassVar[str] = "__xnano_on_field_expression__"
 
     on_event_hooks: list[EventHookFunction] = dataclasses.field(
         default_factory=list, init=False
@@ -132,16 +167,19 @@ class _EventHooksRegistry:
     on_clipboard_hooks: list[EventHookFunction] = dataclasses.field(
         default_factory=list, init=False
     )
-    on_focus_hooks: list[EventHookFunction] = dataclasses.field(
+    on_focus_hooks: list[_OnFocusHookFunctionEntry] = dataclasses.field(
         default_factory=list, init=False
     )
-    on_poll_hooks: list[EventHookFunction] = dataclasses.field(
-        default_factory=list
+    on_poll_hooks: list[_OnPollHookFunctionEntry] = dataclasses.field(
+        default_factory=list, init=False
     )
     on_tick_hooks: list[_OnTickHookFunctionEntry] = dataclasses.field(
         default_factory=list, init=False
     )
     on_state_hooks: list[_OnStateHookFunctionEntry] = dataclasses.field(
+        default_factory=list, init=False
+    )
+    on_field_hooks: list[_OnFieldHookFunctionEntry] = dataclasses.field(
         default_factory=list, init=False
     )
 
@@ -185,9 +223,18 @@ class _EventHooksRegistry:
         if hasattr(handler, self.ON_CLIPBOARD_HOOK_ATTR):
             self.on_clipboard_hooks.append(handler)
         if hasattr(handler, self.ON_FOCUS_HOOK_ATTR):
-            self.on_focus_hooks.append(handler)
+            self.on_focus_hooks.append(
+                _OnFocusHookFunctionEntry(
+                    field=getattr(handler, self.ON_FOCUS_FIELD_ATTR, None),
+                    kind=getattr(handler, self.ON_FOCUS_KIND_ATTR, None),
+                    handler=handler,
+                )
+            )
         if hasattr(handler, self.ON_POLL_HOOK_ATTR):
-            self.on_poll_hooks.append(handler)
+            when = getattr(handler, self.ON_POLL_WHEN_ATTR, "idle")
+            self.on_poll_hooks.append(
+                _OnPollHookFunctionEntry(when=when, handler=handler)
+            )
         if hasattr(handler, self.ON_TICK_HOOK_ATTR):
             interval_milliseconds = getattr(
                 handler,
@@ -205,6 +252,14 @@ class _EventHooksRegistry:
             expression = getattr(handler, self.ON_STATE_EXPRESSION_ATTR, "")
             self.on_state_hooks.append(
                 _OnStateHookFunctionEntry(
+                    expression=expression,
+                    handler=handler,
+                )
+            )
+        if hasattr(handler, self.ON_FIELD_HOOK_ATTR):
+            expression = getattr(handler, self.ON_FIELD_EXPRESSION_ATTR, "")
+            self.on_field_hooks.append(
+                _OnFieldHookFunctionEntry(
                     expression=expression,
                     handler=handler,
                 )
@@ -228,6 +283,7 @@ class _EventHooksRegistry:
             cls.ON_POLL_HOOK_ATTR,
             cls.ON_TICK_HOOK_ATTR,
             cls.ON_STATE_HOOK_ATTR,
+            cls.ON_FIELD_HOOK_ATTR,
         )
 
         for base in component_class.__mro__:
@@ -274,9 +330,20 @@ class _EventHooksRegistry:
                 if hasattr(member, cls.ON_CLIPBOARD_HOOK_ATTR):
                     registry.on_clipboard_hooks.append(member)
                 if hasattr(member, cls.ON_FOCUS_HOOK_ATTR):
-                    registry.on_focus_hooks.append(member)
+                    registry.on_focus_hooks.append(
+                        _OnFocusHookFunctionEntry(
+                            field=getattr(
+                                member, cls.ON_FOCUS_FIELD_ATTR, None
+                            ),
+                            kind=getattr(member, cls.ON_FOCUS_KIND_ATTR, None),
+                            handler=member,
+                        )
+                    )
                 if hasattr(member, cls.ON_POLL_HOOK_ATTR):
-                    registry.on_poll_hooks.append(member)
+                    when = getattr(member, cls.ON_POLL_WHEN_ATTR, "idle")
+                    registry.on_poll_hooks.append(
+                        _OnPollHookFunctionEntry(when=when, handler=member)
+                    )
                 if hasattr(member, cls.ON_TICK_HOOK_ATTR):
                     interval_milliseconds = getattr(
                         member,
@@ -296,6 +363,16 @@ class _EventHooksRegistry:
                     )
                     registry.on_state_hooks.append(
                         _OnStateHookFunctionEntry(
+                            expression=expression,
+                            handler=member,
+                        )
+                    )
+                if hasattr(member, cls.ON_FIELD_HOOK_ATTR):
+                    expression = getattr(
+                        member, cls.ON_FIELD_EXPRESSION_ATTR, ""
+                    )
+                    registry.on_field_hooks.append(
+                        _OnFieldHookFunctionEntry(
                             expression=expression,
                             handler=member,
                         )
@@ -631,10 +708,75 @@ def on_resize(fn: EventHookFunction) -> EventHookFunction:
     return _decorate_hook_function(fn)
 
 
-def on_focus(fn: EventHookFunction) -> EventHookFunction:
-    """Register a hook fired on terminal focus events."""
-    setattr(fn, _EventHooksRegistry.ON_FOCUS_HOOK_ATTR, True)
-    return _decorate_hook_function(fn)
+@overload
+def on_focus(handler: EventHookFunction, /) -> EventHookFunction: ...
+@overload
+def on_focus(
+    field: str,
+    /,
+    *,
+    kind: FocusHookKind | None = None,
+) -> Callable[[EventHookFunction], EventHookFunction]: ...
+@overload
+def on_focus(
+    *,
+    field: str | None = None,
+    kind: FocusHookKind | None = None,
+) -> Callable[[EventHookFunction], EventHookFunction]: ...
+def on_focus(
+    handler_or_field: "EventHookFunction | str | None" = None,
+    /,
+    *,
+    field: str | None = None,
+    kind: FocusHookKind | None = None,
+) -> "EventHookFunction | Callable[[EventHookFunction], EventHookFunction]":
+    """Register a focus hook for the terminal window or a grid field.
+
+    Bare ``@on_focus`` fires on OS-level terminal focus gained/lost events.
+    Pass a field name to listen for application field focus instead — the
+    caret moving onto/off an editable ``Text(input=True)`` field:
+
+        @on_focus
+        def _window(self, ctx: Context) -> None:
+            ...  # terminal focus
+
+        @on_focus("prompt")
+        def _prompt_focused(self) -> None:
+            self.status = "editing prompt"
+
+        @on_focus("prompt", kind="lost")
+        def _prompt_blurred(self) -> None:
+            self.status = "left prompt"
+    """
+
+    def _decorate(
+        fn: EventHookFunction,
+        *,
+        field_name: str | None,
+        focus_kind: FocusHookKind | None,
+    ) -> EventHookFunction:
+        setattr(fn, _EventHooksRegistry.ON_FOCUS_HOOK_ATTR, True)
+        if field_name is not None:
+            setattr(fn, _EventHooksRegistry.ON_FOCUS_FIELD_ATTR, field_name)
+        if focus_kind is not None:
+            setattr(fn, _EventHooksRegistry.ON_FOCUS_KIND_ATTR, focus_kind)
+        return _decorate_hook_function(fn)
+
+    if callable(handler_or_field):
+        return _decorate(
+            handler_or_field,
+            field_name=field,
+            focus_kind=kind,
+        )
+
+    resolved_field = (
+        handler_or_field if isinstance(handler_or_field, str) else field
+    )
+
+    def decorator(fn: EventHookFunction) -> EventHookFunction:
+        return _decorate(fn, field_name=resolved_field, focus_kind=kind)
+
+    return decorator
 
 
 def on_clipboard(fn: EventHookFunction) -> EventHookFunction:
@@ -672,12 +814,120 @@ def on_state(
     return decorator
 
 
+def on_field(
+    expression: str,
+) -> Callable[[EventHookFunction], EventHookFunction]:
+    """Fire the decorated handler each tick when ``expression`` is truthy
+    against the grid's own field values.
+
+    Unlike ``on_state``, which evaluates against the terminal's shared
+    ``State`` object, ``on_field`` evaluates against the grid instance
+    itself — its layout and state fields are available by name.
+
+    Example:
+        @on_field("config['name'] == 'john'")
+        def _on_john(self) -> None:
+            self.current_text = "Hello, John!"
+
+        @on_field("count > 0")
+        def _show_count(self) -> None:
+            self.label = f"Count: {self.count}"
+    """
+
+    def decorator(fn: EventHookFunction) -> EventHookFunction:
+        setattr(fn, _EventHooksRegistry.ON_FIELD_HOOK_ATTR, True)
+        setattr(fn, _EventHooksRegistry.ON_FIELD_EXPRESSION_ATTR, expression)
+        return _decorate_hook_function(fn)
+
+    return decorator
+
+
+@overload
+def on_poll(handler: EventHookFunction, /) -> EventHookFunction: ...
+@overload
+def on_poll(
+    when: PollWhen = "idle",
+    /,
+) -> Callable[[EventHookFunction], EventHookFunction]: ...
+@overload
+def on_poll(
+    *,
+    when: PollWhen,
+) -> Callable[[EventHookFunction], EventHookFunction]: ...
+def on_poll(
+    handler_or_when: "EventHookFunction | PollWhen | None" = None,
+    /,
+    *,
+    when: PollWhen | None = None,
+) -> "EventHookFunction | Callable[[EventHookFunction], EventHookFunction]":
+    """Register a poll hook that fires on idle event waits or every frame.
+
+    Args:
+        handler_or_when: A handler (``@on_poll`` bare form, defaults to
+            ``"idle"``) or a ``PollWhen`` value (``@on_poll("frame")``).
+        when: Keyword form of the poll mode.
+
+    Returns:
+        The decorated hook function, or a decorator.
+
+    Example:
+        @on_poll
+        def _idle_work(self) -> None:
+            self.status = "waiting…"
+
+        @on_poll("frame")
+        def _each_frame(self) -> None:
+            self.frame_count += 1
+
+        @on_poll(when="idle")
+        def _also_idle(self, ctx: Context) -> None:
+            ...
+    """
+
+    def _validate_when(resolved_when: PollWhen) -> None:
+        if resolved_when not in ("idle", "frame"):
+            raise TypeError(
+                "on_poll expects when='idle' or when='frame', got "
+                f"{resolved_when!r}"
+            )
+
+    def _decorate(
+        fn: EventHookFunction, resolved_when: PollWhen
+    ) -> EventHookFunction:
+        _validate_when(resolved_when)
+        setattr(fn, _EventHooksRegistry.ON_POLL_HOOK_ATTR, True)
+        setattr(fn, _EventHooksRegistry.ON_POLL_WHEN_ATTR, resolved_when)
+        return _decorate_hook_function(fn)
+
+    if callable(handler_or_when):
+        return _decorate(handler_or_when, when if when is not None else "idle")
+
+    resolved: PollWhen
+    if handler_or_when is not None:
+        resolved = handler_or_when
+    elif when is not None:
+        resolved = when
+    else:
+        resolved = "idle"
+
+    _validate_when(resolved)
+
+    def decorator(fn: EventHookFunction) -> EventHookFunction:
+        return _decorate(fn, resolved)
+
+    return decorator
+
+
 __all__ = (
+    "PollWhen",
+    "FocusHookKind",
     "on_event",
     "on_resize",
     "on_focus",
     "on_clipboard",
     "on_state",
+    "on_field",
+    "on_poll",
     "on_keyboard",
     "on_mouse",
     "on_click",

--- a/xnano/beta/terminal.py
+++ b/xnano/beta/terminal.py
@@ -148,6 +148,9 @@ class Terminal(Generic[StateT]):
         "_root_width_sizing",
         "_prev_sigterm",
         "_prev_sighup",
+        "_field_focus",
+        "_field_focus_announced",
+        "_last_field_focus_event",
         "title",
         "mouse_events",
         "bracketed_paste",
@@ -207,6 +210,9 @@ class Terminal(Generic[StateT]):
         self._pending_enter: bool = False
         self._prev_sigterm: Any = None
         self._prev_sighup: Any = None
+        self._field_focus: Any = None
+        self._field_focus_announced: bool = False
+        self._last_field_focus_event: Any = None
 
     def _on_exit_signal(
         self,
@@ -382,6 +388,35 @@ class Terminal(Generic[StateT]):
 
     def request_exit(self) -> None:
         self._exit_requested = True
+
+    @property
+    def field_focus(self) -> Any:
+        """The currently focused layout field (``FieldFocus``), if any."""
+        return self._field_focus
+
+    def focus_field(self, grid: Any, field_name: str) -> bool:
+        """Focus an editable ``Text`` layout field on ``grid``."""
+        from xnano.beta.focus import set_field_focus
+
+        return set_field_focus(self, grid, field_name)
+
+    def blur_field(self) -> None:
+        """Clear application field focus."""
+        from xnano.beta.focus import clear_field_focus
+
+        clear_field_focus(self)
+
+    def focus_next(self) -> bool:
+        """Move field focus to the next editable input (tab order)."""
+        from xnano.beta.focus import cycle_field_focus
+
+        return cycle_field_focus(self, reverse=False)
+
+    def focus_previous(self) -> bool:
+        """Move field focus to the previous editable input."""
+        from xnano.beta.focus import cycle_field_focus
+
+        return cycle_field_focus(self, reverse=True)
 
     def get_output(self) -> str:
         """Return the offscreen buffer text (only valid for offscreen sessions)."""
@@ -708,8 +743,20 @@ class Terminal(Generic[StateT]):
                 )
                 self._pump_events()
                 self._pump_tick()
+                # Frame polls fire once per loop iteration, after events/ticks.
+                _dispatch.pump_poll(self, when="frame")
         except (KeyboardInterrupt, Exit):
             pass
+        except Exception:
+            # Fail-fast: log and re-raise.  ``finally`` (and the caller's
+            # ``with Terminal()`` if any) still restores the host terminal so
+            # raw mode / alt-screen cannot stick after a hook crash.
+            import logging
+
+            logging.getLogger("xnano").exception(
+                "Uncaught exception in Terminal.run(); restoring terminal"
+            )
+            raise
         finally:
             self._run_renderables = None
             self._run_field = None

--- a/xnano/beta/utils/events.py
+++ b/xnano/beta/utils/events.py
@@ -314,7 +314,9 @@ def get_event_data_from_core_event(
     if kind == "paste":
         return xnano_events.ClipboardEventData(text=event.paste)
 
-    if kind in ("focus_gained", "focus_lost"):
-        return xnano_events.FocusEventData()
+    if kind == "focus_gained":
+        return xnano_events.FocusEventData(kind="gained")
+    if kind == "focus_lost":
+        return xnano_events.FocusEventData(kind="lost")
 
     return None


### PR DESCRIPTION
## Summary
- Adds field-level focus (tab order across `Text(input=True)` fields, caret placement) and terminal-focus/field-focus hooks via `@on_focus`
- Adds `@on_field` (fires on grid-state expression changes scoped to a field) and `@on_poll` (idle/frame polling), following the same overload pattern as existing decorators
- Adds `HookError` for libraries that want to wrap hook failures explicitly
- Hardens hook merging/dispatch: collapses duplicated handler-rebinding logic into `rebind_hook_handler()`, fixes asymmetric `on_poll` validation between its call-shape branches, tightens `_fire_field_focus_hooks`'s `kind` typing

## Test plan
- [x] `uv run pytest -q` — 923 passed, 6 skipped
- [x] `uv run prek run --all-files` — lint + format clean
- [x] `uv run ty check` — clean