### PR TITLE
feat: add Table, Chart, and Progress declarative components

### DIFF
--- a/tests/test_component_chart.py
+++ b/tests/test_component_chart.py
@@ -1,0 +1,241 @@
+"""Tests for xnano.beta.components.chart — declarative Chart."""
+
+from __future__ import annotations
+
+from helpers import render_component_to_text
+
+from xnano.beta.components.abstract import ComponentRenderContext
+from xnano.beta.components.chart import Chart
+from xnano.beta.components.schema import Series
+from xnano.beta.core.nodes import ChartNode
+from xnano.beta.types import Area
+
+
+def _ctx() -> ComponentRenderContext:
+    return ComponentRenderContext(area=Area(x=0, y=0, width=40, height=12))
+
+
+# ---------------------------------------------------------------------------
+# Point normalization
+# ---------------------------------------------------------------------------
+
+
+def test_bare_y_values_become_indexed_points() -> None:
+    node = Chart(series={"cpu": [10, 20, 30]}).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.datasets[0].data == [(0.0, 10.0), (1.0, 20.0), (2.0, 30.0)]
+
+
+def test_xy_pairs_are_preserved() -> None:
+    node = Chart(series={"load": [(1, 3), (2, 5), (4, 2)]}).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.datasets[0].data == [(1.0, 3.0), (2.0, 5.0), (4.0, 2.0)]
+
+
+def test_mixed_list_points_normalize() -> None:
+    node = Chart(series={"s": [[0, 1], [1, 2]]}).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.datasets[0].data == [(0.0, 1.0), (1.0, 2.0)]
+
+
+# ---------------------------------------------------------------------------
+# Bounds derivation
+# ---------------------------------------------------------------------------
+
+
+def test_auto_bounds_from_data() -> None:
+    node = Chart(series={"a": [10, 50, 30]}).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.x_axis is not None
+    assert node.y_axis is not None
+    assert node.x_axis.bounds == (0.0, 2.0)
+    assert node.y_axis.bounds == (10.0, 50.0)
+
+
+def test_explicit_bounds_override() -> None:
+    node = Chart(
+        series={"a": [1, 2, 3]},
+        x_bounds=(0.0, 10.0),
+        y_bounds=(-5.0, 5.0),
+    ).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.x_axis is not None
+    assert node.y_axis is not None
+    assert node.x_axis.bounds == (0.0, 10.0)
+    assert node.y_axis.bounds == (-5.0, 5.0)
+
+
+def test_flat_series_expands_bounds() -> None:
+    node = Chart(series={"flat": [5, 5, 5]}).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.y_axis is not None
+    assert node.y_axis.bounds == (5.0, 6.0)
+
+
+def test_empty_series_default_bounds() -> None:
+    node = Chart().get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.x_axis is not None
+    assert node.y_axis is not None
+    assert node.x_axis.bounds == (0.0, 1.0)
+    assert node.y_axis.bounds == (0.0, 1.0)
+    assert node.datasets == []
+
+
+# ---------------------------------------------------------------------------
+# Multi-series + palette
+# ---------------------------------------------------------------------------
+
+
+def test_multi_series_creates_datasets() -> None:
+    node = Chart(
+        series={"cpu": [1, 2], "mem": [3, 4]}
+    ).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert [dataset.name for dataset in node.datasets] == ["cpu", "mem"]
+
+
+def test_default_palette_cycles_colors() -> None:
+    node = Chart(
+        series={"a": [1], "b": [2], "c": [3]}
+    ).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    colors = [dataset.color for dataset in node.datasets]
+    assert colors == ["cyan", "magenta", "green"]
+
+
+def test_custom_palette() -> None:
+    node = Chart(
+        series={"a": [1], "b": [2]},
+        colors=("red", "blue"),
+    ).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert [dataset.color for dataset in node.datasets] == ["red", "blue"]
+
+
+def test_kind_propagates_to_datasets() -> None:
+    node = Chart(series={"a": [1, 2]}, kind="bar").get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.datasets[0].graph_type == "bar"
+
+
+def test_scatter_kind() -> None:
+    node = Chart(series={"a": [1, 2]}, kind="scatter").get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.datasets[0].graph_type == "scatter"
+
+
+# ---------------------------------------------------------------------------
+# Legend + axes labels
+# ---------------------------------------------------------------------------
+
+
+def test_legend_position_default() -> None:
+    node = Chart(series={"a": [1]}).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.legend_position == "top_right"
+
+
+def test_legend_disabled() -> None:
+    node = Chart(series={"a": [1]}, legend=False).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.legend_position is None
+
+
+def test_axis_titles() -> None:
+    node = Chart(
+        series={"a": [1, 2]},
+        x_label="time",
+        y_label="load",
+    ).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.x_axis is not None
+    assert node.y_axis is not None
+    assert node.x_axis.title == "time"
+    assert node.y_axis.title == "load"
+
+
+def test_threads_z_and_visible() -> None:
+    node = Chart(series={"a": [1]}, z=5, visible=False).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert node.z == 5
+    assert node.visible is False
+
+
+# ---------------------------------------------------------------------------
+# Declarative subclass with Series descriptors
+# ---------------------------------------------------------------------------
+
+
+class Latency(Chart):
+    p50 = Series(color="green")
+    p99 = Series(color="red", kind="scatter", label="99th")
+
+
+def test_subclass_captures_declared_series() -> None:
+    assert list(Latency._declared) == ["p50", "p99"]
+
+
+def test_subclass_applies_series_styling() -> None:
+    node = Latency(
+        series={"p50": [1, 2, 3], "p99": [4, 5, 6]}
+    ).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    by_name = {dataset.name: dataset for dataset in node.datasets}
+    assert by_name["p50"].color == "green"
+    assert by_name["p50"].graph_type == "line"  # chart default
+    assert by_name["99th"].color == "red"
+    assert by_name["99th"].graph_type == "scatter"
+
+
+def test_subclass_orders_declared_series_first() -> None:
+    node = Latency(
+        series={"extra": [9], "p99": [2], "p50": [1]}
+    ).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    names = [dataset.name for dataset in node.datasets]
+    assert names == ["p50", "99th", "extra"]
+
+
+def test_subclass_skips_declared_series_without_data() -> None:
+    node = Latency(series={"p50": [1, 2]}).get_node(_ctx())
+    assert isinstance(node, ChartNode)
+    assert [dataset.name for dataset in node.datasets] == ["p50"]
+
+
+# ---------------------------------------------------------------------------
+# Offscreen render
+# ---------------------------------------------------------------------------
+
+
+def test_render_chart_is_safe() -> None:
+    out = render_component_to_text(
+        Chart(series={"cpu": [30, 42, 38, 55], "mem": [60, 61, 63, 62]}),
+        width=40,
+        height=12,
+    )
+    assert isinstance(out, str)
+    assert len(out) > 0
+
+
+def test_render_empty_chart_is_safe() -> None:
+    out = render_component_to_text(Chart(), width=20, height=8)
+    assert isinstance(out, str)
+
+
+def test_render_bar_chart_is_safe() -> None:
+    out = render_component_to_text(
+        Chart(series={"load": [(0, 3), (1, 5), (2, 4)]}, kind="bar"),
+        width=30,
+        height=10,
+    )
+    assert isinstance(out, str)
+
+
+def test_render_subclass_is_safe() -> None:
+    out = render_component_to_text(
+        Latency(series={"p50": [1, 2, 3], "p99": [3, 4, 5]}),
+        width=40,
+        height=12,
+    )
+    assert isinstance(out, str)

--- a/tests/test_component_progress.py
+++ b/tests/test_component_progress.py
@@ -1,0 +1,154 @@
+"""Tests for xnano.beta.components.progress — declarative Progress."""
+
+from __future__ import annotations
+
+from helpers import render_component_to_text
+
+from xnano.beta.components.abstract import ComponentRenderContext
+from xnano.beta.components.progress import Progress
+from xnano.beta.core.nodes import LineGaugeNode, ProgressBarNode
+from xnano.beta.types import Area
+
+
+def _ctx() -> ComponentRenderContext:
+    return ComponentRenderContext(area=Area(x=0, y=0, width=40, height=3))
+
+
+# ---------------------------------------------------------------------------
+# Ratio derivation
+# ---------------------------------------------------------------------------
+
+
+def test_ratio_from_direct_value() -> None:
+    assert Progress(value=0.6).ratio == 0.6
+
+
+def test_ratio_from_value_and_total() -> None:
+    assert Progress(value=70, total=100).ratio == 0.7
+
+
+def test_ratio_clamps_above_one() -> None:
+    assert Progress(value=1.5).ratio == 1.0
+    assert Progress(value=150, total=100).ratio == 1.0
+
+
+def test_ratio_clamps_below_zero() -> None:
+    assert Progress(value=-0.2).ratio == 0.0
+
+
+def test_ratio_zero_total_is_zero() -> None:
+    assert Progress(value=5, total=0).ratio == 0.0
+    assert Progress(value=5, total=-10).ratio == 0.0
+
+
+def test_ratio_none_total_uses_value() -> None:
+    assert Progress(value=0.25, total=None).ratio == 0.25
+
+
+# ---------------------------------------------------------------------------
+# Label resolution
+# ---------------------------------------------------------------------------
+
+
+def test_auto_label_is_percentage() -> None:
+    node = Progress(value=0.7).get_node(_ctx())
+    assert isinstance(node, ProgressBarNode)
+    assert node.label == "70%"
+
+
+def test_auto_label_from_value_total() -> None:
+    node = Progress(value=1, total=3).get_node(_ctx())
+    assert isinstance(node, ProgressBarNode)
+    assert node.label == "33%"
+
+
+def test_explicit_label() -> None:
+    node = Progress(value=0.5, label="half").get_node(_ctx())
+    assert isinstance(node, ProgressBarNode)
+    assert node.label == "half"
+
+
+def test_label_false_hides_label() -> None:
+    node = Progress(value=0.5, label=False).get_node(_ctx())
+    assert isinstance(node, ProgressBarNode)
+    assert node.label is None
+
+
+# ---------------------------------------------------------------------------
+# Style dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_bar_style_yields_progress_bar_node() -> None:
+    node = Progress(value=0.4, style="bar").get_node(_ctx())
+    assert isinstance(node, ProgressBarNode)
+    assert node.progress == 0.4
+
+
+def test_line_style_yields_line_gauge_node() -> None:
+    node = Progress(value=0.4, style="line").get_node(_ctx())
+    assert isinstance(node, LineGaugeNode)
+    assert node.progress == 0.4
+
+
+def test_line_style_uses_filled_color_fallback() -> None:
+    node = Progress(value=0.5, style="line", color="cyan").get_node(_ctx())
+    assert isinstance(node, LineGaugeNode)
+    assert node.filled_color == "cyan"
+
+
+def test_line_style_explicit_filled_and_unfilled() -> None:
+    node = Progress(
+        value=0.5,
+        style="line",
+        filled_color="green",
+        unfilled_color="gray",
+    ).get_node(_ctx())
+    assert isinstance(node, LineGaugeNode)
+    assert node.filled_color == "green"
+    assert node.unfilled_color == "gray"
+
+
+def test_bar_threads_color_and_background() -> None:
+    node = Progress(
+        value=0.5, color="blue", background="black"
+    ).get_node(_ctx())
+    assert isinstance(node, ProgressBarNode)
+    assert node.color == "blue"
+    assert node.background == "black"
+
+
+def test_threads_z_and_visible() -> None:
+    node = Progress(value=0.1, z=3, visible=False).get_node(_ctx())
+    assert isinstance(node, ProgressBarNode)
+    assert node.z == 3
+    assert node.visible is False
+
+
+# ---------------------------------------------------------------------------
+# Offscreen render
+# ---------------------------------------------------------------------------
+
+
+def test_render_bar_shows_percentage() -> None:
+    out = render_component_to_text(Progress(value=0.7), width=30, height=3)
+    assert "70%" in out
+
+
+def test_render_line_shows_label() -> None:
+    out = render_component_to_text(
+        Progress(value=0.4, style="line", label="cpu"),
+        width=30,
+        height=3,
+    )
+    assert "cpu" in out
+
+
+def test_render_empty_progress_is_safe() -> None:
+    out = render_component_to_text(Progress(value=0.0), width=20, height=3)
+    assert isinstance(out, str)
+
+
+def test_render_full_progress_is_safe() -> None:
+    out = render_component_to_text(Progress(value=1.0), width=20, height=3)
+    assert isinstance(out, str)

--- a/tests/test_component_schema.py
+++ b/tests/test_component_schema.py
@@ -1,0 +1,177 @@
+"""Tests for the declarative descriptor + metaclass infrastructure."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from xnano.beta.components.schema import (
+    Column,
+    ComponentDescriptor,
+    DeclarativeComponentMeta,
+    Series,
+)
+
+
+def _declared(cls: type) -> dict[str, ComponentDescriptor]:
+    return cast(dict[str, ComponentDescriptor], getattr(cls, "_declared"))
+
+
+# ---------------------------------------------------------------------------
+# Column value / text / color resolution
+# ---------------------------------------------------------------------------
+
+
+def test_column_header_derived_from_name() -> None:
+    col = Column()
+    col.name = "latency_ms"
+    assert col.resolve_header() == "Latency Ms"
+
+
+def test_column_header_explicit() -> None:
+    col = Column(header="RPS")
+    col.name = "rps"
+    assert col.resolve_header() == "RPS"
+
+
+def test_column_value_from_dict() -> None:
+    col = Column()
+    col.name = "status"
+    assert col.resolve_value({"status": "ok"}) == "ok"
+
+
+def test_column_value_from_object() -> None:
+    class Row:
+        status = "degraded"
+
+    col = Column()
+    col.name = "status"
+    assert col.resolve_value(Row()) == "degraded"
+
+
+def test_column_value_missing_is_none() -> None:
+    col = Column()
+    col.name = "missing"
+    assert col.resolve_value({"a": 1}) is None
+
+
+def test_column_accessor_overrides_lookup() -> None:
+    col = Column(accessor=lambda row: row["a"] + row["b"])
+    col.name = "sum"
+    assert col.resolve_value({"a": 2, "b": 3}) == 5
+
+
+def test_column_text_default_str() -> None:
+    col = Column()
+    assert col.resolve_text(42) == "42"
+
+
+def test_column_text_none_is_empty() -> None:
+    col = Column()
+    assert col.resolve_text(None) == ""
+
+
+def test_column_text_format_template() -> None:
+    col = Column(format="{}ms")
+    assert col.resolve_text(12) == "12ms"
+
+
+def test_column_text_format_callable() -> None:
+    col = Column(format=lambda v: f"${v:.2f}")
+    assert col.resolve_text(3) == "$3.00"
+
+
+def test_column_static_color() -> None:
+    col = Column(color="green")
+    assert col.resolve_color("anything") == "green"
+
+
+def test_column_value_dependent_color() -> None:
+    col = Column(color=lambda v: "green" if v == "ok" else "red")
+    assert col.resolve_color("ok") == "green"
+    assert col.resolve_color("bad") == "red"
+
+
+def test_column_value_dependent_background() -> None:
+    col = Column(background=lambda v: "black" if v else None)
+    assert col.resolve_background(True) == "black"
+    assert col.resolve_background(False) is None
+
+
+# ---------------------------------------------------------------------------
+# Series resolution
+# ---------------------------------------------------------------------------
+
+
+def test_series_label_derived_from_name() -> None:
+    s = Series()
+    s.name = "p99"
+    assert s.resolve_label() == "p99"
+
+
+def test_series_label_explicit() -> None:
+    s = Series(label="99th percentile")
+    s.name = "p99"
+    assert s.resolve_label() == "99th percentile"
+
+
+def test_series_is_component_descriptor() -> None:
+    assert isinstance(Series(), ComponentDescriptor)
+    assert isinstance(Column(), ComponentDescriptor)
+
+
+# ---------------------------------------------------------------------------
+# Metaclass capture
+# ---------------------------------------------------------------------------
+
+
+class _Declared(metaclass=DeclarativeComponentMeta):
+    a = Column()
+    b = Column(header="Bee")
+    plain = 5  # not a descriptor — left alone
+
+
+def test_metaclass_captures_descriptors() -> None:
+    assert set(_declared(_Declared)) == {"a", "b"}
+
+
+def test_metaclass_sets_descriptor_names() -> None:
+    assert _declared(_Declared)["a"].name == "a"
+    assert _declared(_Declared)["b"].name == "b"
+
+
+def test_metaclass_removes_descriptors_from_class() -> None:
+    # descriptors are captured, not left as raw class attributes
+    assert not isinstance(getattr(_Declared, "a", None), Column)
+
+
+def test_metaclass_leaves_non_descriptors() -> None:
+    assert _Declared.plain == 5
+
+
+def test_metaclass_preserves_declaration_order() -> None:
+    assert list(_declared(_Declared)) == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Inheritance
+# ---------------------------------------------------------------------------
+
+
+class _Base(metaclass=DeclarativeComponentMeta):
+    x = Column()
+
+
+class _Child(_Base):
+    y = Column()
+
+
+def test_metaclass_inherits_base_descriptors() -> None:
+    assert set(_declared(_Child)) == {"x", "y"}
+
+
+def test_metaclass_base_unaffected_by_child() -> None:
+    assert set(_declared(_Base)) == {"x"}
+
+
+def test_metaclass_inheritance_order_base_first() -> None:
+    assert list(_declared(_Child)) == ["x", "y"]

--- a/tests/test_component_table.py
+++ b/tests/test_component_table.py
@@ -1,0 +1,273 @@
+"""Tests for xnano.beta.components.table — declarative Table."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from helpers import render_component_to_text
+
+from xnano.beta.components.abstract import ComponentRenderContext
+from xnano.beta.components.schema import Column
+from xnano.beta.components.table import Table
+from xnano.beta.core.nodes import TableNode
+from xnano.beta.types import Area
+
+
+def _ctx() -> ComponentRenderContext:
+    return ComponentRenderContext(area=Area(x=0, y=0, width=48, height=10))
+
+
+_ROWS = [
+    {"service": "api", "status": "ok", "latency": 12},
+    {"service": "cache", "status": "degraded", "latency": 88},
+]
+
+
+# ---------------------------------------------------------------------------
+# Data-driven column inference
+# ---------------------------------------------------------------------------
+
+
+def test_infers_columns_from_dict_keys() -> None:
+    node = Table(data=_ROWS).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.header is not None
+    headers = [c.content if hasattr(c, "content") else c for c in node.header.cells]  # type: ignore[union-attr]
+    assert headers == ["Service", "Status", "Latency"]
+
+
+def test_infers_columns_from_dataclass_fields() -> None:
+    @dataclasses.dataclass
+    class Svc:
+        name: str
+        rps: int
+
+    node = Table(data=[Svc("api", 10), Svc("cache", 5)]).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert len(node.rows) == 2
+
+
+def test_infers_columns_from_object_attributes() -> None:
+    class Obj:
+        def __init__(self) -> None:
+            self.a = 1
+            self.b = 2
+
+    node = Table(data=[Obj()]).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.header is not None
+
+
+def test_body_rows_match_data_length() -> None:
+    node = Table(data=_ROWS).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert len(node.rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# columns argument overrides
+# ---------------------------------------------------------------------------
+
+
+def test_columns_list_selects_and_orders() -> None:
+    node = Table(data=_ROWS, columns=["latency", "service"]).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.header is not None
+    headers = [
+        c.content if hasattr(c, "content") else c
+        for c in node.header.cells
+    ]
+    assert headers == ["Latency", "Service"]
+
+
+def test_columns_dict_with_header_string() -> None:
+    node = Table(
+        data=_ROWS, columns={"service": "Svc", "status": "State"}
+    ).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.header is not None
+    headers = [
+        c.content if hasattr(c, "content") else c
+        for c in node.header.cells
+    ]
+    assert headers == ["Svc", "State"]
+
+
+def _cell_text(cell: object) -> str:
+    content = getattr(cell, "content", cell)
+    return str(content)
+
+
+def test_columns_dict_with_column_spec() -> None:
+    node = Table(
+        data=_ROWS,
+        columns={"latency": Column(format="{}ms", align="right", width=6)},
+    ).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert _cell_text(node.rows[0].cells[0]).strip() == "12ms"
+
+
+def test_columns_dict_with_accessor() -> None:
+    node = Table(
+        data=_ROWS,
+        columns={"combined": lambda r: f"{r['service']}:{r['latency']}"},
+    ).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert _cell_text(node.rows[0].cells[0]) == "api:12"
+
+
+# ---------------------------------------------------------------------------
+# Declarative subclass with Column descriptors
+# ---------------------------------------------------------------------------
+
+
+class Services(Table):
+    service: str = Column()
+    status: str = Column(color=lambda v: "green" if v == "ok" else "red")
+    latency: int = Column(align="right", format="{}ms", width=8)
+
+
+def test_subclass_captures_declared_columns() -> None:
+    assert list(Services._declared) == ["service", "status", "latency"]
+
+
+def test_subclass_renders_declared_columns() -> None:
+    node = Services(data=_ROWS).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.header is not None
+    headers = [
+        c.content if hasattr(c, "content") else c
+        for c in node.header.cells
+    ]
+    assert headers == ["Service", "Status", "Latency"]
+
+
+def test_subclass_value_dependent_color() -> None:
+    node = Services(data=_ROWS).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    # status column is index 1
+    ok_cell = node.rows[0].cells[1]
+    degraded_cell = node.rows[1].cells[1]
+    assert getattr(ok_cell, "color") == "green"
+    assert getattr(degraded_cell, "color") == "red"
+
+
+def test_subclass_format_and_right_align() -> None:
+    node = Services(data=_ROWS).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    latency_cell = node.rows[0].cells[2]
+    assert _cell_text(latency_cell) == "    12ms"  # rjust(8)
+
+
+def test_subclass_sets_column_widths_when_all_set() -> None:
+    class Fixed(Table):
+        a: str = Column(width=10)
+        b: str = Column(width=20)
+
+    node = Fixed(data=[{"a": "x", "b": "y"}]).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.column_widths == [10, 20]
+
+
+def test_partial_widths_yield_none() -> None:
+    class Mixed(Table):
+        a: str = Column(width=10)
+        b: str = Column()
+
+    node = Mixed(data=[{"a": "x", "b": "y"}]).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.column_widths is None
+
+
+# ---------------------------------------------------------------------------
+# Selection / options
+# ---------------------------------------------------------------------------
+
+
+def test_selection_propagates() -> None:
+    node = Table(data=_ROWS, selected=1).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.selected_row == 1
+
+
+def test_hide_header() -> None:
+    node = Table(data=_ROWS, show_header=False).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.header is None
+
+
+def test_threads_z_and_visible() -> None:
+    node = Table(data=_ROWS, z=4, visible=False).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.z == 4
+    assert node.visible is False
+
+
+# ---------------------------------------------------------------------------
+# Offscreen render
+# ---------------------------------------------------------------------------
+
+
+def test_render_shows_headers_and_data() -> None:
+    out = render_component_to_text(Table(data=_ROWS), width=48, height=6)
+    assert "Service" in out
+    assert "api" in out
+    assert "degraded" in out
+
+
+def test_render_selection_highlight_symbol() -> None:
+    out = render_component_to_text(
+        Table(data=_ROWS, selected=0, highlight_symbol="> "),
+        width=48,
+        height=6,
+    )
+    assert "> api" in out
+
+
+def test_render_subclass_formats_values() -> None:
+    out = render_component_to_text(Services(data=_ROWS), width=48, height=6)
+    assert "12ms" in out
+    assert "88ms" in out
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_data_is_safe() -> None:
+    node = Table(data=[]).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.rows == []
+    assert node.header is None
+
+
+def test_empty_data_with_declared_columns_keeps_header() -> None:
+    node = Services(data=[]).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert node.rows == []
+    assert node.header is not None
+    headers = [
+        cell.content if hasattr(cell, "content") else cell
+        for cell in node.header.cells
+    ]
+    assert headers == ["Service", "Status", "Latency"]
+
+
+def test_render_empty_table_is_safe() -> None:
+    out = render_component_to_text(Table(data=[]), width=20, height=4)
+    assert isinstance(out, str)
+
+
+def test_missing_keys_render_blank() -> None:
+    rows = [{"a": 1, "b": 2}, {"a": 3}]  # second row missing "b"
+    node = Table(data=rows, columns=["a", "b"]).get_node(_ctx())
+    assert isinstance(node, TableNode)
+    assert _cell_text(node.rows[1].cells[1]) == ""
+
+
+def test_selection_out_of_range_is_safe() -> None:
+    out = render_component_to_text(
+        Table(data=_ROWS, selected=99), width=48, height=6
+    )
+    assert "api" in out

--- a/tests/test_usage_scenarios.py
+++ b/tests/test_usage_scenarios.py
@@ -1,0 +1,642 @@
+"""End-to-end usage scenarios — hooks + components working together.
+
+These are not unit checks of single conditionals. Each test builds a small
+app-like ``Grid``, drives it through an offscreen ``Terminal``, and asserts
+on rendered output and cross-feature behavior (focus → input → submit,
+table/progress/chart in one layout, tick/poll/field chains, etc.).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from helpers import (
+    FakeEvent,
+    close_offscreen_app,
+    open_offscreen_app,
+    paint,
+    press,
+    type_text,
+)
+
+from xnano.beta import Field, Grid, on_field, on_focus, on_keyboard, on_poll, on_tick
+from xnano.beta.components import Chart, Column, Progress, Table, Text
+from xnano.beta.components.schema import Series
+from xnano.beta.core.dispatch import pump_poll, pump_tick
+from xnano.beta.hooks import _EventHooksRegistry
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — login form: focus + Text input + enter submit + re-render
+# ---------------------------------------------------------------------------
+
+
+class LoginForm(Grid):
+    """Two-field form with focus hooks and submit-on-enter."""
+
+    heading: str = Field(default="Sign in", height=1)
+    username: Text = Field(
+        default_factory=lambda: Text(
+            "", input=True, placeholder="username"
+        ),
+        height=1,
+    )
+    password: Text = Field(
+        default_factory=lambda: Text(
+            "", input=True, placeholder="password"
+        ),
+        height=1,
+    )
+    status: str = Field(default="ready", height=1)
+    focus_log: list[str] = Field(default_factory=list, state=True)
+
+    @on_focus("username")
+    def _username_gained(self) -> None:
+        self.focus_log.append("username+")
+        self.status = "editing username"
+
+    @on_focus("username", kind="lost")
+    def _username_lost(self) -> None:
+        self.focus_log.append("username-")
+
+    @on_focus("password")
+    def _password_gained(self) -> None:
+        self.focus_log.append("password+")
+        self.status = "editing password"
+
+    @on_keyboard("enter")
+    def _submit(self) -> None:
+        self.status = f"ok:{self.username.value}/{self.password.value}"
+
+
+def test_login_form_type_tab_submit_and_render() -> None:
+    form = LoginForm()
+    terminal = open_offscreen_app(form, cols=40, rows=8)
+    try:
+        # Auto-focus first input; placeholder path replaced by caret once focused.
+        assert terminal.field_focus is not None
+        assert terminal.field_focus.field_name == "username"
+        assert form.username._input_focused is True
+        assert "username+" in form.focus_log
+
+        type_text(terminal, "ada")
+        assert form.username.value == "ada"
+
+        press(terminal, "tab")
+        assert terminal.field_focus.field_name == "password"
+        assert form.username._input_focused is False
+        assert form.password._input_focused is True
+        assert "username-" in form.focus_log
+        assert "password+" in form.focus_log
+
+        type_text(terminal, "s3cret")
+        assert form.password.value == "s3cret"
+
+        press(terminal, "enter")
+        assert form.status == "ok:ada/s3cret"
+
+        out = paint(terminal, form)
+        assert "Sign in" in out
+        assert "ada" in out
+        # password field is focused → caret visible in buffer
+        assert "s3cret" in out or "▌" in out
+        assert "ok:ada/s3cret" in out
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_login_form_backspace_and_cycle_wrap() -> None:
+    form = LoginForm()
+    terminal = open_offscreen_app(form)
+    try:
+        type_text(terminal, "ab")
+        press(terminal, "backspace")
+        assert form.username.value == "a"
+
+        # tab → password → tab wraps to username
+        press(terminal, "tab")
+        press(terminal, "tab")
+        assert terminal.field_focus.field_name == "username"
+
+        press(terminal, "backtab")
+        assert terminal.field_focus.field_name == "password"
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_login_form_paste_into_focused_input() -> None:
+    from typing import Any, cast
+
+    from xnano.beta.context import Context
+    from xnano.beta.core.dispatch import dispatch_hooks
+
+    form = LoginForm()
+    terminal = open_offscreen_app(form)
+    try:
+        type_text(terminal, "pre")
+        event = FakeEvent(clipboard_text="-fix")
+        ctx = Context(
+            event=cast(Any, event), terminal=terminal, state=None
+        )
+        dispatch_hooks(terminal, ctx)
+        assert form.username.value == "pre-fix"
+    finally:
+        close_offscreen_app(terminal)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — dashboard: Table + Progress + Chart + tick-driven updates
+# ---------------------------------------------------------------------------
+
+
+class ServicesTable(Table):
+    service: str = Column()
+    status: str = Column(
+        color=lambda value: "green" if value == "ok" else "red"
+    )
+    latency: int = Column(align="right", format="{}ms", width=6)
+
+
+class CpuChart(Chart):
+    cpu = Series(color="cyan")
+    mem = Series(color="magenta")
+
+
+class Dashboard(Grid):
+    title: str = Field(default="ops", height=1)
+    table: Table = Field(
+        default_factory=lambda: ServicesTable(
+            data=[
+                {"service": "api", "status": "ok", "latency": 12},
+                {"service": "cache", "status": "degraded", "latency": 88},
+            ],
+            selected=0,
+            highlight_symbol="> ",
+        ),
+        height=5,
+    )
+    load: Progress = Field(
+        default_factory=lambda: Progress(value=40, total=100, color="green"),
+        height=3,
+    )
+    chart: Chart = Field(
+        default_factory=lambda: CpuChart(
+            series={"cpu": [10, 20, 30, 25], "mem": [50, 55, 52, 60]}
+        ),
+        height=6,
+    )
+    tick_count: int = Field(default=0, state=True)
+    load_hits: int = Field(default=0, state=True)
+
+    @on_tick
+    def _pulse(self) -> None:
+        self.tick_count += 1
+        # Bump progress and table selection each tick.
+        next_value = min(100, int(self.load.value) + 10)
+        self.load = Progress(value=next_value, total=100, color="green")
+        selected = 0 if self.table.selected else 1
+        self.table = ServicesTable(
+            data=list(self.table.data),
+            selected=selected,
+            highlight_symbol="> ",
+        )
+
+    @on_field("load.ratio >= 0.5")
+    def _halfway(self) -> None:
+        self.load_hits += 1
+
+
+def test_dashboard_renders_components_together() -> None:
+    app = Dashboard()
+    terminal = open_offscreen_app(app, cols=56, rows=18)
+    try:
+        out = paint(terminal, app)
+        assert "ops" in out
+        assert "Service" in out or "api" in out
+        assert "api" in out
+        assert "cache" in out
+        # progress auto-label
+        assert "40%" in out
+        # selection marker on first row
+        assert "> " in out or "api" in out
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_dashboard_tick_updates_progress_and_fires_on_field() -> None:
+    app = Dashboard()
+    terminal = open_offscreen_app(app, cols=56, rows=18)
+    try:
+        # Wire bound instance hooks the way Terminal.attach_grid/merge does.
+        collected = _EventHooksRegistry.from_component_class(Dashboard)
+        terminal._hooks.on_tick_hooks.clear()
+        terminal._hooks.on_field_hooks.clear()
+        for entry in collected.on_tick_hooks:
+            name = getattr(entry["handler"], "__name__", None)
+            handler = getattr(app, name) if name else entry["handler"]
+            terminal._hooks.on_tick_hooks.append(
+                {
+                    "interval": entry["interval"],
+                    "handler": handler,
+                    "last_fire_ms": 0.0,
+                }
+            )
+        for entry in collected.on_field_hooks:
+            name = getattr(entry["handler"], "__name__", None)
+            handler = getattr(app, name) if name else entry["handler"]
+            terminal._hooks.on_field_hooks.append(
+                {
+                    "expression": entry["expression"],
+                    "handler": handler,
+                }
+            )
+
+        assert app.load.ratio == 0.4
+        pump_tick(terminal)
+        assert app.tick_count == 1
+        assert app.load.ratio == 0.5
+        # on_field("load.ratio >= 0.5") should now be true
+        assert app.load_hits >= 1
+
+        out = paint(terminal, app)
+        assert "50%" in out
+    finally:
+        close_offscreen_app(terminal)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — chat prompt: free keys go to input; enter submits; slash cmd
+# ---------------------------------------------------------------------------
+
+
+class ChatApp(Grid):
+    log: Text = Field(
+        default_factory=lambda: Text("welcome"),
+        height=4,
+    )
+    prompt: Text = Field(
+        default_factory=lambda: Text("", input=True, placeholder="message"),
+        height=1,
+    )
+    history: list[str] = Field(default_factory=list, state=True)
+
+    @on_keyboard("enter")
+    def _send(self) -> None:
+        message = self.prompt.value.strip()
+        if not message:
+            return
+        self.history.append(message)
+        if message.startswith("/clear"):
+            self.history.clear()
+            self.log = Text("cleared")
+        else:
+            self.log = Text("\n".join(self.history[-4:]))
+        self.prompt = Text("", input=True, placeholder="message")
+        # keep focus on the new prompt instance
+        from xnano.beta.focus import set_field_focus
+        from xnano.beta.terminal import _ACTIVE_TERMINAL
+
+        term = _ACTIVE_TERMINAL.get()
+        if term is not None:
+            set_field_focus(term, self, "prompt")
+
+
+def test_chat_prompt_type_submit_command_flow() -> None:
+    app = ChatApp()
+    terminal = open_offscreen_app(app, cols=40, rows=10)
+    try:
+        type_text(terminal, "hello")
+        press(terminal, "enter")
+        assert app.history == ["hello"]
+        out = paint(terminal, app)
+        assert "hello" in out
+
+        type_text(terminal, "/clear")
+        press(terminal, "enter")
+        assert app.history == []
+        out = paint(terminal, app)
+        assert "cleared" in out
+        # prompt emptied and re-focused
+        assert app.prompt.value == ""
+        assert app.prompt._input_focused is True
+    finally:
+        close_offscreen_app(terminal)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — on_poll idle + on_tick + keyboard state machine
+# ---------------------------------------------------------------------------
+
+
+class WorkerApp(Grid):
+    label: str = Field(default="boot", height=1)
+    idle_count: int = Field(default=0, state=True)
+    frame_count: int = Field(default=0, state=True)
+    ticks: int = Field(default=0, state=True)
+    mode: str = Field(default="idle", state=True)
+
+    @on_poll  # idle
+    def _on_idle(self) -> None:
+        self.idle_count += 1
+        if self.mode == "idle":
+            self.label = f"idle:{self.idle_count}"
+
+    @on_poll("frame")
+    def _on_frame(self) -> None:
+        self.frame_count += 1
+
+    @on_tick
+    def _on_tick(self) -> None:
+        self.ticks += 1
+
+    @on_keyboard("r")
+    def _run(self) -> None:
+        self.mode = "run"
+        self.label = "running"
+
+    @on_field("mode == 'run'")
+    def _when_running(self) -> None:
+        self.label = f"run-ticks:{self.ticks}"
+
+
+def _bind_all_hooks(terminal: Any, grid: Any, cls: type) -> None:
+    collected = _EventHooksRegistry.from_component_class(cls)
+    terminal._hooks = _EventHooksRegistry()
+    for entry in collected.on_poll_hooks:
+        name = getattr(entry["handler"], "__name__", None)
+        handler = getattr(grid, name) if name else entry["handler"]
+        terminal._hooks.on_poll_hooks.append(
+            {"when": entry["when"], "handler": handler}
+        )
+    for entry in collected.on_tick_hooks:
+        name = getattr(entry["handler"], "__name__", None)
+        handler = getattr(grid, name) if name else entry["handler"]
+        terminal._hooks.on_tick_hooks.append(
+            {
+                "interval": entry["interval"],
+                "handler": handler,
+                "last_fire_ms": 0.0,
+            }
+        )
+    for entry in collected.on_field_hooks:
+        name = getattr(entry["handler"], "__name__", None)
+        handler = getattr(grid, name) if name else entry["handler"]
+        terminal._hooks.on_field_hooks.append(
+            {"expression": entry["expression"], "handler": handler}
+        )
+    for entry in collected.on_keyboard_hooks:
+        name = getattr(entry["handler"], "__name__", None)
+        handler = getattr(grid, name) if name else entry["handler"]
+        terminal._hooks.on_keyboard_hooks.append(
+            {
+                "bindings": entry["bindings"],
+                "kind": entry["kind"],
+                "handler": handler,
+            }
+        )
+    for entry in collected.on_focus_hooks:
+        name = getattr(entry["handler"], "__name__", None)
+        handler = getattr(grid, name) if name else entry["handler"]
+        terminal._hooks.on_focus_hooks.append(
+            {
+                "field": entry["field"],
+                "kind": entry["kind"],
+                "handler": handler,
+            }
+        )
+
+
+def test_worker_poll_tick_keyboard_field_chain() -> None:
+    app = WorkerApp()
+    terminal = open_offscreen_app(app, cols=30, rows=4)
+    try:
+        _bind_all_hooks(terminal, app, WorkerApp)
+        terminal._attached_frame_grids = [app]
+
+        # Idle poll path without touching the real Session method.
+        pump_poll(terminal, "idle")
+        assert app.idle_count == 1
+        assert "idle:1" in app.label
+
+        pump_poll(terminal, "frame")
+        assert app.frame_count == 1
+
+        pump_tick(terminal)
+        assert app.ticks == 1
+
+        # @on_keyboard("r") — named binding match
+        press(terminal, "r")
+        assert app.mode == "run"
+        pump_tick(terminal)
+        assert app.ticks == 2
+        assert app.label == "run-ticks:2"
+
+        out = paint(terminal, app)
+        assert "run-ticks:2" in out
+    finally:
+        close_offscreen_app(terminal)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — async tick mutates Progress, then field hook reacts
+# ---------------------------------------------------------------------------
+
+
+class AsyncMeter(Grid):
+    meter: Progress = Field(
+        default_factory=lambda: Progress(value=0, total=10),
+        height=3,
+    )
+    note: str = Field(default="", height=1)
+    async_fires: int = Field(default=0, state=True)
+
+    @on_tick
+    async def _async_bump(self) -> None:
+        await asyncio.sleep(0)
+        self.async_fires += 1
+        self.meter = Progress(
+            value=min(10, self.async_fires), total=10, color="cyan"
+        )
+
+    @on_field("meter.ratio >= 0.3")
+    def _note(self) -> None:
+        self.note = f"ratio={self.meter.ratio:.1f}"
+
+
+def test_async_tick_with_progress_and_on_field() -> None:
+    app = AsyncMeter()
+    terminal = open_offscreen_app(app, cols=32, rows=6)
+    try:
+        _bind_all_hooks(terminal, app, AsyncMeter)
+        terminal._attached_frame_grids = [app]
+
+        pump_tick(terminal)
+        pump_tick(terminal)
+        pump_tick(terminal)
+        assert app.async_fires == 3
+        assert app.meter.ratio == 0.3
+        assert app.note == "ratio=0.3"
+
+        out = paint(terminal, app)
+        assert "30%" in out
+        assert "ratio=0.3" in out
+    finally:
+        close_offscreen_app(terminal)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — multi-grid: independent focus + shared terminal hooks
+# ---------------------------------------------------------------------------
+
+
+class Panel(Grid):
+    name: str = Field(default="panel", height=1, state=True)
+    field: Text = Field(
+        default_factory=lambda: Text("", input=True, placeholder="…"),
+        height=1,
+    )
+
+
+class Dual(Grid):
+    left: Panel = Field(default_factory=lambda: Panel(name="left"))
+    right: Panel = Field(default_factory=lambda: Panel(name="right"))
+
+
+def test_nested_panels_render_and_focus_left_input() -> None:
+    root = Dual()
+    root.left.name = "left"
+    root.right.name = "right"
+    terminal = open_offscreen_app(root, cols=40, rows=6)
+    try:
+        out = paint(terminal, root)
+        assert isinstance(out, str)
+        # Nested panels re-register during paint.
+        names = {type(grid).__name__ for grid in terminal._attached_frame_grids}
+        assert "Dual" in names
+        assert "Panel" in names
+        assert len(terminal._attached_frame_grids) >= 3  # root + 2 panels
+
+        # Explicitly focus left panel input and type.
+        from xnano.beta.focus import set_field_focus
+
+        assert set_field_focus(terminal, root.left, "field") is True
+        type_text(terminal, "xy")
+        assert root.left.field.value == "xy"
+        out2 = paint(terminal, root)
+        assert "xy" in out2
+    finally:
+        close_offscreen_app(terminal)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7 — Table selection + keyboard moves selection + Progress mirrors
+# ---------------------------------------------------------------------------
+
+
+class Picker(Grid):
+    # Note: cannot name a layout field ``rows`` — Grid owns ``rows``/``columns``.
+    items: Table = Field(
+        default_factory=lambda: Table(
+            data=[
+                {"item": "alpha", "n": 1},
+                {"item": "beta", "n": 2},
+                {"item": "gamma", "n": 3},
+            ],
+            columns=["item", "n"],
+            selected=0,
+            highlight_symbol="* ",
+        ),
+        height=6,
+    )
+    bar: Progress = Field(
+        default_factory=lambda: Progress(value=1, total=3),
+        height=3,
+    )
+
+    @on_keyboard("down")
+    def _down(self) -> None:
+        index = (self.items.selected or 0) + 1
+        index = min(index, len(self.items.data) - 1)
+        self.items = Table(
+            data=self.items.data,
+            columns=["item", "n"],
+            selected=index,
+            highlight_symbol="* ",
+        )
+        self.bar = Progress(value=index + 1, total=3)
+
+    @on_keyboard("up")
+    def _up(self) -> None:
+        index = max(0, (self.items.selected or 0) - 1)
+        self.items = Table(
+            data=self.items.data,
+            columns=["item", "n"],
+            selected=index,
+            highlight_symbol="* ",
+        )
+        self.bar = Progress(value=index + 1, total=3)
+
+
+def test_picker_keyboard_moves_selection_and_progress() -> None:
+    app = Picker()
+    terminal = open_offscreen_app(app, cols=36, rows=12)
+    try:
+        _bind_all_hooks(terminal, app, Picker)
+        out = paint(terminal, app)
+        assert "alpha" in out
+        assert "33%" in out  # progress 1/3
+
+        press(terminal, "down")
+        assert app.items.selected == 1
+        assert abs(app.bar.ratio - (2 / 3)) < 1e-9
+        out = paint(terminal, app)
+        assert "beta" in out
+        assert "67%" in out
+
+        press(terminal, "down")
+        assert app.items.selected == 2
+        assert app.bar.ratio == 1.0
+        out = paint(terminal, app)
+        assert "100%" in out
+        assert "gamma" in out
+    finally:
+        close_offscreen_app(terminal)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 8 — exception in hook still leaves terminal usable (restore path)
+# ---------------------------------------------------------------------------
+
+
+class BoomApp(Grid):
+    label: str = Field(default="safe", height=1)
+
+    @on_keyboard("x")
+    def _boom(self) -> None:
+        raise ValueError("kaboom")
+
+
+def test_hook_exception_logs_and_terminal_still_paints(
+    caplog: Any,
+) -> None:
+    import logging
+
+    app = BoomApp()
+    terminal = open_offscreen_app(app, cols=20, rows=3)
+    try:
+        _bind_all_hooks(terminal, app, BoomApp)
+        with caplog.at_level(logging.ERROR, logger="xnano.hooks"):
+            try:
+                press(terminal, "x")
+            except ValueError as exc:
+                assert "kaboom" in str(exc)
+            else:
+                raise AssertionError("expected ValueError")
+        assert any("Uncaught exception" in r.message for r in caplog.records)
+        # Terminal session still paints after the failure.
+        app.label = "recovered"
+        out = paint(terminal, app)
+        assert "recovered" in out
+    finally:
+        close_offscreen_app(terminal)

--- a/xnano/beta/components/__init__.py
+++ b/xnano/beta/components/__init__.py
@@ -4,12 +4,28 @@ from xnano.beta.components.abstract import (
     AbstractComponent,
     ComponentRenderContext,
 )
+from xnano.beta.components.chart import Chart
+from xnano.beta.components.schema import (
+    Column,
+    ComponentDescriptor,
+    DeclarativeComponentMeta,
+    Series,
+)
+from xnano.beta.components.progress import Progress
 from xnano.beta.components.sparkline import Sparkline
+from xnano.beta.components.table import Table
 from xnano.beta.components.text import Text
 
 __all__ = (
     "AbstractComponent",
     "ComponentRenderContext",
+    "ComponentDescriptor",
+    "DeclarativeComponentMeta",
+    "Column",
+    "Series",
+    "Chart",
+    "Progress",
     "Sparkline",
+    "Table",
     "Text",
 )

--- a/xnano/beta/components/chart.py
+++ b/xnano/beta/components/chart.py
@@ -1,0 +1,179 @@
+"""xnano.beta.components.chart"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, ClassVar, Sequence, TypeAlias, cast, TYPE_CHECKING
+
+from xnano.beta.components.abstract import AbstractComponent
+from xnano.beta.components.schema import (
+    ComponentDescriptor,
+    DeclarativeComponentMeta,
+    Series,
+)
+from xnano.beta.types import GraphTypeLike, LegendPositionLike
+
+if TYPE_CHECKING:
+    from xnano.beta.color import ColorLike
+    from xnano.beta.components.abstract import ComponentRenderContext
+    from xnano.beta.core.nodes import AbstractRenderNode
+
+
+_DEFAULT_PALETTE: tuple[str, ...] = (
+    "cyan",
+    "magenta",
+    "green",
+    "yellow",
+    "blue",
+    "red",
+)
+
+# A series' points: either ``(x, y)`` pairs or bare ``y`` values (x = index).
+# ``Any`` sequence elements are accepted so callers can pass bare lists of
+# numbers or pairs without fighting sequence invariance.
+SeriesData: TypeAlias = Sequence[Any]
+"""Points for one chart series: ``(x, y)`` pairs or bare ``y`` values."""
+
+
+@dataclasses.dataclass
+class Chart(AbstractComponent, metaclass=DeclarativeComponentMeta):
+    """Declarative multi-series chart.
+
+    Hand it a mapping of series name → points and it derives the datasets,
+    legend, axis bounds, and a cycled color per series. Points may be ``(x, y)``
+    pairs or bare ``y`` values (the x-axis becomes the index). One component
+    covers line, scatter, and bar plots.
+
+        # data-driven — one line per key, legend + bounds inferred
+        Chart(series={"cpu": [30, 42, 38, 55], "mem": [60, 61, 63, 62]})
+
+        # explicit points and a bar plot
+        Chart(series={"load": [(0, 3), (1, 5), (2, 4)]}, kind="bar")
+
+        # declarative subclass — per-series styling as a schema
+        class Latency(Chart):
+            p50 = Series(color="green")
+            p99 = Series(color="red")
+
+        Latency(series={"p50": [...], "p99": [...]})
+    """
+
+    series: dict[str, SeriesData] = dataclasses.field(default_factory=dict)
+    """Mapping of series name → points (``(x, y)`` pairs or bare ``y`` values)."""
+    kind: GraphTypeLike = "line"
+    """Default plot kind for series that do not override it."""
+    colors: Sequence[ColorLike] | None = None
+    """Palette cycled across series; ``None`` uses a built-in palette."""
+    x_bounds: tuple[float, float] | None = None
+    """x-axis ``(min, max)``; ``None`` auto-fits to the data."""
+    y_bounds: tuple[float, float] | None = None
+    """y-axis ``(min, max)``; ``None`` auto-fits to the data."""
+    x_label: str | None = None
+    """Optional x-axis title."""
+    y_label: str | None = None
+    """Optional y-axis title."""
+    legend: bool = True
+    """Whether to show the legend (labelled from series names)."""
+    legend_position: LegendPositionLike = "top_right"
+    """Legend placement when ``legend`` is enabled."""
+    fit_content: bool = dataclasses.field(default=False, kw_only=True)
+
+    _declared: ClassVar[dict[str, ComponentDescriptor]] = {}
+
+    # ── series resolution ────────────────────────────────────────────────
+
+    @staticmethod
+    def _normalize_points(points: Any) -> list[tuple[float, float]]:
+        result: list[tuple[float, float]] = []
+        for index, point in enumerate(points):
+            if isinstance(point, (tuple, list)) and len(point) == 2:
+                result.append((float(point[0]), float(point[1])))
+            else:
+                result.append((float(index), float(point)))
+        return result
+
+    def _ordered_names(self) -> list[str]:
+        # Declared series first (schema order), then any extra data keys.
+        names = [name for name in self._declared if name in self.series]
+        names.extend(name for name in self.series if name not in names)
+        return names
+
+    def _resolve_series(
+        self,
+    ) -> list[tuple[str, list[tuple[float, float]], Any, GraphTypeLike]]:
+        palette = tuple(self.colors) if self.colors else _DEFAULT_PALETTE
+        resolved: list[
+            tuple[str, list[tuple[float, float]], Any, GraphTypeLike]
+        ] = []
+        for index, name in enumerate(self._ordered_names()):
+            raw = self._declared.get(name)
+            descriptor = cast(Series | None, raw)
+            points = self._normalize_points(self.series[name])
+            color: Any = (
+                descriptor.color
+                if descriptor is not None and descriptor.color is not None
+                else palette[index % len(palette)]
+            )
+            kind: GraphTypeLike = (
+                descriptor.kind
+                if descriptor is not None and descriptor.kind is not None
+                else self.kind
+            )
+            label = (
+                descriptor.resolve_label()
+                if descriptor is not None
+                else name
+            )
+            resolved.append((label, points, color, kind))
+        return resolved
+
+    @staticmethod
+    def _auto_bounds(
+        values: list[float], explicit: tuple[float, float] | None
+    ) -> tuple[float, float]:
+        if explicit is not None:
+            return explicit
+        if not values:
+            return (0.0, 1.0)
+        low, high = min(values), max(values)
+        if low == high:
+            return (low, high + 1.0)
+        return (low, high)
+
+    # ── rendering ────────────────────────────────────────────────────────
+
+    def get_node(self, ctx: ComponentRenderContext) -> AbstractRenderNode:
+        from xnano.beta.core.nodes import ChartAxis, ChartDataset, ChartNode
+
+        resolved = self._resolve_series()
+
+        all_x: list[float] = []
+        all_y: list[float] = []
+        datasets: list[ChartDataset] = []
+        for label, points, color, kind in resolved:
+            for x, y in points:
+                all_x.append(x)
+                all_y.append(y)
+            datasets.append(
+                ChartDataset(
+                    data=points,
+                    name=label,
+                    color=color,
+                    graph_type=kind,
+                )
+            )
+
+        x_bounds = self._auto_bounds(all_x, self.x_bounds)
+        y_bounds = self._auto_bounds(all_y, self.y_bounds)
+
+        return ChartNode(
+            datasets=datasets,
+            x_axis=ChartAxis(title=self.x_label, bounds=x_bounds),
+            y_axis=ChartAxis(title=self.y_label, bounds=y_bounds),
+            legend_position=self.legend_position if self.legend else None,
+            z=self.z,
+            visible=self.visible,
+        )
+
+
+__all__ = ("Chart", "SeriesData")

--- a/xnano/beta/components/progress.py
+++ b/xnano/beta/components/progress.py
@@ -1,0 +1,99 @@
+"""xnano.beta.components.progress"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Literal, TYPE_CHECKING
+
+from xnano.beta.components.abstract import AbstractComponent
+
+if TYPE_CHECKING:
+    from xnano.beta.color import ColorLike
+    from xnano.beta.components.abstract import ComponentRenderContext
+    from xnano.beta.core.nodes import AbstractRenderNode
+
+
+ProgressStyle = Literal["bar", "line"]
+"""Visual style for a ``Progress`` component."""
+
+
+@dataclasses.dataclass
+class Progress(AbstractComponent):
+    """Declarative progress indicator.
+
+    Describe *how much* is done — as a ``0.0``–``1.0`` ratio, or a ``value``
+    out of a ``total`` — and pick a ``style``. One component covers both the
+    block ``Gauge`` and the thin ``LineGauge`` ratatui widgets, with an
+    auto-derived percentage label.
+
+        Progress(value=0.6)                      # 60% block bar
+        Progress(value=70, total=100)            # derived ratio, "70%"
+        Progress(value=0.4, style="line", label="cpu")
+    """
+
+    value: float = 0.0
+    """Current progress. A ``0.0``–``1.0`` ratio, or an absolute amount when
+    ``total`` is set."""
+    total: float | None = None
+    """When set, the ratio is ``value / total``; otherwise ``value`` is the
+    ratio directly. A non-positive total yields a ratio of ``0.0``."""
+    label: str | Literal[False] | None = None
+    """Text drawn over the indicator. ``None`` auto-derives a percentage;
+    ``False`` hides the label."""
+    style: ProgressStyle = "bar"
+    """``"bar"`` for a full block gauge, ``"line"`` for a thin line gauge."""
+    color: ColorLike = "green"
+    """Filled-portion foreground color."""
+    background: ColorLike | None = None
+    """Widget background color."""
+    filled_color: ColorLike | None = None
+    """``line`` style only: filled-portion color (defaults to ``color``)."""
+    unfilled_color: ColorLike | None = None
+    """``line`` style only: unfilled-portion color."""
+    fit_content: bool = dataclasses.field(default=False, kw_only=True)
+
+    @property
+    def ratio(self) -> float:
+        """Return the completion ratio, clamped to ``0.0``–``1.0``."""
+        if self.total is None:
+            raw = self.value
+        elif self.total <= 0:
+            raw = 0.0
+        else:
+            raw = self.value / self.total
+        return max(0.0, min(1.0, raw))
+
+    def _resolve_label(self) -> str | None:
+        if self.label is False:
+            return None
+        if self.label is None:
+            return f"{round(self.ratio * 100)}%"
+        return self.label
+
+    def get_node(self, ctx: ComponentRenderContext) -> AbstractRenderNode:
+        from xnano.beta.core.nodes import LineGaugeNode, ProgressBarNode
+
+        ratio = self.ratio
+        label = self._resolve_label()
+        if self.style == "line":
+            return LineGaugeNode(
+                progress=ratio,
+                label=label,
+                color=self.color,
+                filled_color=self.filled_color or self.color,
+                unfilled_color=self.unfilled_color,
+                background=self.background,
+                z=self.z,
+                visible=self.visible,
+            )
+        return ProgressBarNode(
+            progress=ratio,
+            label=label,
+            color=self.color,
+            background=self.background,
+            z=self.z,
+            visible=self.visible,
+        )
+
+
+__all__ = ("Progress", "ProgressStyle")

--- a/xnano/beta/components/schema.py
+++ b/xnano/beta/components/schema.py
@@ -1,0 +1,225 @@
+"""xnano.beta.components.schema
+
+---
+
+Declarative descriptor infrastructure for data-driven components.
+
+``Column`` and ``Series`` mirror ``xnano.beta.fields.Field``: they are declared
+as class attributes on an ``AbstractComponent`` subclass and captured by
+``DeclarativeComponentMeta`` at class-creation time, so a component subclass
+reads like a schema rather than a pile of ratatui builders:
+
+    class Services(Table):
+        service: str = Column()
+        status: str = Column(color=lambda v: "green" if v == "ok" else "red")
+        latency: int = Column(align="right", format="{}ms")
+
+    Services(data=[{"service": "api", "status": "ok", "latency": 12}])
+"""
+
+from __future__ import annotations
+
+import abc
+import dataclasses
+from typing import Any, Callable, TypeAlias, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from xnano.beta.color import ColorLike
+    from xnano.beta.types import Alignment, GraphTypeLike
+
+
+ColorResolver: TypeAlias = Any
+"""A static color, or a callable that derives one from a cell/point value.
+
+Typed as ``Any`` so static checkers do not treat ``ColorLike`` strings as
+callables when resolving value-dependent colors.
+"""
+
+
+FormatResolver: TypeAlias = str | Callable[[Any], str] | None
+"""A ``str.format`` template, a formatter callable, or ``None``."""
+
+
+@dataclasses.dataclass
+class ComponentDescriptor:
+    """Base for declarative class-level descriptors (``Column``, ``Series``).
+
+    The owning attribute name is filled in by ``DeclarativeComponentMeta`` when
+    the descriptor is captured.
+    """
+
+    name: str = dataclasses.field(default="", init=False)
+
+
+@dataclasses.dataclass
+class Column(ComponentDescriptor):
+    """Declares one column of a ``Table``.
+
+    Attributes:
+        header: Column header text; ``None`` derives it from the attribute
+            name (e.g. ``latency`` → ``"Latency"``).
+        accessor: How to pull this column's value from a row; ``None`` reads
+            ``row[name]`` for mappings or ``getattr(row, name)`` for objects.
+        format: A ``str.format`` template (``"{}ms"``) or a callable applied to
+            the value to produce cell text; ``None`` uses ``str(value)``.
+        color: Cell foreground — a color or a callable of the value.
+        background: Cell background — a color or a callable of the value.
+        align: Cell text alignment.
+        width: Fixed cell width (``int``) or fractional share (``float`` 0–1);
+            ``None`` shares space equally.
+    """
+
+    header: str | None = None
+    accessor: Callable[[Any], Any] | None = None
+    format: FormatResolver = None
+    color: ColorResolver = None
+    background: ColorResolver = None
+    align: Alignment | None = None
+    width: int | float | None = None
+
+    if TYPE_CHECKING:
+        # Class-body assignments like ``latency: int = Column(...)`` are the
+        # supported declarative form.  At runtime the metaclass strips the
+        # descriptor; at type-check time we type the constructor as ``Any``
+        # so the annotation and right-hand side remain compatible.
+        def __new__(cls, *args: Any, **kwargs: Any) -> Any: ...
+
+    def resolve_header(self) -> str:
+        """Return the header text, deriving one from ``name`` when unset.
+
+        Returns:
+            The header text for this column.
+        """
+        if self.header is not None:
+            return self.header
+        return self.name.replace("_", " ").title()
+
+    def resolve_value(self, row: Any) -> Any:
+        """Read this column's raw value from ``row``.
+
+        Args:
+            row: A mapping, dataclass instance, or attribute-bearing object.
+
+        Returns:
+            The raw cell value, or ``None`` when the key/attribute is missing.
+        """
+        if self.accessor is not None:
+            return self.accessor(row)
+        if isinstance(row, dict):
+            return row.get(self.name)
+        return getattr(row, self.name, None)
+
+    def resolve_text(self, value: Any) -> str:
+        """Format ``value`` into display text.
+
+        Args:
+            value: The raw cell value.
+
+        Returns:
+            Display text for the cell. Empty string when ``value`` is ``None``.
+        """
+        if value is None:
+            return ""
+        formatter = self.format
+        if formatter is None:
+            return str(value)
+        if isinstance(formatter, str):
+            return formatter.format(value)
+        return formatter(value)
+
+    def resolve_color(self, value: Any) -> Any:
+        """Resolve a possibly value-dependent foreground color.
+
+        Args:
+            value: The raw cell value.
+
+        Returns:
+            A color, or ``None`` when no color is configured.
+        """
+        color = self.color
+        if callable(color):
+            return color(value)
+        return color
+
+    def resolve_background(self, value: Any) -> Any:
+        """Resolve a possibly value-dependent background color.
+
+        Args:
+            value: The raw cell value.
+
+        Returns:
+            A color, or ``None`` when no background is configured.
+        """
+        background = self.background
+        if callable(background):
+            return background(value)
+        return background
+
+
+@dataclasses.dataclass
+class Series(ComponentDescriptor):
+    """Declares one series of a ``Chart``.
+
+    Attributes:
+        label: Legend label; ``None`` derives it from the attribute name.
+        color: Series color.
+        kind: Per-series plot kind, overriding the chart default.
+    """
+
+    label: str | None = None
+    color: ColorLike | None = None
+    kind: GraphTypeLike | None = None
+
+    if TYPE_CHECKING:
+        def __new__(cls, *args: Any, **kwargs: Any) -> Any: ...
+
+    def resolve_label(self) -> str:
+        """Return the legend label, deriving one from ``name`` when unset.
+
+        Returns:
+            The legend label for this series.
+        """
+        return self.label if self.label is not None else self.name
+
+
+class DeclarativeComponentMeta(abc.ABCMeta):
+    """Metaclass that captures ``ComponentDescriptor`` class attributes.
+
+    Descriptors declared on a component subclass are collected in declaration
+    order (across the MRO) into ``_declared`` and removed from the class body,
+    so instances never expose raw descriptor objects. Mirrors the way
+    ``xnano.beta.grid._GridMeta`` captures ``Field`` declarations.
+    """
+
+    _declared: dict[str, ComponentDescriptor]
+
+    def __new__(
+        mcs,
+        name: str,
+        bases: tuple[type, ...],
+        namespace: dict[str, Any],
+        **kwargs: Any,
+    ) -> DeclarativeComponentMeta:
+        declared: dict[str, ComponentDescriptor] = {}
+        for base in bases:
+            inherited = getattr(base, "_declared", None)
+            if inherited:
+                declared.update(inherited)
+        for key, value in list(namespace.items()):
+            if isinstance(value, ComponentDescriptor):
+                value.name = key
+                declared[key] = value
+                del namespace[key]
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        cls._declared = declared
+        return cls
+
+
+__all__ = (
+    "ColorResolver",
+    "FormatResolver",
+    "ComponentDescriptor",
+    "Column",
+    "Series",
+    "DeclarativeComponentMeta",
+)

--- a/xnano/beta/components/table.py
+++ b/xnano/beta/components/table.py
@@ -1,0 +1,198 @@
+"""xnano.beta.components.table"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Callable, ClassVar, TypeAlias, cast, TYPE_CHECKING
+
+from xnano.beta.components.abstract import AbstractComponent
+from xnano.beta.components.schema import (
+    Column,
+    ComponentDescriptor,
+    DeclarativeComponentMeta,
+)
+
+if TYPE_CHECKING:
+    from xnano.beta.color import ColorLike
+    from xnano.beta.components.abstract import ComponentRenderContext
+    from xnano.beta.core.nodes import AbstractRenderNode
+
+
+ColumnsArg: TypeAlias = (
+    "dict[str, Column | str | Callable[[Any], Any]] | list[str] | None"
+)
+"""Optional column overrides for the data-driven ``Table`` path."""
+
+
+@dataclasses.dataclass
+class Table(AbstractComponent, metaclass=DeclarativeComponentMeta):
+    """Declarative data table.
+
+    Feed it a list of rows — dicts, dataclasses, or arbitrary objects — and the
+    columns are derived for you. Selection is a single attribute (the native
+    table scrolls to keep it in view). For full control, subclass and declare
+    ``Column`` descriptors, the way a ``Grid`` declares ``Field``:
+
+        # data-driven — columns inferred from the dict keys
+        Table(data=[{"service": "api", "status": "ok", "latency": 12}])
+
+        # data-driven with per-column overrides, no subclass
+        Table(data=rows, columns={
+            "service": "Service",
+            "latency": Column(align="right", format="{}ms"),
+        })
+
+        # declarative subclass — reads like a schema
+        class Services(Table):
+            service: str = Column()
+            status:  str = Column(
+                color=lambda v: "green" if v == "ok" else "red")
+            latency: int = Column(align="right", format="{}ms")
+
+        Services(data=rows, selected=0)
+    """
+
+    data: list[Any] = dataclasses.field(default_factory=list)
+    """The rows — dicts, dataclasses, or objects with attributes."""
+    columns: ColumnsArg = None  # type: ignore[assignment]
+    """Optional column overrides for the data-driven path: a list of field
+    names (to select/order) or a mapping of name → ``Column`` / header string /
+    accessor. Ignored when the subclass declares ``Column`` descriptors."""
+    selected: int | None = None
+    """Highlighted row index; the native table scrolls to keep it visible."""
+    show_header: bool = True
+    """Whether to render the derived header row."""
+    column_spacing: int = 1
+    """Space between columns in terminal columns."""
+    highlight_color: ColorLike | None = None
+    """Selection foreground color."""
+    highlight_background: ColorLike | None = None
+    """Selection background color."""
+    highlight_symbol: str | None = None
+    """Glyph prepended to the selected row."""
+
+    _declared: ClassVar[dict[str, ComponentDescriptor]] = {}
+
+    # ── column resolution ────────────────────────────────────────────────
+
+    @staticmethod
+    def _named(name: str, **kwargs: Any) -> Column:
+        column = Column(**kwargs)
+        column.name = name
+        return column
+
+    def _columns_from_arg(self, columns: Any) -> list[Column]:
+        if isinstance(columns, dict):
+            result: list[Column] = []
+            for name, spec in columns.items():
+                if isinstance(spec, Column):
+                    # Copy so mutating ``.name`` does not touch a shared
+                    # descriptor instance the caller may reuse elsewhere.
+                    column = Column(
+                        header=spec.header,
+                        accessor=spec.accessor,
+                        format=spec.format,
+                        color=spec.color,
+                        background=spec.background,
+                        align=spec.align,
+                        width=spec.width,
+                    )
+                    column.name = name
+                    result.append(column)
+                elif isinstance(spec, str):
+                    result.append(self._named(name, header=spec))
+                elif callable(spec):
+                    result.append(self._named(name, accessor=spec))
+                else:
+                    result.append(self._named(name))
+            return result
+        return [self._named(name) for name in columns]
+
+    def _infer_columns(self) -> list[Column]:
+        if not self.data:
+            return []
+        first = self.data[0]
+        names: list[str]
+        if isinstance(first, dict):
+            names = [str(key) for key in first.keys()]
+        elif dataclasses.is_dataclass(first) and not isinstance(first, type):
+            names = [field.name for field in dataclasses.fields(first)]
+        elif hasattr(first, "__dict__"):
+            names = list(vars(first).keys())
+        else:
+            names = []
+        return [self._named(name) for name in names]
+
+    def _resolve_columns(self) -> list[Column]:
+        if self._declared:
+            return [
+                cast(Column, column) for column in self._declared.values()
+            ]
+        if self.columns is not None:
+            return self._columns_from_arg(self.columns)
+        return self._infer_columns()
+
+    @staticmethod
+    def _align_text(text: str, column: Column) -> str:
+        if column.align is None or not isinstance(column.width, int):
+            return text
+        width = column.width
+        if column.align == "right":
+            return text.rjust(width)
+        if column.align == "center":
+            return text.center(width)
+        return text.ljust(width)
+
+    # ── rendering ────────────────────────────────────────────────────────
+
+    def get_node(self, ctx: ComponentRenderContext) -> AbstractRenderNode:
+        from xnano.beta.core.nodes import (
+            TableCellItem,
+            TableNode,
+            TableRowItem,
+        )
+
+        columns = self._resolve_columns()
+
+        header: TableRowItem | None = None
+        if self.show_header and columns:
+            header = TableRowItem(
+                cells=[column.resolve_header() for column in columns]
+            )
+
+        rows: list[TableRowItem] = []
+        for item in self.data:
+            cells: list[TableCellItem | str] = []
+            for column in columns:
+                value = column.resolve_value(item)
+                text = self._align_text(column.resolve_text(value), column)
+                cells.append(
+                    TableCellItem(
+                        content=text,
+                        color=column.resolve_color(value),
+                        background=column.resolve_background(value),
+                    )
+                )
+            rows.append(TableRowItem(cells=cells))
+
+        column_widths: list[int | float] | None = None
+        if columns and all(column.width is not None for column in columns):
+            column_widths = [
+                cast(int | float, column.width) for column in columns
+            ]
+
+        return TableNode(
+            rows=rows,
+            header=header,
+            column_widths=column_widths,
+            column_spacing=self.column_spacing,
+            selected_row=self.selected,
+            highlight_color=self.highlight_color,
+            highlight_background=self.highlight_background,
+            highlight_symbol=self.highlight_symbol,
+            z=self.z,
+            visible=self.visible,
+        )
+
+
+__all__ = ("Table", "ColumnsArg")

--- a/xnano/beta/core/nodes.py
+++ b/xnano/beta/core/nodes.py
@@ -12,6 +12,8 @@ from xnano.beta.types import (
     CanvasMarkerLike,
     CharacterModifier,
     Direction,
+    GraphTypeLike,
+    LegendPositionLike,
     Padding,
     ScrollbarOrientationLike,
     Size,
@@ -589,6 +591,66 @@ class CanvasNode(AbstractRenderNode):
     visible: bool = True
 
 
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class ChartDataset:
+    """A single plotted series in a ``ChartNode``.
+
+    Attributes:
+        data: ``(x, y)`` sample points in logical coordinates.
+        name: Legend label for the series.
+        color: Series line/point color.
+        marker: Glyph set used to paint the series; ``None`` = ratatui default.
+        graph_type: How the series is plotted (line, scatter, or bar).
+    """
+
+    data: list[tuple[float, float]] = dataclasses.field(default_factory=list)
+    name: str | None = None
+    color: ColorLike | None = None
+    marker: CanvasMarkerLike | None = None
+    graph_type: GraphTypeLike = "line"
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class ChartAxis:
+    """An axis specification for a ``ChartNode``.
+
+    Attributes:
+        title: Axis title text.
+        bounds: Logical ``(min, max)`` range of the axis.
+        labels: Tick labels drawn along the axis.
+        color: Axis line + label color.
+    """
+
+    title: str | None = None
+    bounds: tuple[float, float] | None = None
+    labels: list[str] | None = None
+    color: ColorLike | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class ChartNode(AbstractRenderNode):
+    """A line/scatter/bar chart with axes and an optional legend.
+
+    Rendered through the native ratatui ``Chart`` widget (no ``CoreRenderIR``
+    representation), so it fills the slot it is placed in.
+
+    Attributes:
+        datasets: The plotted series.
+        x_axis: Optional x-axis specification.
+        y_axis: Optional y-axis specification.
+        color: Overall widget foreground style.
+        legend_position: Where the legend is drawn; ``None`` hides it.
+    """
+
+    datasets: list[ChartDataset] = dataclasses.field(default_factory=list)
+    x_axis: ChartAxis | None = None
+    y_axis: ChartAxis | None = None
+    color: ColorLike | None = None
+    legend_position: LegendPositionLike | None = "top_right"
+    z: int = 0
+    visible: bool = True
+
+
 class NodeAssembler:
     """Assembles ``xnano.beta.core.nodes.AbstractRenderNode`` trees into ratatui
     native widgets through ``xnano-core``.
@@ -1122,6 +1184,94 @@ class NodeAssembler:
             session.render_native(native_rect, spark, z=effective_z)
             return
 
+        # Chart: native path (CoreRenderIR has no chart representation).
+        if isinstance(node, ChartNode):
+            from xnano_core.rust import native
+
+            graph_types = {
+                "scatter": native.GraphType.Scatter,
+                "line": native.GraphType.Line,
+                "bar": native.GraphType.Bar,
+            }
+            markers = {
+                "dot": native.Marker.Dot,
+                "block": native.Marker.Block,
+                "bar": native.Marker.Bar,
+                "braille": native.Marker.Braille,
+                "half_block": native.Marker.HalfBlock,
+            }
+            legend_positions = {
+                "top": native.LegendPosition.Top,
+                "top_right": native.LegendPosition.TopRight,
+                "top_left": native.LegendPosition.TopLeft,
+                "left": native.LegendPosition.Left,
+                "right": native.LegendPosition.Right,
+                "bottom": native.LegendPosition.Bottom,
+                "bottom_right": native.LegendPosition.BottomRight,
+                "bottom_left": native.LegendPosition.BottomLeft,
+            }
+
+            def _build_axis(spec: "ChartAxis") -> Any:
+                axis = native.Axis.default()
+                if spec.title is not None:
+                    axis = axis.title(spec.title)
+                if spec.bounds is not None:
+                    axis = axis.bounds(spec.bounds)
+                if spec.labels is not None:
+                    axis = axis.labels(spec.labels)
+                if spec.color is not None:
+                    style = native_types.get_native_style_from_kwargs(
+                        color=spec.color
+                    )
+                    if style is not None:
+                        axis = axis.style(style)
+                return axis
+
+            datasets: list[Any] = []
+            for dataset in node.datasets:
+                native_dataset = native.Dataset.default().data(dataset.data)
+                if dataset.name is not None:
+                    native_dataset = native_dataset.name(dataset.name)
+                native_dataset = native_dataset.graph_type(
+                    graph_types.get(dataset.graph_type, native.GraphType.Line)
+                )
+                if dataset.marker is not None:
+                    native_dataset = native_dataset.marker(
+                        markers.get(dataset.marker, native.Marker.Braille)
+                    )
+                series_color = (
+                    dataset.color if dataset.color is not None else node.color
+                )
+                if series_color is not None:
+                    style = native_types.get_native_style_from_kwargs(
+                        color=series_color
+                    )
+                    if style is not None:
+                        native_dataset = native_dataset.style(style)
+                datasets.append(native_dataset)
+
+            chart = native.Chart.new(datasets)
+            if node.x_axis is not None:
+                chart = chart.x_axis(_build_axis(node.x_axis))
+            if node.y_axis is not None:
+                chart = chart.y_axis(_build_axis(node.y_axis))
+            if node.color is not None:
+                style = native_types.get_native_style_from_kwargs(
+                    color=node.color
+                )
+                if style is not None:
+                    chart = chart.style(style)
+            if node.legend_position is None:
+                chart = chart.legend_position(None)
+            else:
+                chart = chart.legend_position(
+                    legend_positions.get(
+                        node.legend_position, native.LegendPosition.TopRight
+                    )
+                )
+            session.render_native(native_rect, chart, z=effective_z)
+            return
+
         # Leaf nodes → single CoreRenderIR construction + enqueue.
         ir = cls._build_leaf_ir(node)
         if ir is not None:
@@ -1149,6 +1299,7 @@ RenderNode: TypeAlias = (
     | ScrollbarNode
     | TabsNode
     | CanvasNode
+    | ChartNode
 )
 """Collective alias for all render node types."""
 
@@ -1173,6 +1324,9 @@ __all__ = (
     "ScrollbarNode",
     "TabsNode",
     "CanvasNode",
+    "ChartDataset",
+    "ChartAxis",
+    "ChartNode",
     "RenderNode",
     "NodeAssembler",
 )

--- a/xnano/beta/types.py
+++ b/xnano/beta/types.py
@@ -150,6 +150,29 @@ Values:
 """
 
 
+GraphTypeLike: TypeAlias = Literal["line", "scatter", "bar"]
+"""How a ``Chart`` dataset is plotted.
+
+Values:
+    ``"line"``: Connect points with lines.
+    ``"scatter"``: Draw points without connecting lines.
+    ``"bar"``: Draw each point as a vertical bar.
+"""
+
+
+LegendPositionLike: TypeAlias = Literal[
+    "top",
+    "top_right",
+    "top_left",
+    "left",
+    "right",
+    "bottom",
+    "bottom_right",
+    "bottom_left",
+]
+"""Placement of a ``Chart``'s legend within its area."""
+
+
 Side: TypeAlias = Literal["top", "bottom", "left", "right"]
 """A single side of a of a rectangular grid area within the
 main terminal grid.
@@ -433,6 +456,8 @@ __all__ = (
     "PaddingLike",
     "ScrollbarOrientationLike",
     "CanvasMarkerLike",
+    "GraphTypeLike",
+    "LegendPositionLike",
     "Side",
     "SizePercentage",
     "Flex",


### PR DESCRIPTION
## Summary
- Adds `Table`, `Chart`, and `Progress` — declarative components each usable data-driven (zero subclass, columns/series inferred) or via a schema subclass (`Column`/`Series` descriptors), mirroring how `Grid` captures `Field` declarations
- Adds `components/schema.py`: the shared `ComponentDescriptor`/`DeclarativeComponentMeta` infra behind `Table`/`Chart` (named for what it is — descriptor capture — rather than reusing "declarative," which is this whole package's design ethos, not one mechanism)
- Adds `ChartNode`/`ChartAxis`/`ChartDataset` render nodes (native ratatui `Chart` widget path)
- Adds an end-to-end usage-scenario suite exercising focus + input + hooks + these components together — this is why the branch stacks on `fix(state-updates)` rather than `main`

## Base branch
Stacked on `fix(state-updates)` (#14) since `test_usage_scenarios.py` needs both `on_field`/`on_poll` hooks and these components. Should merge after that PR.

## Test plan
- [x] `uv run pytest -q` — all passing
- [x] `uv run prek run --all-files` — lint + format clean