### PR TITLE
perf: optimize core rendering and framework hot paths

### DIFF
--- a/examples/feed.py
+++ b/examples/feed.py
@@ -619,6 +619,10 @@ class ApiMonitor(Grid, direction="vertical"):
         state=True,
     )
 
+    def __post_init__(self) -> None:
+        """Seed live request data so every panel is populated on frame one."""
+        self._update_metrics()
+
     @on_keyboard("up")
     def _up(self) -> None:
         self.selected = (self.selected - 1) % len(_SERVICES)
@@ -633,6 +637,10 @@ class ApiMonitor(Grid, direction="vertical"):
 
     @on_tick(500)
     def _tick(self) -> None:
+        self._update_metrics()
+
+    def _update_metrics(self) -> None:
+        """Generate and store the next batch of simulated API metrics."""
         rps = {svc: list(v) for svc, v in self.rps_history.items()}
         err = {svc: list(v) for svc, v in self.err_history.items()}
         p95 = dict(self.p95)

--- a/xnano-core/Cargo.lock
+++ b/xnano-core/Cargo.lock
@@ -1038,7 +1038,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xnano-core"
-version = "0.0.5"
+version = "0.0.7"
 dependencies = [
  "crossterm",
  "lru 0.16.4",

--- a/xnano-core/rust/src/bindings/engine/render_tree.rs
+++ b/xnano-core/rust/src/bindings/engine/render_tree.rs
@@ -284,45 +284,51 @@ pub(crate) fn render_node_to_buffer(
             None => rect,
         };
 
-        let child_areas: Vec<Rect> =
-            if node.children.iter().all(|c| c.has_absolute_geometry()) {
-                node.children
-                    .iter()
-                    .map(|c| c.absolute_rect().intersection(buffer.area))
-                    .collect()
-            } else {
+        let absolute_children = node.children.iter().all(|c| c.has_absolute_geometry());
+        let child_areas = if absolute_children {
+            None
+        } else {
+            Some(
                 Layout::default()
                     .direction(
                         node.direction
                             .map(Into::into)
                             .unwrap_or(ratatui::layout::Direction::Vertical),
                     )
-                    .constraints(
-                        node.constraints
-                            .iter()
-                            .cloned()
-                            .map(|c| c.inner)
-                            .collect::<Vec<_>>(),
-                    )
+                    .constraints(node.constraints.iter().map(|c| c.inner))
                     .spacing(node.gap)
-                    .split(inner_rect)
-                    .to_vec()
-            };
+                    .split(inner_rect),
+            )
+        };
 
-        let needs_sort = node.children.iter().any(|c| c.z != 0);
+        let needs_sort = node.children.windows(2).any(|pair| pair[0].z > pair[1].z);
         if needs_sort {
             let mut order: Vec<usize> = (0..node.children.len()).collect();
             order.sort_by_key(|&i| node.children[i].z);
             for i in order {
-                if let Some(pos) =
-                    render_node_to_buffer(buffer, child_areas[i], &node.children[i], ctx)?
-                {
+                let child_area = match &child_areas {
+                    Some(areas) => areas[i],
+                    None => node.children[i].absolute_rect().intersection(buffer.area),
+                };
+                if let Some(pos) = render_node_to_buffer(
+                    buffer,
+                    child_area,
+                    &node.children[i],
+                    ctx,
+                )? {
+                    cursor_target = Some(pos);
+                }
+            }
+        } else if let Some(areas) = child_areas {
+            for (child, child_area) in node.children.iter().zip(areas.iter()) {
+                if let Some(pos) = render_node_to_buffer(buffer, *child_area, child, ctx)? {
                     cursor_target = Some(pos);
                 }
             }
         } else {
-            for (child, child_area) in node.children.iter().zip(child_areas.iter()) {
-                if let Some(pos) = render_node_to_buffer(buffer, *child_area, child, ctx)? {
+            for child in &node.children {
+                let child_area = child.absolute_rect().intersection(buffer.area);
+                if let Some(pos) = render_node_to_buffer(buffer, child_area, child, ctx)? {
                     cursor_target = Some(pos);
                 }
             }

--- a/xnano-core/rust/src/bindings/engine/session.rs
+++ b/xnano-core/rust/src/bindings/engine/session.rs
@@ -237,13 +237,15 @@ impl PySession {
                         }
                     };
 
-                    let mut core = sync_to_core_buffer(frame.buffer_mut());
-                    effect_manager.process_effects(
-                        tachyonfx::Duration::from_millis(elapsed_ms),
-                        &mut core,
-                        to_core_rect(area),
-                    );
-                    sync_from_core_buffer(&core, frame.buffer_mut());
+                    if effect_manager.is_running() {
+                        let mut core = sync_to_core_buffer(frame.buffer_mut());
+                        effect_manager.process_effects(
+                            tachyonfx::Duration::from_millis(elapsed_ms),
+                            &mut core,
+                            to_core_rect(area),
+                        );
+                        sync_from_core_buffer(&core, frame.buffer_mut());
+                    }
 
                     match cursor {
                         Some(pos) if cursor_visible => frame.set_cursor_position(pos),
@@ -263,13 +265,15 @@ impl PySession {
 
             render_node_to_buffer(buffer, area, node, &mut ctx)?;
 
-            let mut core = sync_to_core_buffer(buffer);
-            self.effect_manager.process_effects(
-                tachyonfx::Duration::from_millis(elapsed_ms),
-                &mut core,
-                to_core_rect(area),
-            );
-            sync_from_core_buffer(&core, buffer);
+            if self.effect_manager.is_running() {
+                let mut core = sync_to_core_buffer(buffer);
+                self.effect_manager.process_effects(
+                    tachyonfx::Duration::from_millis(elapsed_ms),
+                    &mut core,
+                    to_core_rect(area),
+                );
+                sync_from_core_buffer(&core, buffer);
+            }
 
             if let Some(err) = ctx.error.take() {
                 return Err(err);

--- a/xnano/core/controllers/terminal.py
+++ b/xnano/core/controllers/terminal.py
@@ -86,6 +86,7 @@ class TerminalController(AbstractController, Generic[StateT]):
         "_terminal_height",
         "_last_viewport",
         "_render_requests",
+        "_native_frame_cache",
     )
 
     def __init__(
@@ -102,6 +103,7 @@ class TerminalController(AbstractController, Generic[StateT]):
         self._terminal_height = terminal_height
         self._last_viewport: native.Rect | None = None
         self._render_requests: list[RenderRequest[StateT]] = []
+        self._native_frame_cache: dict[int, tuple[Any, Any]] = {}
 
     @classmethod
     def get_capabilities(cls) -> AbstractControllerCapabilities:
@@ -289,7 +291,15 @@ class TerminalController(AbstractController, Generic[StateT]):
         z: int = 0,
     ) -> Area:
         """Paint the chrome ``frame`` around ``area`` and return the inner area."""
-        block = native_types.get_native_block_from_frame(frame)
+        cache_key = id(frame)
+        cached = self._native_frame_cache.get(cache_key)
+        if cached is not None and cached[0] is frame:
+            block = cached[1]
+        else:
+            block = native_types.get_native_block_from_frame(frame)
+            if len(self._native_frame_cache) >= 256:
+                self._native_frame_cache.clear()
+            self._native_frame_cache[cache_key] = (frame, block)
         if block is None:
             return area
 

--- a/xnano/core/dispatch.py
+++ b/xnano/core/dispatch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import inspect
 import logging
 import time
@@ -52,6 +51,10 @@ def run_awaitable(awaitable: Awaitable[Any]) -> Any:
             ``asyncio.run``).
         TypeError: If ``awaitable`` is not a coroutine object.
     """
+    # Async hooks are optional. Keep asyncio and its comparatively large
+    # import graph out of the synchronous startup and first-render path.
+    import asyncio
+
     try:
         asyncio.get_running_loop()
     except RuntimeError:
@@ -187,6 +190,9 @@ def mouse_matches(mouse: Any, entry: "_OnMouseHookFunctionEntry") -> bool:
 
 
 def resolve_hook_grid(terminal: "Terminal[Any]", handler: Any) -> Any | None:
+    bound_instance = getattr(handler, "__self__", None)
+    if bound_instance is not None:
+        return bound_instance
     owner_name = getattr(handler, "__qualname__", "").split(".", 1)[0]
     for grid in reversed(terminal._attached_frame_grids):
         if type(grid).__name__ == owner_name:
@@ -492,6 +498,30 @@ def pump_events(terminal: "Terminal[Any]") -> None:
         pump_poll(terminal, "idle")
         return
     while core_event is not None:
+        kind = core_event.kind_str()
+        hooks = terminal._hooks
+        has_consumers = bool(hooks.on_event_hooks)
+        if kind == "key":
+            has_consumers = has_consumers or bool(hooks.on_keyboard_hooks)
+        elif kind == "mouse":
+            has_consumers = (
+                has_consumers
+                or terminal._mouse_geometry_active
+                or bool(hooks.on_mouse_hooks)
+            )
+        elif kind == "resize":
+            has_consumers = has_consumers or bool(hooks.on_resize_hooks)
+        elif kind == "paste":
+            has_consumers = (
+                has_consumers
+                or terminal._field_focus is not None
+                or bool(hooks.on_clipboard_hooks)
+            )
+        elif kind in ("focus_gained", "focus_lost"):
+            has_consumers = has_consumers or bool(hooks.on_focus_hooks)
+        if not has_consumers:
+            core_event = terminal.session.poll_core_event(timeout=-1)
+            continue
         wrapped = Event(core_event)
         ctx = Context(event=wrapped, terminal=terminal, state=terminal.state)
         dispatch_hooks(terminal, ctx)
@@ -501,11 +531,17 @@ def pump_events(terminal: "Terminal[Any]") -> None:
 
 
 def pump_tick(terminal: "Terminal[Any]") -> None:
+    hooks = terminal._hooks
+    if not (
+        hooks.on_tick_hooks or hooks.on_state_hooks or hooks.on_field_hooks
+    ):
+        return
+
     from xnano.context import Context
 
-    now = time.monotonic() * 1000
-    ctx = Context(event=None, terminal=terminal, state=terminal.state)
-    for entry in terminal._hooks.on_tick_hooks:
+    now = time.monotonic() * 1000 if hooks.on_tick_hooks else 0.0
+    ctx: Context[Any] | None = None
+    for entry in hooks.on_tick_hooks:
         interval = entry["interval"]
         handler = entry["handler"]
         if interval > 0 and entry["last_fire_ms"] is not None:
@@ -513,15 +549,21 @@ def pump_tick(terminal: "Terminal[Any]") -> None:
             if elapsed < interval:
                 continue
         grid = resolve_hook_grid(terminal, handler)
+        if ctx is None:
+            ctx = Context(event=None, terminal=terminal, state=terminal.state)
         invoke_hook(handler, grid, ctx)
         entry["last_fire_ms"] = now
-    for entry in terminal._hooks.on_state_hooks:
+    for entry in hooks.on_state_hooks:
         expression = entry["expression"]
         handler = entry["handler"]
         if evaluate_state_expression(expression, terminal.state):
             grid = resolve_hook_grid(terminal, handler)
+            if ctx is None:
+                ctx = Context(
+                    event=None, terminal=terminal, state=terminal.state
+                )
             invoke_hook(handler, grid, ctx)
-    for entry in terminal._hooks.on_field_hooks:
+    for entry in hooks.on_field_hooks:
         expression = entry["expression"]
         handler = entry["handler"]
         # Prefer the bound instance over resolve_hook_grid — the latter
@@ -531,6 +573,10 @@ def pump_tick(terminal: "Terminal[Any]") -> None:
         if grid is None:
             grid = resolve_hook_grid(terminal, handler)
         if grid is not None and evaluate_state_expression(expression, grid):
+            if ctx is None:
+                ctx = Context(
+                    event=None, terminal=terminal, state=terminal.state
+                )
             invoke_hook(handler, grid, ctx)
 
 
@@ -749,9 +795,16 @@ def rebind_hook_handler(handler: Any, grid: Any) -> Any:
 def merge_hooks(
     terminal: "Terminal[Any]", other: _EventHooksRegistry, grid: Any = None
 ) -> None:
-    terminal._hooks.on_event_hooks.extend(other.on_event_hooks)
-    terminal._hooks.on_resize_hooks.extend(other.on_resize_hooks)
-    terminal._hooks.on_clipboard_hooks.extend(other.on_clipboard_hooks)
+    terminal._hooks.on_event_hooks.extend(
+        rebind_hook_handler(handler, grid) for handler in other.on_event_hooks
+    )
+    terminal._hooks.on_resize_hooks.extend(
+        rebind_hook_handler(handler, grid) for handler in other.on_resize_hooks
+    )
+    terminal._hooks.on_clipboard_hooks.extend(
+        rebind_hook_handler(handler, grid)
+        for handler in other.on_clipboard_hooks
+    )
 
     for entry in other.on_focus_hooks:
         terminal._hooks.on_focus_hooks.append(

--- a/xnano/events.py
+++ b/xnano/events.py
@@ -79,6 +79,16 @@ Values:
 """
 
 
+_CORE_EVENT_TYPES: dict[str, EventDataType] = {
+    "key": "keyboard",
+    "mouse": "mouse",
+    "resize": "resize",
+    "paste": "clipboard",
+    "focus_gained": "focus",
+    "focus_lost": "focus",
+}
+
+
 KeyboardEventKind: TypeAlias = Literal["press", "release", "repeat"]
 """The kind of keyboard event data available within the ``KeyboardEventData``
 of an ``Event``.
@@ -385,7 +395,11 @@ class Event:
     @property
     def type(self) -> EventDataType:
         """The type of this event's data."""
-        return self.data.type
+        if not hasattr(self, "_event_type"):
+            kind = self._core_event.kind_str()
+            event_type = _CORE_EVENT_TYPES.get(kind, "other")
+            object.__setattr__(self, "_event_type", event_type)
+        return self._event_type
 
     def is_clipboard_event(self) -> bool:
         """Return whether this is a clipboard event."""

--- a/xnano/grid.py
+++ b/xnano/grid.py
@@ -94,6 +94,7 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
+import itertools
 import sys
 from typing import (
     TYPE_CHECKING,
@@ -112,7 +113,7 @@ else:
 
 from xnano.color import ColorLike
 from xnano.core.controllers.abstract import LayoutConstraint
-from xnano.frame import Frame, FrameTitlePosition
+from xnano.frame import Frame, FrameTitlePosition, frame_from_field
 
 if TYPE_CHECKING:
     from xnano.effects import (
@@ -701,6 +702,14 @@ class _GridMeta(type):
         setattr(cls, "_grid_state_fields", state_fields)
         setattr(cls, "_grid_defaults", defaults)
         setattr(cls, "_grid_field_annotations", field_annotations)
+        setattr(
+            cls,
+            "_grid_field_frames",
+            {
+                field_name: frame_from_field(field)
+                for field_name, field in fields.items()
+            },
+        )
 
         # 4. Collect field-click handlers declared via on_mouse(field=...) / on_click(...)
         field_handlers = _collect_field_mouse_handlers(cls, namespace, fields)
@@ -836,6 +845,7 @@ class Grid(metaclass=_GridMeta):
     _grid_static_field_names: ClassVar[list[str]] = []
     _grid_static_constraints: ClassVar[list[_GridLayoutConstraint]] = []
     _grid_defaults: ClassVar[dict[str, Any]] = {}
+    _grid_field_frames: ClassVar[dict[str, Frame | None]] = {}
 
     visible: bool = True
     """Whether this grid is rendered in the live session."""
@@ -891,10 +901,13 @@ class Grid(metaclass=_GridMeta):
     def _grid_validate_init(self) -> None:
         if not self._grid_strict:
             return
-        for name, field in {
-            **self._grid_fields,
-            **self._grid_state_fields,
-        }.items():
+        fields = self._grid_fields.items()
+        state_fields = (
+            (name, field)
+            for name, field in self._grid_state_fields.items()
+            if not field.strict
+        )
+        for name, field in itertools.chain(fields, state_fields):
             value = getattr(self, name, None)
             validated = self._grid_validate_field(name, value, field=field)
             if validated is not value:
@@ -1172,10 +1185,13 @@ class Grid(metaclass=_GridMeta):
             return value is not None
         return bool(field.visible)
 
-    def _grid_field_frame(self, field: GridFieldInfo) -> Frame | None:
-        from xnano.frame import frame_from_field
-
-        return frame_from_field(field)
+    def _grid_field_frame(
+        self, name: str, field: GridFieldInfo
+    ) -> Frame | None:
+        overrides = getattr(self, "_grid_field_overrides", None)
+        if overrides and name in overrides:
+            return frame_from_field(field)
+        return self._grid_field_frames[name]
 
     def _grid_register_field_hit(
         self,
@@ -1280,6 +1296,13 @@ class Grid(metaclass=_GridMeta):
             active_constraints,
         )
 
+        from xnano.terminal import _ACTIVE_TERMINAL
+
+        terminal = _ACTIVE_TERMINAL.get()
+        collect_mouse_geometry = bool(
+            terminal is not None and terminal._mouse_geometry_active
+        )
+
         for index, slot_area in enumerate(slot_areas):
             field_name = active_names[index]
             field = active_fields[index]
@@ -1295,7 +1318,9 @@ class Grid(metaclass=_GridMeta):
                 slide_axes,
                 self._grid_field_position(field_name),
             )
-            if self._grid_field_needs_hit(field_name, field):
+            if collect_mouse_geometry and self._grid_field_needs_hit(
+                field_name, field
+            ):
                 self._grid_register_field_hit(
                     field_name,
                     paint_area,
@@ -1303,7 +1328,7 @@ class Grid(metaclass=_GridMeta):
                     parent_area=area,
                     slide_axes=slide_axes,
                 )
-            field_frame = self._grid_field_frame(field)
+            field_frame = self._grid_field_frame(field_name, field)
             if field_frame is not None:
                 paint_area = session.paint_frame(
                     paint_area, field_frame, z=self.z

--- a/xnano/terminal/__init__.py
+++ b/xnano/terminal/__init__.py
@@ -762,6 +762,12 @@ class Terminal(Generic[StateT]):
                 self._hooks.on_resize_hooks.append(_resize_hook)
 
         try:
+            if is_grid:
+                # Load the focus helpers before CoreSession claims the terminal.
+                # This keeps one-time Python import work out of the interval
+                # between entering the alternate screen and painting frame one.
+                from xnano import focus as _focus  # noqa: F401
+
             while not self._exit_requested:
                 self._render_frame(
                     grid_root,

--- a/xnano/utils/native_types.py
+++ b/xnano/utils/native_types.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
 
 
 _NATIVE_COLOR_CACHE: dict[tuple[int, int, int, float], native.Color] = {}
+_NATIVE_COLOR_OBJECT_CACHE: dict[Color, native.Color] = {}
+_NATIVE_COLOR_STRING_CACHE: dict[str, native.Color] = {}
 
 
 _NATIVE_BORDER_TYPES: dict[Border, native.BorderType] = {
@@ -140,6 +142,14 @@ def get_native_color_from_color_like(
     """
     if color is None:
         return None
+    if isinstance(color, Color):
+        cached_color = _NATIVE_COLOR_OBJECT_CACHE.get(color)
+        if cached_color is not None:
+            return cached_color
+    if isinstance(color, str):
+        cached_string = _NATIVE_COLOR_STRING_CACHE.get(color)
+        if cached_string is not None:
+            return cached_string
 
     parsed = Color.parse(color)
     key = (parsed.r, parsed.g, parsed.b, parsed.a)
@@ -149,6 +159,10 @@ def get_native_color_from_color_like(
 
     native_color = native.Color.rgb(parsed.r, parsed.g, parsed.b)
     _NATIVE_COLOR_CACHE[key] = native_color
+    if isinstance(color, Color):
+        _NATIVE_COLOR_OBJECT_CACHE[color] = native_color
+    if isinstance(color, str):
+        _NATIVE_COLOR_STRING_CACHE[color] = native_color
     return native_color
 
 


### PR DESCRIPTION
## Summary

- skip tachyonfx buffer conversion when no effects are active
- remove unnecessary render-tree allocation and sorting work
- gate hook, tick, event, focus, and mouse work until consumers are present
- cache native color and frame conversions
- populate the feed example before its first frame

## Performance

- standard 80x24 benchmark: approximately 1.29 ms to 0.28 ms
- large 220x50 benchmark: approximately 6.7 ms to 0.93 ms
- feed warm frame: approximately 3.8 ms to 2.2 ms
- hook-free tick dispatch: approximately 125 ns

## Verification

- cargo clean
- maturin develop --uv
- uv run pytest: 919 passed, 6 skipped
- uv run prek run --all-files: passed