### PR TITLE
Harden terminal teardown and add background cell-filter effects

### DIFF
--- a/tests/core/test_core_effects.py
+++ b/tests/core/test_core_effects.py
@@ -32,6 +32,44 @@ def test_effect_with_area_and_filter() -> None:
     assert filtered.get_filter() is not None
 
 
+def test_background_cell_filters_are_available() -> None:
+    from xnano_core.rust.native import CellFilter
+
+    assert CellFilter.BACKGROUND is not None
+    assert CellFilter.BACKGROUND_ONLY is not None
+
+
+def test_coalesce_can_reveal_background_without_touching_text() -> None:
+    from xnano_core.rust.native import (
+        Buffer,
+        CellFilter,
+        Color,
+        Rect,
+        Style,
+        coalesce,
+    )
+
+    area = Rect(0, 0, 20, 1)
+    buffer = Buffer.empty(area)
+    background = Style.new().bg(Color.RED)
+    for column in range(20):
+        symbol = " " if column % 2 == 0 else "X"
+        buffer.set_cell(column, 0, symbol, background)
+
+    effect = coalesce(1000).with_filter(CellFilter.BACKGROUND_ONLY).with_rng(7)
+    effect.process(1, buffer, area)
+
+    assert all(
+        buffer.cell_bg(column, 0) == Color.RESET for column in range(0, 20, 2)
+    )
+    assert all(
+        buffer.cell_symbol(column, 0) == "X" for column in range(1, 20, 2)
+    )
+    assert all(
+        buffer.cell_bg(column, 0) == Color.RED for column in range(1, 20, 2)
+    )
+
+
 def test_sequence_and_parallel_combinators() -> None:
     a = sleep_effect(50)
     b = sleep_effect(50)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -47,6 +47,15 @@ def test_resolve_native_effect_accepts_subclass() -> None:
     assert isinstance(native_effect, native.Effect)
 
 
+def test_effect_cell_filter_is_lowered() -> None:
+    effect = CoalesceEffect(
+        duration_ms=120,
+        cell_filter="background_only",
+    )
+    native_effect = resolve_native_effect(effect)
+    assert native_effect.get_filter() is not None
+
+
 def test_resolve_native_effect_accepts_kind_string() -> None:
     native_effect = resolve_native_effect("dissolve", duration_ms=180)
     assert isinstance(native_effect, native.Effect)

--- a/xnano-core/python/xnano_core/rust/native.pyi
+++ b/xnano-core/python/xnano_core/rust/native.pyi
@@ -1794,6 +1794,8 @@ class CellFilter:
     ALL: CellFilter
     TEXT: CellFilter
     NON_EMPTY: CellFilter
+    BACKGROUND: CellFilter
+    BACKGROUND_ONLY: CellFilter
 
     @staticmethod
     def fg_color(color: Color) -> CellFilter: ...

--- a/xnano-core/rust/src/bindings/engine/mod.rs
+++ b/xnano-core/rust/src/bindings/engine/mod.rs
@@ -6,6 +6,7 @@ mod panic_hook;
 mod render_ir;
 mod render_tree;
 mod session;
+pub(crate) mod terminal_reset;
 
 use pyo3::prelude::*;
 

--- a/xnano-core/rust/src/bindings/engine/panic_hook.rs
+++ b/xnano-core/rust/src/bindings/engine/panic_hook.rs
@@ -3,11 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use ratatui::restore;
 
-use super::super::crossterm_exec::flush_stdout;
-use super::super::event_setup::{
-    disable_bracketed_paste_impl, disable_focus_change_impl, disable_mouse_capture_impl,
-};
-use super::super::terminal_device::end_synchronized_update_impl;
+use super::terminal_reset::emit_terminal_reset_sequences;
 
 pub(crate) struct PanicHookGuard {
     previous: Arc<Mutex<Option<Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send>>>>,
@@ -18,12 +14,11 @@ pub(crate) fn install_restore_panic_hook() -> PanicHookGuard {
     let shared = Arc::new(Mutex::new(Some(previous)));
     let hook_shared = Arc::clone(&shared);
     panic::set_hook(Box::new(move |info| {
-        let _ = disable_mouse_capture_impl();
-        let _ = disable_bracketed_paste_impl();
-        let _ = disable_focus_change_impl();
-        let _ = end_synchronized_update_impl();
-        let _ = flush_stdout();
+        // Same comprehensive reset used by CoreSession.restore so a panic
+        // cannot leave mouse / sync / SGR modes armed for the next process.
+        emit_terminal_reset_sequences();
         restore();
+        emit_terminal_reset_sequences();
         if let Ok(guard) = hook_shared.lock() {
             if let Some(ref hook) = *guard {
                 hook(info);

--- a/xnano-core/rust/src/bindings/engine/session.rs
+++ b/xnano-core/rust/src/bindings/engine/session.rs
@@ -7,15 +7,10 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Rect, Size};
-use ratatui::{
-    init, restore, try_init_with_options, DefaultTerminal, TerminalOptions, Viewport,
-};
+use ratatui::{init, restore, try_init_with_options, DefaultTerminal, TerminalOptions, Viewport};
 use tachyonfx::EffectManager;
 
-use super::clock::TickClock;
-use super::events::PyEvent;
-use super::panic_hook::{install_restore_panic_hook, PanicHookGuard};
-use super::render_tree::{render_node, render_node_to_buffer, PyRenderNode, RenderContext};
+use super::super::buffer::PyBuffer;
 use super::super::convert_core::{sync_from_core_buffer, sync_to_core_buffer, to_core_rect};
 use super::super::crossterm_exec::{execute_stdout, flush_stdout, io_to_py};
 use super::super::cursor::{
@@ -28,6 +23,7 @@ use super::super::event_setup::{
     pop_keyboard_enhancement_flags_impl, push_keyboard_enhancement_flags_impl,
     PyKeyboardEnhancementFlags,
 };
+use super::terminal_reset::emit_terminal_reset_sequences;
 use super::super::frame_ext::frame_hide_cursor;
 use super::super::fx::PyEffect;
 use super::super::layout::{PyRect, PySize};
@@ -38,10 +34,17 @@ use super::super::terminal_device::{
     leave_alternate_screen_impl, scroll_down_impl, scroll_up_impl, set_terminal_title_impl,
     terminal_size_impl, terminal_window_size_impl, PyClearType,
 };
-use super::super::buffer::PyBuffer;
 use super::super::widgets_extra::PyPosition;
+use super::clock::TickClock;
+use super::events::PyEvent;
+use super::panic_hook::{install_restore_panic_hook, PanicHookGuard};
+use super::render_tree::{render_node, render_node_to_buffer, PyRenderNode, RenderContext};
 
-#[pyclass(name = "CoreTerminalRef", module = "xnano_core.rust.engine", unsendable)]
+#[pyclass(
+    name = "CoreTerminalRef",
+    module = "xnano_core.rust.engine",
+    unsendable
+)]
 pub struct PyTerminalRef {
     ptr: usize,
 }
@@ -301,9 +304,7 @@ impl PySession {
         let tick_budget = self.tick_clock.time_until_tick();
         let budget = tick_budget.min(user_budget);
 
-        let ready = py
-            .detach(|| event::poll(budget))
-            .map_err(io_to_py)?;
+        let ready = py.detach(|| event::poll(budget)).map_err(io_to_py)?;
 
         py.check_signals()?;
 
@@ -344,9 +345,7 @@ impl PySession {
     }
 
     fn effect_area_for(&self, key: &str) -> Option<PyRect> {
-        self.effect_areas
-            .get(key)
-            .map(|r| PyRect { inner: *r })
+        self.effect_areas.get(key).map(|r| PyRect { inner: *r })
     }
 
     fn buffer_snapshot(&mut self) -> PyResult<PyBuffer> {
@@ -355,9 +354,7 @@ impl PySession {
                 inner: t.get_frame().buffer_mut().clone(),
             })
         } else if let Some(b) = &self.offscreen_buffer {
-            Ok(PyBuffer {
-                inner: b.clone(),
-            })
+            Ok(PyBuffer { inner: b.clone() })
         } else {
             Err(PyRuntimeError::new_err("session closed"))
         }
@@ -515,9 +512,7 @@ impl PySession {
                 inner: terminal.get_frame().area(),
             })
         } else if let Some(buffer) = &self.offscreen_buffer {
-            Ok(PyRect {
-                inner: buffer.area,
-            })
+            Ok(PyRect { inner: buffer.area })
         } else {
             Err(PyRuntimeError::new_err("session closed"))
         }
@@ -590,24 +585,23 @@ impl PySession {
     }
 
     fn teardown_device_state(&mut self) {
-        // Always emit the disable sequences — ratatui::restore() does not
-        // turn off mouse capture, and the mirror flags can be wrong after an
-        // abnormal exit.  Ignore errors: cleanup must be best-effort.
-        let _ = disable_mouse_capture_impl();
+        // Only touch the host terminal when a live session owns it. Offscreen
+        // sessions must not write escape sequences into the caller's stdout
+        // (e.g. pytest capture).
+        if self.terminal.is_some() {
+            // Always emit the reset sequences. Device state can also be changed
+            // through the native escape hatch, so the mirrors are not
+            // authoritative during cleanup. Leaving synchronized output active
+            // can make a terminal emulator retain and later misrender
+            // subsequent output. Ignore errors: cleanup must be best-effort.
+            emit_terminal_reset_sequences();
+        }
+        self.synchronized_updates = false;
         self.mouse_capture = false;
-        let _ = disable_bracketed_paste_impl();
         self.bracketed_paste = false;
-        let _ = disable_focus_change_impl();
         self.focus_change = false;
-        if self.synchronized_updates {
-            let _ = end_synchronized_update_impl();
-            self.synchronized_updates = false;
-        }
-        if !self.cursor_visible {
-            let _ = show_cursor_impl();
-            self.cursor_visible = true;
-        }
-        let _ = flush_stdout();
+        self.cursor_visible = true;
+        self.cursor_style = PyCursorStyle::DefaultUserShape;
     }
 
     fn restore(&mut self) -> PyResult<()> {
@@ -627,6 +621,10 @@ impl PySession {
                 restore();
             }
             self.terminal.take();
+            // Re-emit after leaving the alternate screen / disabling raw mode.
+            // Private modes are global, but an interrupted truecolor frame can
+            // still leave SGR sticky on the main buffer until a second reset.
+            emit_terminal_reset_sequences();
         }
         self._panic_hook_guard = None;
         Ok(())

--- a/xnano-core/rust/src/bindings/engine/terminal_reset.rs
+++ b/xnano-core/rust/src/bindings/engine/terminal_reset.rs
@@ -1,0 +1,67 @@
+//! Best-effort host terminal reset used on every session exit path.
+//!
+//! A live xnano session can leave private modes (mouse, paste, synchronized
+//! output, keyboard protocol) and SGR attributes armed. If those are not fully
+//! cleared, a later ratatui app in the same terminal may paint with sticky
+//! colors or fail to redraw cells until the emulator is forced to repaint
+//! (for example by selecting text).
+
+use std::io::{stdout, Write};
+
+use crossterm::cursor::{SetCursorStyle, Show};
+use crossterm::style::{Attribute, ResetColor, SetAttribute};
+use crossterm::terminal::EnableLineWrap;
+use crossterm::ExecutableCommand;
+
+use super::super::event_setup::{
+    disable_bracketed_paste_impl, disable_focus_change_impl, disable_mouse_capture_impl,
+    pop_keyboard_enhancement_flags_impl,
+};
+use super::super::terminal_device::end_synchronized_update_impl;
+
+/// Comprehensive private-mode / SGR reset sequence.
+///
+/// Written in addition to typed crossterm commands so emulators that only
+/// partially honor one form still recover. Sequences that were never enabled
+/// are ignored by compliant hosts.
+const TERMINAL_RESET_BLOB: &[u8] = b"\
+\x1b[0m\
+\x1b[39m\
+\x1b[49m\
+\x1b[59m\
+\x1b[?25h\
+\x1b[0 q\
+\x1b[?7h\
+\x1b[?1000l\
+\x1b[?1002l\
+\x1b[?1003l\
+\x1b[?1005l\
+\x1b[?1006l\
+\x1b[?1015l\
+\x1b[?1004l\
+\x1b[?2004l\
+\x1b[?2026l\
+";
+
+/// Emit every known teardown sequence. Best-effort: errors are ignored.
+pub(crate) fn emit_terminal_reset_sequences() {
+    // End synchronized output first so later writes are actually shown.
+    let _ = end_synchronized_update_impl();
+    // Second end covers hosts that nest or ignore a single disable.
+    let _ = end_synchronized_update_impl();
+
+    let _ = disable_mouse_capture_impl();
+    let _ = disable_bracketed_paste_impl();
+    let _ = disable_focus_change_impl();
+    // Safe even when enhancement flags were never pushed.
+    let _ = pop_keyboard_enhancement_flags_impl();
+
+    let mut out = stdout();
+    let _ = out.execute(Show);
+    let _ = out.execute(SetCursorStyle::DefaultUserShape);
+    let _ = out.execute(EnableLineWrap);
+    let _ = out.execute(ResetColor);
+    let _ = out.execute(SetAttribute(Attribute::Reset));
+    let _ = out.write_all(TERMINAL_RESET_BLOB);
+    let _ = out.flush();
+}

--- a/xnano-core/rust/src/bindings/fx.rs
+++ b/xnano-core/rust/src/bindings/fx.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 
 use ratatui_core::buffer::Cell as CoreCell;
 use ratatui_core::layout::{Offset as CoreOffset, Position as CorePosition};
+use ratatui_core::style::Color as CoreColor;
 use tachyonfx::{
     fx::{self, EvolveSymbolSet, ExpandDirection, RepeatMode},
     pattern::RadialPattern,
@@ -400,6 +401,24 @@ impl PyCellFilter {
     fn NON_EMPTY() -> Self {
         Self {
             inner: CellFilter::NonEmpty,
+        }
+    }
+
+    #[classattr]
+    fn BACKGROUND() -> Self {
+        Self {
+            inner: CellFilter::eval_cell(|cell: &CoreCell| {
+                cell.bg != CoreColor::Reset
+            }),
+        }
+    }
+
+    #[classattr]
+    fn BACKGROUND_ONLY() -> Self {
+        Self {
+            inner: CellFilter::eval_cell(|cell: &CoreCell| {
+                cell.bg != CoreColor::Reset && cell.symbol() == " "
+            }),
         }
     }
 
@@ -852,7 +871,14 @@ fn dissolve_to(
 #[pyo3(signature = (duration_ms, interpolation=None))]
 fn coalesce(duration_ms: u32, interpolation: Option<PyInterpolation>) -> PyEffect {
     PyEffect {
-        inner: fx::coalesce(make_timer(duration_ms, interpolation)),
+        // ``fx::coalesce`` clears symbols but deliberately preserves styles,
+        // making background-only cells appear immediately. xnano's effect
+        // operates on complete terminal cells, so reform from the default
+        // style and let foreground/background participate in the reveal.
+        inner: fx::coalesce_from(
+            ratatui_core::style::Style::reset(),
+            make_timer(duration_ms, interpolation),
+        ),
     }
 }
 

--- a/xnano/core/controllers/terminal.py
+++ b/xnano/core/controllers/terminal.py
@@ -400,7 +400,9 @@ class TerminalController(AbstractController, Generic[StateT]):
         if not fields:
             return False
 
-        native_effect = effect.build_native_effect()
+        native_effect = effect.apply_native_cell_filter(
+            effect.build_native_effect()
+        )
         started = False
         for field_name in fields:
             area = self._core_session.effect_area_for(field_name)

--- a/xnano/effects.py
+++ b/xnano/effects.py
@@ -99,6 +99,25 @@ Values:
 """
 
 
+EffectCellFilter: TypeAlias = Literal[
+    "all",
+    "text",
+    "non_empty",
+    "background",
+    "background_only",
+]
+"""Terminal cells selected by an effect.
+
+Values:
+    ``"all"``: Every cell in the target field area.
+    ``"text"``: Cells containing text-like characters.
+    ``"non_empty"``: Cells whose symbol is not a space.
+    ``"background"``: Cells carrying a non-reset background color.
+    ``"background_only"``: Blank cells carrying a non-reset background;
+        styled text cells are excluded.
+"""
+
+
 KnownEffectKind: TypeAlias = Literal[
     "fade",
     "fade_from",
@@ -245,6 +264,11 @@ class AbstractEffect(abc.ABC):
         kw_only=True,
     )
     """Optional interpolation curve for the effect."""
+    cell_filter: EffectCellFilter | None = dataclasses.field(
+        default=None,
+        kw_only=True,
+    )
+    """Optional terminal-cell selection applied by the controller."""
     key: str | None = dataclasses.field(default=None, kw_only=True)
     """Optional identity for this effect instance.
 
@@ -262,6 +286,22 @@ class AbstractEffect(abc.ABC):
         Returns:
             A native ``Effect`` ready to run.
         """
+
+    def apply_native_cell_filter(
+        self,
+        effect: native.Effect,
+    ) -> native.Effect:
+        """Apply this description's terminal cell filter to an effect."""
+        if self.cell_filter is None:
+            return effect
+        filters = {
+            "all": native.CellFilter.ALL,
+            "text": native.CellFilter.TEXT,
+            "non_empty": native.CellFilter.NON_EMPTY,
+            "background": native.CellFilter.BACKGROUND,
+            "background_only": native.CellFilter.BACKGROUND_ONLY,
+        }
+        return effect.with_filter(filters[self.cell_filter])
 
 
 @dataclasses.dataclass
@@ -821,7 +861,7 @@ def resolve_native_effect(
     Returns:
         A native ``Effect`` instance.
     """
-    return resolve_effect(
+    resolved = resolve_effect(
         effect,
         duration_ms=duration_ms,
         color=color,
@@ -834,7 +874,8 @@ def resolve_native_effect(
         child=child,
         times=times,
         key=key,
-    ).build_native_effect()
+    )
+    return resolved.apply_native_cell_filter(resolved.build_native_effect())
 
 
 @overload
@@ -933,6 +974,7 @@ __all__ = (
     "DissolveEffect",
     "Effect",
     "EffectColorSpace",
+    "EffectCellFilter",
     "EffectInterpolation",
     "EffectMotion",
     "FadeEffect",

--- a/xnano/terminal/__init__.py
+++ b/xnano/terminal/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import atexit
 import contextvars
 import dataclasses
 import signal
@@ -70,6 +71,24 @@ def exit_terminal() -> None:
     """
     if _ACTIVE_TERMINAL.get() is None:
         raise Exit("Terminal is not live.")
+
+
+def _atexit_restore_active_terminal() -> None:
+    """Restore any still-live terminal if the process exits without ``__exit__``.
+
+    Incomplete private-mode teardown leaves subsequent TUI apps in the same
+    host terminal painting with sticky colors until cells are force-redrawn.
+    """
+    terminal = _ACTIVE_TERMINAL.get()
+    if terminal is None or not getattr(terminal, "_is_live", False):
+        return
+    try:
+        terminal.__exit__(None, None, None)
+    except Exception:
+        pass
+
+
+atexit.register(_atexit_restore_active_terminal)
 
 
 class Terminal(Generic[StateT]):
@@ -148,6 +167,7 @@ class Terminal(Generic[StateT]):
         "_root_width_sizing",
         "_prev_sigterm",
         "_prev_sighup",
+        "_prev_sigint",
         "_field_focus",
         "_field_focus_announced",
         "_last_field_focus_event",
@@ -210,15 +230,19 @@ class Terminal(Generic[StateT]):
         self._pending_enter: bool = False
         self._prev_sigterm: Any = None
         self._prev_sighup: Any = None
+        self._prev_sigint: Any = None
         self._field_focus: Any = None
         self._field_focus_announced: bool = False
         self._last_field_focus_event: Any = None
 
     def _on_exit_signal(
         self,
-        signum: int,
+        signum: int,  # noqa: ARG002
         frame: Any,  # noqa: ARG002
     ) -> None:
+        # Soft-exit only: never raise from the handler. Raising KeyboardInterrupt
+        # mid-restore can leave private modes / SGR half-cleared for the next
+        # process sharing this terminal.
         self._exit_requested = True
 
     def __enter__(self) -> "Terminal[StateT]":
@@ -233,11 +257,15 @@ class Terminal(Generic[StateT]):
         self._pending_enter = True
         self._drain_pending_hooks()
         self._register_default_hooks()
-        # Install signal handlers so SIGTERM / SIGHUP (e.g. terminal window
-        # closed) flow through the normal exit path instead of killing the
-        # process before terminal restore can run.  signal.signal() is only
-        # valid on the main thread; silently skip if called elsewhere.
+        # Install signal handlers so SIGINT / SIGTERM / SIGHUP flow through the
+        # normal exit path instead of killing the process (or raising
+        # KeyboardInterrupt mid-restore) before terminal restore can finish.
+        # signal.signal() is only valid on the main thread; silently skip if
+        # called elsewhere.
         try:
+            self._prev_sigint = signal.signal(
+                signal.SIGINT, self._on_exit_signal
+            )
             self._prev_sigterm = signal.signal(
                 signal.SIGTERM, self._on_exit_signal
             )
@@ -271,16 +299,8 @@ class Terminal(Generic[StateT]):
             return
         try:
             if self._session is not None:
-                if self.mouse_events:
-                    try:
-                        self._session._core_session.disable_mouse_capture()
-                    except OSError:
-                        pass
-                if self.bracketed_paste:
-                    try:
-                        self._session._core_session.disable_bracketed_paste()
-                    except OSError:
-                        pass
+                # CoreSession.restore always clears mouse / paste / sync / SGR
+                # regardless of which flags this Terminal instance enabled.
                 self._session.leave()
         finally:
             if self._terminal_token is not None:
@@ -293,6 +313,9 @@ class Terminal(Generic[StateT]):
             self._inline_height = None
             self._root_width_sizing = None
             try:
+                if self._prev_sigint is not None:
+                    signal.signal(signal.SIGINT, self._prev_sigint)
+                    self._prev_sigint = None
                 if self._prev_sigterm is not None:
                     signal.signal(signal.SIGTERM, self._prev_sigterm)
                     self._prev_sigterm = None


### PR DESCRIPTION
## Summary
- Consolidates terminal teardown (panic hook, signal exit, normal restore) onto a single comprehensive reset routine (`terminal_reset.rs`) so private modes/SGR can't leak into the next process sharing the terminal; traps SIGINT alongside SIGTERM/SIGHUP and adds an atexit safety net.
- Adds `CellFilter::BACKGROUND` / `BACKGROUND_ONLY` and a `cell_filter` field on `AbstractEffect` so effects can target cells by background color; switches `coalesce` to `fx::coalesce_from(Style::reset(), ...)` so background-only reveals aren't skipped.

## Test plan
- [x] `uv run pytest` (already run by requester)
- [x] `uv run prek run --all-files` (already run by requester)