### PR TITLE
refactor(core): sound BufferMutView borrows and unicode IR measure

### DIFF
--- a/xnano-core/rust/src/bindings/buffer.rs
+++ b/xnano-core/rust/src/bindings/buffer.rs
@@ -703,20 +703,29 @@ impl PyBufferMutView {
         self.alive.set(false);
     }
 
-    fn buffer_mut(&self) -> PyResult<&mut Buffer> {
+    /// Run `f` against the wrapped buffer while the view is still alive.
+    ///
+    /// The mutable borrow is scoped to the closure rather than returned
+    /// from `&self`, so the pointer-backed access stays sound by
+    /// construction: the view is `unsendable` and the borrow can never
+    /// outlive this call.
+    fn with_buffer_mut<R>(
+        &self,
+        f: impl FnOnce(&mut Buffer) -> PyResult<R>,
+    ) -> PyResult<R> {
         if !self.alive.get() {
             return Err(PyRuntimeError::new_err("BufferMutView expired"));
         }
-        Ok(unsafe { &mut *(self.ptr as *mut Buffer) })
+        // SAFETY: `ptr` points at the live buffer for the duration of the
+        // drawable callback; `alive` is flipped before it dangles.
+        f(unsafe { &mut *(self.ptr as *mut Buffer) })
     }
 }
 
 #[pymethods]
 impl PyBufferMutView {
     fn get_area(&self) -> PyResult<PyRect> {
-        Ok(PyRect {
-            inner: self.buffer_mut()?.area,
-        })
+        self.with_buffer_mut(|buffer| Ok(PyRect { inner: buffer.area }))
     }
 
     fn area(&self) -> PyResult<PyRect> {
@@ -724,12 +733,13 @@ impl PyBufferMutView {
     }
 
     fn get_cell(&self, x: u16, y: u16) -> PyResult<Option<PyBufferCell>> {
-        let buffer = self.buffer_mut()?;
-        check_local_coords(buffer, x, y)?;
-        let position = local_position(buffer, x, y);
-        Ok(buffer
-            .cell(position)
-            .map(|cell| PyBufferCell { inner: cell.clone() }))
+        self.with_buffer_mut(|buffer| {
+            check_local_coords(buffer, x, y)?;
+            let position = local_position(buffer, x, y);
+            Ok(buffer
+                .cell(position)
+                .map(|cell| PyBufferCell { inner: cell.clone() }))
+        })
     }
 
     fn set_cell(
@@ -739,17 +749,18 @@ impl PyBufferMutView {
         symbol: &str,
         style: PyStyle,
     ) -> PyResult<()> {
-        let buffer = self.buffer_mut()?;
-        check_local_coords(buffer, x, y)?;
-        let position = local_position(buffer, x, y);
-        if let Some(cell) = buffer.cell_mut(position) {
-            cell.set_symbol(symbol).set_style(style.inner);
-            Ok(())
-        } else {
-            Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                "position ({x}, {y}) out of bounds"
-            )))
-        }
+        self.with_buffer_mut(|buffer| {
+            check_local_coords(buffer, x, y)?;
+            let position = local_position(buffer, x, y);
+            if let Some(cell) = buffer.cell_mut(position) {
+                cell.set_symbol(symbol).set_style(style.inner);
+                Ok(())
+            } else {
+                Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "position ({x}, {y}) out of bounds"
+                )))
+            }
+        })
     }
 
     fn set_string(
@@ -759,19 +770,22 @@ impl PyBufferMutView {
         string: &str,
         style: PyStyle,
     ) -> PyResult<()> {
-        let buffer = self.buffer_mut()?;
-        if x >= buffer.area.width || y >= buffer.area.height {
-            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                "position ({x}, {y}) out of bounds"
-            )));
-        }
-        buffer.set_string(x, y, string, style.inner);
-        Ok(())
+        self.with_buffer_mut(|buffer| {
+            if x >= buffer.area.width || y >= buffer.area.height {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "position ({x}, {y}) out of bounds"
+                )));
+            }
+            buffer.set_string(x, y, string, style.inner);
+            Ok(())
+        })
     }
 
     fn set_style(&self, area: PyRect, style: PyStyle) -> PyResult<()> {
-        self.buffer_mut()?.set_style(area.inner, style.inner);
-        Ok(())
+        self.with_buffer_mut(|buffer| {
+            buffer.set_style(area.inner, style.inner);
+            Ok(())
+        })
     }
 }
 

--- a/xnano-core/rust/src/bindings/engine/render_ir.rs
+++ b/xnano-core/rust/src/bindings/engine/render_ir.rs
@@ -710,30 +710,28 @@ impl CoreRenderIR {
     // ── Measure ───────────────────────────────────────────────────────────────
 
     fn measure(&self) -> (u16, u16) {
+        // Widths are measured in display cells (unicode-aware), not bytes —
+        // byte lengths over-measure any non-ASCII content and break `fit`
+        // sizing upstream.
         match &self.inner {
-            RenderIrInner::Span { content, .. } => (content.len() as u16, 1),
-            RenderIrInner::Line { line } => (line_width(line) as u16, 1),
+            RenderIrInner::Span { content, .. } => {
+                (Span::raw(content.as_str()).width() as u16, 1)
+            }
+            RenderIrInner::Line { line } => (line.width() as u16, 1),
             RenderIrInner::Text { text, .. } => {
                 let h = text.lines.len().max(1) as u16;
-                let w = text.lines.iter().map(line_width).max().unwrap_or(0) as u16;
-                (w, h)
+                (text.width() as u16, h)
             }
             RenderIrInner::Paragraph { text, .. } => {
                 let h = text.lines.len().max(1) as u16;
-                let w = text.lines.iter().map(line_width).max().unwrap_or(0) as u16;
-                (w, h)
+                (text.width() as u16, h)
             }
             RenderIrInner::List { items, highlight_symbol, .. } => {
                 if items.is_empty() {
                     return (0, 1);
                 }
-                let sym_w = highlight_symbol.len() as u16;
-                let w = items
-                    .iter()
-                    .flat_map(|t| t.lines.iter())
-                    .map(line_width)
-                    .max()
-                    .unwrap_or(0) as u16;
+                let sym_w = Span::raw(highlight_symbol.as_str()).width() as u16;
+                let w = items.iter().map(|t| t.width()).max().unwrap_or(0) as u16;
                 (w + sym_w, items.len() as u16)
             }
             RenderIrInner::ProgressBar { .. } => (0, 1),
@@ -757,10 +755,6 @@ impl CoreRenderIR {
             RenderIrInner::Canvas { .. } => (0, 0),
         }
     }
-}
-
-fn line_width(line: &Line<'_>) -> usize {
-    line.spans.iter().map(|s| s.content.len()).sum()
 }
 
 // ── Rust-internal rendering ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Hardens two soundness/correctness paths in `xnano-core` that showed up in the architecture audit:

- **`BufferMutView`**: mutable buffer access is scoped through `with_buffer_mut`, so the pointer-backed borrow cannot escape the call (view is `unsendable`; `alive` is cleared before the pointer dangles).
- **Render IR measure**: widths use display-cell (unicode-aware) metrics instead of raw byte/`content.len()` lengths, so `fit` sizing is correct for non-ASCII text (accents, CJK, etc.).

## Changes

| Area | What changed |
|------|----------------|
| `bindings/buffer.rs` | Replace `buffer_mut() -> &mut Buffer` with `with_buffer_mut(\|buf\| …)`; update get/set helpers |
| `bindings/engine/render_ir.rs` | Measure spans/lines/text/lists via `.width()` / `Span::raw(...).width()`; drop byte-based `line_width` helper |

## Test plan

- [ ] Rebuild extension: `cd xnano-core && cargo clean && maturin develop --uv`
- [ ] `uv run pytest tests/core -q`
- [ ] Spot-check fit sizing with unicode content if available