### PR TITLE
refactor(arch): fix hook registration, layout measure, and event cache

### DIFF
--- a/tests/test_hook_interop.py
+++ b/tests/test_hook_interop.py
@@ -1140,6 +1140,34 @@ def test_parent_used_alone_has_only_parent_hook() -> None:
     assert len(registry_grand.on_field_hooks) == 3
 
 
+def test_overridden_hook_registers_once() -> None:
+    # A subclass overriding a parent's hook method must shadow it — both
+    # collected members rebind to the same bound method, so registering
+    # both would fire the override twice per event.
+    class _OverrideParent(Grid):
+        flag: bool = Field(default=False, state=True)
+        fired: int = Field(default=0, state=True)
+
+        @on_field("flag")
+        def react(self) -> None:
+            self.fired += 1
+
+    class _OverrideChild(_OverrideParent):
+        @on_field("flag")
+        def react(self) -> None:
+            self.fired += 10
+
+    registry = _EventHooksRegistry.from_component_class(_OverrideChild)
+    assert len(registry.on_field_hooks) == 1
+
+    grid = _OverrideChild()
+    terminal = _StubTerminal()
+    terminal.attach(grid)
+    grid.flag = True
+    pump_tick(cast(Any, terminal))
+    assert grid.fired == 10
+
+
 # ---------------------------------------------------------------------------
 # 13. Multi-grid isolation and cross-grid independence
 # ---------------------------------------------------------------------------

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -246,6 +246,22 @@ def test_frame_node_measure_with_padding() -> None:
     assert size.height == 1 + 2
 
 
+def test_frame_node_measure_asymmetric_padding() -> None:
+    # (vertical, horizontal) padding — each axis carries its own overhead.
+    child = ParagraphNode(text="hi")
+    node = FrameNode(frame=Frame(padding=(1, 3)), child=child)
+    size = (node).measure()
+    assert size.width == 2 + 6
+    assert size.height == 1 + 2
+
+
+def test_paragraph_node_measure_unicode_width() -> None:
+    # Widths are display cells, not UTF-8 bytes.
+    assert ParagraphNode(text="héllo").measure().width == 5
+    # CJK characters are two cells wide.
+    assert ParagraphNode(text="你好").measure().width == 4
+
+
 # ---------------------------------------------------------------------------
 # ContainerNode
 # ---------------------------------------------------------------------------

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -78,6 +78,13 @@ def test_parse_percent_string() -> None:
     assert Sizing.parse("75%") == Sizing.percent(75)
 
 
+def test_parse_percent_string_is_literal() -> None:
+    # ``"1%"`` is one percent — the 0..=1 fraction rule only applies to
+    # bare floats, never to explicit ``%`` strings.
+    parsed = Sizing.parse("1%")
+    assert parsed is not None and parsed.value == 1
+
+
 def test_parse_fr_string() -> None:
     assert Sizing.parse("3fr") == Sizing.fraction(3)
 

--- a/tests/test_usage_scenarios.py
+++ b/tests/test_usage_scenarios.py
@@ -647,3 +647,39 @@ def test_hook_exception_logs_and_terminal_still_paints(
         assert "recovered" in out
     finally:
         close_offscreen_app(terminal)
+
+
+# ---------------------------------------------------------------------------
+# Scenario — two instances of one grid class each receive their own hooks
+# ---------------------------------------------------------------------------
+
+
+class _Tally(Grid):
+    label: str = Field(default="", height=1)
+    count: int = Field(default=0, state=True)
+
+    @on_keyboard("k")
+    def bump(self) -> None:
+        self.count += 1
+
+
+def test_same_grid_class_instances_each_receive_hooks() -> None:
+    # Hook registration is per instance — a per-class guard would leave
+    # every instance after the first without hooks (or firing on the
+    # wrong ``self``).
+    first = _Tally()
+    second = _Tally()
+    terminal = open_offscreen_app(first)
+    try:
+        terminal.attach_grid(second)
+        press(terminal, "k")
+        assert first.count == 1
+        assert second.count == 1
+
+        # Re-attaching an already-known instance must not double-register.
+        terminal.attach_grid(first)
+        press(terminal, "k")
+        assert first.count == 2
+        assert second.count == 2
+    finally:
+        close_offscreen_app(terminal)

--- a/xnano/core/dispatch.py
+++ b/xnano/core/dispatch.py
@@ -20,7 +20,6 @@ from xnano.hooks import (
 )
 from xnano.utils.core import (
     evaluate_state_expression,
-    get_first_function_parameter_type,
     get_function_extra_parameter_count,
 )
 from xnano.utils.native_types import get_area_from_native_rect
@@ -73,9 +72,12 @@ def run_awaitable(awaitable: Awaitable[Any]) -> Any:
 
 
 def _call_hook(handler: Any, bound_self: Any, ctx: "Context[Any]") -> Any:
-    """Invoke ``handler`` with the right arity (sync call only)."""
-    from xnano.context import Context as ContextClass
+    """Invoke ``handler`` with the right arity (sync call only).
 
+    Handlers may take zero extra parameters or a single ``Context``,
+    whether they are bound methods, unbound methods resolved against a
+    live grid (``bound_self``), or free functions.
+    """
     bound_instance = getattr(handler, "__self__", None)
     if bound_instance is not None:
         function = getattr(handler, "__func__", handler)
@@ -83,11 +85,13 @@ def _call_hook(handler: Any, bound_self: Any, ctx: "Context[Any]") -> Any:
             return handler()
         return handler(ctx)
 
-    param_type = get_first_function_parameter_type(handler)
-    if param_type is ContextClass:
-        return handler(ctx)
+    count = get_function_extra_parameter_count(handler)
     if bound_self is not None:
+        if count == 0:
+            return handler(bound_self)
         return handler(bound_self, ctx)
+    if count == 0:
+        return handler()
     return handler(ctx)
 
 
@@ -119,32 +123,18 @@ def grid_clamp_slide_position(
     slide_axes: tuple[str, ...],
     position: "Coordinate",
 ) -> "Coordinate":
-    x = position[0]
-    y = position[1]
-    if "x" in slide_axes:
-        x = max(0, min(x, parent_area.width - slot_area.width))
-    if "y" in slide_axes:
-        y = max(0, min(y, parent_area.height - slot_area.height))
-    return (x, y)
+    from xnano.grid import _grid_clamp_slide_position
+
+    return _grid_clamp_slide_position(
+        parent_area, slot_area, list(slide_axes), position
+    )
 
 
 def resolve_grid_mouse_handler(grid: "Grid", field_name: str) -> Any | None:
     """Return the field-bound mouse handler for ``field_name`` on ``grid``."""
-    for cls in type(grid).__mro__:
-        if not (isinstance(cls, type)):
-            continue
-        from xnano.grid import Grid as GridClass
+    from xnano.grid import _resolve_grid_mouse_handler
 
-        if not issubclass(cls, GridClass):
-            continue
-        handlers = cls.__dict__.get("_grid_field_handlers")
-        if not isinstance(handlers, dict) or field_name not in handlers:
-            continue
-        attr = handlers[field_name]
-        if not hasattr(attr, _EventHooksRegistry.ON_MOUSE_HOOK_ATTR):
-            return None
-        return attr.__get__(grid, cls)
-    return None
+    return _resolve_grid_mouse_handler(grid, field_name)
 
 
 def field_mouse_handler_matches(handler: Any, mouse: Any) -> bool:
@@ -190,12 +180,21 @@ def mouse_matches(mouse: Any, entry: "_OnMouseHookFunctionEntry") -> bool:
 
 
 def resolve_hook_grid(terminal: "Terminal[Any]", handler: Any) -> Any | None:
+    """Return the grid instance a hook handler belongs to, if any.
+
+    Bound methods carry their own instance. Unbound handlers fall back to
+    matching the class named in their ``__qualname__`` against the frame's
+    painted grids (including base classes, so a hook declared on a parent
+    grid class resolves for a subclass instance).
+    """
     bound_instance = getattr(handler, "__self__", None)
     if bound_instance is not None:
         return bound_instance
     owner_name = getattr(handler, "__qualname__", "").split(".", 1)[0]
+    if not owner_name:
+        return None
     for grid in reversed(terminal._attached_frame_grids):
-        if type(grid).__name__ == owner_name:
+        if any(base.__name__ == owner_name for base in type(grid).__mro__):
             return grid
     return None
 
@@ -490,8 +489,11 @@ def pump_events(terminal: "Terminal[Any]") -> None:
     from xnano.context import Context
     from xnano.events import Event
 
+    # ``poll_core_event(timeout=0)`` blocks until input arrives, which would
+    # stall the render loop for a ``Terminal(tick_interval=0)`` — clamp to a
+    # 1ms wait so ticks and repaints keep flowing.
     core_event = terminal.session.poll_core_event(
-        timeout=terminal.tick_interval
+        timeout=max(1, terminal.tick_interval)
     )
     if core_event is None:
         # Idle: the blocking poll returned no input within the tick window.
@@ -759,13 +761,23 @@ def update_slide_capture(
 
 
 def track_frame_grid(terminal: "Terminal[Any]", grid: Any) -> None:
-    grid_class = type(grid)
-    if grid_class not in terminal._attached_grid_classes:
-        collected = _EventHooksRegistry.from_component_class(grid_class)
+    """Register ``grid`` for this frame, merging its hooks on first sight.
+
+    Hooks are registered once per grid *instance* and bound to it, so two
+    live grids of the same class each receive their own events — a
+    per-class guard would leave every instance after the first without
+    hooks (or firing with the wrong ``self``). Registration is permanent
+    for the terminal's lifetime; grids are meant to be stable instances,
+    not rebuilt every frame.
+    """
+    attached = terminal._attached_grids
+    if id(grid) not in attached:
+        collected = _EventHooksRegistry.from_component_class(type(grid))
         merge_hooks(terminal, collected, grid=grid)
-        terminal._attached_grid_classes.add(grid_class)
+        # The strong reference keeps ``id(grid)`` unique for the life of
+        # the terminal (bound hook handlers hold the instance anyway).
+        attached[id(grid)] = grid
     terminal._attached_frame_grids.append(grid)
-    terminal._attached_grids.add(id(grid))
 
 
 def rebind_hook_handler(handler: Any, grid: Any) -> Any:

--- a/xnano/core/nodes/terminal.py
+++ b/xnano/core/nodes/terminal.py
@@ -499,10 +499,11 @@ class FrameNode(AbstractTerminalNode):
         if not self.visible:
             return Size(width=0, height=0)
         child_size = self.child.measure()
-        overhead = _frame_length_overhead(self.frame, "vertical")
         return Size(
-            width=child_size.width + overhead,
-            height=child_size.height + overhead,
+            width=child_size.width
+            + _frame_length_overhead(self.frame, "horizontal"),
+            height=child_size.height
+            + _frame_length_overhead(self.frame, "vertical"),
         )
 
     def lower(

--- a/xnano/grid.py
+++ b/xnano/grid.py
@@ -741,9 +741,7 @@ class _GridMeta(type):
                     continue
                 static_names.append(field_name)
                 static_constraints.append(
-                    _layout_constraint_for_field(
-                        field, cfg.get("direction", "vertical")
-                    )
+                    _layout_constraint_for_field(field, _direction)
                 )
 
         setattr(cls, "_grid_needs_dynamic_layout", needs_dynamic)

--- a/xnano/hooks.py
+++ b/xnano/hooks.py
@@ -50,7 +50,6 @@ from typing import (
     overload,
 )
 
-from xnano.utils.core import get_first_function_parameter_type
 from xnano.context import Context
 from xnano.events import KeyboardEventKind, MouseEventKind, EventDataType
 from xnano.keyboard import KeyboardBinding
@@ -286,12 +285,20 @@ class _EventHooksRegistry:
             cls.ON_FIELD_HOOK_ATTR,
         )
 
+        # A name defined on a more-derived class shadows any base definition —
+        # without this, overriding a hook method registers both the override
+        # and the base member, which rebind to the same bound method and fire
+        # twice per event.
+        seen_names: set[str] = set()
         for base in component_class.__mro__:
             if base is object:
                 continue
             for name, member in base.__dict__.items():
                 if not callable(member):
                     continue
+                if name in seen_names:
+                    continue
+                seen_names.add(name)
 
                 is_hook_method = any(
                     hasattr(member, attribute) for attribute in hook_attributes
@@ -483,7 +490,7 @@ def _decorate_on_mouse_hook(
 def on_keyboard(
     key: KeyboardBinding,
     /,
-    *,
+    *keys: KeyboardBinding,
     kind: KeyboardEventKind | None = None,
 ) -> Callable[[EventHookFunction], EventHookFunction]: ...
 @overload

--- a/xnano/sizing.py
+++ b/xnano/sizing.py
@@ -255,7 +255,11 @@ class Sizing:
         if token in _FLEX_CLASS_WEIGHTS:
             return cls.fraction(_FLEX_CLASS_WEIGHTS[token])
         if token.endswith("%"):
-            return cls.percent(float(token[:-1]))
+            # A ``%`` string is always a literal percentage — ``"1%"`` means
+            # one percent, unlike the bare-float form where ``0..=1`` reads
+            # as a fraction (``0.5`` → 50%).
+            pct = float(token[:-1])
+            return cls(kind="percent", value=max(0, min(100, int(round(pct)))))
         if token.endswith("fr"):
             weight = token[:-2].strip() or "1"
             return cls.fraction(int(weight))

--- a/xnano/terminal/__init__.py
+++ b/xnano/terminal/__init__.py
@@ -148,7 +148,6 @@ class Terminal(Generic[StateT]):
         "_is_live",
         "_has_context",
         "_attached_grids",
-        "_attached_grid_classes",
         "_attached_frame_grids",
         "_field_hits",
         "_mouse_geometry_active",
@@ -213,8 +212,9 @@ class Terminal(Generic[StateT]):
         self._renderable_overlays: list[tuple[Any, int]] = []
         self._is_live: bool = False
         self._has_context: bool = False
-        self._attached_grids: set[int] = set()
-        self._attached_grid_classes: set[type] = set()
+        # Grids whose hooks are registered, keyed by ``id`` — the value is a
+        # strong reference so the id stays unique for the terminal's life.
+        self._attached_grids: dict[int, Any] = {}
         self._attached_frame_grids: list[Any] = []
         self._field_hits: list[Any] = []
         self._mouse_geometry_active: bool = False

--- a/xnano/utils/events.py
+++ b/xnano/utils/events.py
@@ -18,9 +18,8 @@ from typing import (
 from xnano_core import core
 from xnano_core.rust import native
 
-import xnano.events as xnano_events
-
 if TYPE_CHECKING:
+    import xnano.events as xnano_events
     from xnano.events import KeyboardEventKind, MouseEventKind
     from xnano.keyboard import KeyboardModifier
 
@@ -48,7 +47,7 @@ _SPECIAL_KEYBOARD_KEYS_DICT: dict[str, native.KeyCode] = {
     "space": native.KeyCode.Char,
 }
 _KEY_RESOLUTION_CACHE: dict[
-    tuple[int, str | None, int | None],
+    tuple[int, str | None, int | None, int],
     tuple[list[KeyboardModifier], str | None],
 ] = {}
 
@@ -157,10 +156,19 @@ def get_keyboard_binding_tuple_from_native_event(
     Returns:
         The corresponding ``xnano`` style keyboard binding string.
     """
+    # The resolved tuple includes the held modifiers, so the cache key must
+    # too — otherwise ``a`` and ``alt+a`` collide on the same entry and the
+    # second press reports the first press's modifiers.
+    modifier_bits = (
+        (4 if event.modifiers.control() else 0)
+        | (2 if event.modifiers.alt() else 0)
+        | (1 if event.modifiers.shift() else 0)
+    )
     cache_key = (
         int(event.code_name),
         event.char(),
         event.function_number(),
+        modifier_bits,
     )
     if cache_key in _KEY_RESOLUTION_CACHE:
         return _KEY_RESOLUTION_CACHE[cache_key]
@@ -287,6 +295,11 @@ def get_event_data_from_core_event(
     Returns:
         The corresponding ``xnano.events.EventData`` instance.
     """
+    # Imported at call time: ``xnano.events`` imports this module at its own
+    # top level, so a module-level import here is circular whenever
+    # ``xnano.utils.events`` happens to be imported first.
+    import xnano.events as xnano_events
+
     kind = event.kind_str()
 
     if kind == "key":


### PR DESCRIPTION
## Summary

Python-layer fixes from the architecture audit for the stable `xnano` package (not `xnano-core`, not the beta web UI).

### Hooks / dispatch
- Register hooks **per grid instance** instead of once per class, so multiple live grids of the same class each get their own handlers.
- Shadow overridden hook methods during MRO collection so parent + child definitions do not fire twice.
- Invoke handlers by parameter arity (not type annotations); resolve unbound hooks against base classes in the painted frame list.
- `@on_keyboard("up", "ctrl+k")` multi-key overload matches runtime support.
- Clamp `tick_interval=0` polls to a 1ms wait so the render loop does not block forever.

### Layout / measure
- `FrameNode.measure` applies horizontal vs vertical padding independently.
- `"1%"` sizing strings parse as one percent (literal), not as a fraction.
- Static field layout constraints use the grid's resolved direction.

### Events
- Keyboard resolution cache keys include held modifiers (`a` vs `alt+a`).
- Lazy-import `xnano.events` to avoid circular import when `utils.events` loads first.

## Commits
1. `fix(hooks): register hooks per grid instance and shadow overrides`
2. `fix(layout): correct frame measure axes, percent parse, and static split`
3. `fix(events): include modifiers in keyboard cache key`
4. `test: cover instance hooks, override shadowing, and measure edges`

## Test plan
- [ ] `uv run pytest -q`
- [ ] Confirm two instances of one Grid class each respond to hooks
- [ ] Confirm subclass `@on_field` override fires once
- [ ] Spot-check percent strings and framed measure if convenient