### PR TITLE
feat: Tailwind CSS class_name support for grid fields

### DIFF
--- a/scripts/generate_tailwind_literal.py
+++ b/scripts/generate_tailwind_literal.py
@@ -1,0 +1,269 @@
+"""scripts.generate_tailwind_literal
+
+---
+
+One-off generator for the ``TailwindClass`` Literal blocks committed in
+``xnano/beta/tailwind.py``. Never imported at runtime — rerun it and
+paste the output below the generated-code marker in that module when
+the supported class vocabulary changes:
+
+    uv run python scripts/generate_tailwind_literal.py
+"""
+
+from __future__ import annotations
+
+
+TAILWIND_PALETTES: list[str] = [
+    "amber",
+    "blue",
+    "cyan",
+    "emerald",
+    "fuchsia",
+    "gray",
+    "green",
+    "indigo",
+    "lime",
+    "neutral",
+    "orange",
+    "pink",
+    "purple",
+    "red",
+    "rose",
+    "sky",
+    "slate",
+    "stone",
+    "teal",
+    "violet",
+    "yellow",
+    "zinc",
+]
+
+TAILWIND_SHADES: list[int] = [
+    50,
+    100,
+    200,
+    300,
+    400,
+    500,
+    600,
+    700,
+    800,
+    900,
+    950,
+]
+
+SPACING_SCALE: list[str] = [
+    "0",
+    "0.5",
+    "1",
+    "1.5",
+    "2",
+    "2.5",
+    "3",
+    "3.5",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
+    "11",
+    "12",
+    "14",
+    "16",
+    "20",
+    "24",
+    "28",
+    "32",
+    "36",
+    "40",
+    "44",
+    "48",
+    "52",
+    "56",
+    "60",
+    "64",
+    "72",
+    "80",
+    "96",
+    "px",
+]
+
+PADDING_PREFIXES: list[str] = ["p", "px", "py", "pt", "pr", "pb", "pl"]
+MARGIN_PREFIXES: list[str] = ["m", "mx", "my", "mt", "mr", "mb", "ml"]
+GAP_PREFIXES: list[str] = ["gap", "gap-x", "gap-y"]
+
+BORDER_CLASSES: list[str] = [
+    "border",
+    "border-0",
+    "border-2",
+    "border-4",
+    "border-8",
+    "border-double",
+    "border-t",
+    "border-r",
+    "border-b",
+    "border-l",
+    "border-x",
+    "border-y",
+    "rounded",
+    "rounded-none",
+    "rounded-sm",
+    "rounded-md",
+    "rounded-lg",
+    "rounded-xl",
+    "rounded-2xl",
+    "rounded-3xl",
+    "rounded-full",
+]
+
+TYPOGRAPHY_CLASSES: list[str] = [
+    "font-thin",
+    "font-extralight",
+    "font-light",
+    "font-normal",
+    "font-medium",
+    "font-semibold",
+    "font-bold",
+    "font-extrabold",
+    "font-black",
+    "italic",
+    "not-italic",
+    "underline",
+    "no-underline",
+    "line-through",
+    "animate-pulse",
+    "text-left",
+    "text-center",
+    "text-right",
+    "text-xs",
+    "text-sm",
+    "text-base",
+    "text-lg",
+    "text-xl",
+    "text-2xl",
+    "text-3xl",
+    "text-4xl",
+    "text-5xl",
+    "text-6xl",
+    "text-7xl",
+    "text-8xl",
+    "text-9xl",
+]
+
+SIZING_FRACTIONS: list[str] = [
+    "1/2",
+    "1/3",
+    "2/3",
+    "1/4",
+    "2/4",
+    "3/4",
+    "1/5",
+    "2/5",
+    "3/5",
+    "4/5",
+    "1/6",
+    "5/6",
+]
+
+SIZING_KEYWORDS: list[str] = ["full", "screen", "fit", "auto", "min", "max"]
+
+FLEX_CLASSES: list[str] = [
+    "flex",
+    "flex-row",
+    "flex-col",
+    "flex-1",
+    "flex-auto",
+    "flex-initial",
+    "flex-none",
+    "grow",
+    "grow-0",
+    "shrink",
+    "shrink-0",
+]
+
+PASSTHROUGH_CLASSES: list[str] = [
+    "shadow",
+    "shadow-sm",
+    "shadow-md",
+    "shadow-lg",
+    "shadow-xl",
+    "shadow-2xl",
+    "shadow-inner",
+    "shadow-none",
+    "transition",
+    "transition-all",
+    "transition-colors",
+    "transition-opacity",
+    "transition-shadow",
+    "transition-transform",
+    "truncate",
+    "overflow-hidden",
+    "overflow-auto",
+    "overflow-scroll",
+    "overflow-visible",
+    "opacity-0",
+    "opacity-25",
+    "opacity-50",
+    "opacity-60",
+    "opacity-75",
+    "opacity-100",
+    "cursor-pointer",
+    "cursor-default",
+    "select-none",
+    "select-text",
+]
+
+
+def build_color_classes() -> list[str]:
+    """Return every ``{text,bg,border}-{binding}`` color class."""
+    bindings: list[str] = ["black", "white"]
+    for palette in TAILWIND_PALETTES:
+        for shade in TAILWIND_SHADES:
+            bindings.append(f"{palette}-{shade}")
+    return [
+        f"{prefix}-{binding}"
+        for prefix in ("text", "bg", "border")
+        for binding in bindings
+    ]
+
+
+def build_spacing_classes() -> list[str]:
+    """Return every padding, margin, and gap spacing class."""
+    prefixes = PADDING_PREFIXES + MARGIN_PREFIXES + GAP_PREFIXES
+    return [
+        f"{prefix}-{unit}" for prefix in prefixes for unit in SPACING_SCALE
+    ]
+
+
+def build_sizing_classes() -> list[str]:
+    """Return every ``w-*`` / ``h-*`` sizing class."""
+    suffixes = SPACING_SCALE + SIZING_FRACTIONS + SIZING_KEYWORDS
+    return [f"{axis}-{suffix}" for axis in ("w", "h") for suffix in suffixes]
+
+
+def emit_literal(name: str, values: list[str]) -> str:
+    """Render one ``TypeAlias`` Literal block as source text."""
+    lines = [f"{name}: TypeAlias = Literal["]
+    for value in values:
+        lines.append(f'    "{value}",')
+    lines.append("]")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    blocks = [
+        emit_literal("TailwindColorClass", build_color_classes()),
+        emit_literal("TailwindSpacingClass", build_spacing_classes()),
+        emit_literal("TailwindBorderClass", BORDER_CLASSES),
+        emit_literal("TailwindTypographyClass", TYPOGRAPHY_CLASSES),
+        emit_literal("TailwindSizingClass", build_sizing_classes()),
+        emit_literal("TailwindFlexClass", FLEX_CLASSES),
+        emit_literal("TailwindPassthroughClass", PASSTHROUGH_CLASSES),
+    ]
+    print("\n\n\n".join(blocks))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/beta/test_tailwind.py
+++ b/tests/beta/test_tailwind.py
@@ -1,0 +1,1139 @@
+"""tests.beta.test_tailwind"""
+
+from __future__ import annotations
+
+import math
+import typing
+from typing import Any, cast
+
+import pytest
+
+from xnano.beta.tailwind import (
+    KNOWN_TAILWIND_CLASSES,
+    TailwindBorderClass,
+    TailwindColorClass,
+    TailwindFlexClass,
+    TailwindSizingClass,
+    TailwindSpacingClass,
+    normalize_tailwind_classes,
+    resolve_tailwind_classes,
+)
+from xnano.color import Color
+from xnano.fields import Field, GridFieldInfo
+from xnano.sizing import Sizing
+from xnano.types import Padding
+
+
+TAILWIND_PALETTES = (
+    "amber",
+    "blue",
+    "cyan",
+    "emerald",
+    "fuchsia",
+    "gray",
+    "green",
+    "indigo",
+    "lime",
+    "neutral",
+    "orange",
+    "pink",
+    "purple",
+    "red",
+    "rose",
+    "sky",
+    "slate",
+    "stone",
+    "teal",
+    "violet",
+    "yellow",
+    "zinc",
+)
+
+TAILWIND_SHADES = (50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950)
+
+
+def expected_cells(units: float, *, vertical: bool) -> int:
+    """The aspect-corrected unit-to-cell formula, restated for tests."""
+    if units <= 0:
+        return 0
+    divisor = 4 if vertical else 2
+    return max(1, math.floor(units / divisor + 0.5))
+
+
+def literal_members(alias: object) -> tuple[str, ...]:
+    """The string members of a Literal type alias."""
+    return typing.get_args(alias)
+
+
+def field_info(**kwargs: Any) -> GridFieldInfo:
+    """Build a ``GridFieldInfo`` through ``Field`` with typed access."""
+    return cast(GridFieldInfo, Field(**kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Resolver — color group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("palette", TAILWIND_PALETTES)
+def test_resolve_every_palette_for_all_prefixes(palette: str) -> None:
+    for shade in TAILWIND_SHADES:
+        binding = f"{palette}-{shade}"
+        style = resolve_tailwind_classes(
+            f"text-{binding} bg-{binding} border-{binding}"
+        )
+        assert style.color == binding
+        assert style.background == binding
+        assert style.border_color == binding
+        assert style.passthrough_classes == ()
+        # Every binding must resolve to a real RGB color downstream.
+        parsed = Color.parse(binding)
+        assert 0 <= parsed.r <= 255
+        assert 0 <= parsed.g <= 255
+        assert 0 <= parsed.b <= 255
+
+
+def test_resolve_black_and_white_bindings() -> None:
+    style = resolve_tailwind_classes("text-white bg-black border-black")
+    assert style.color == "white"
+    assert style.background == "black"
+    assert style.border_color == "black"
+
+
+def test_color_last_wins_within_attribute() -> None:
+    style = resolve_tailwind_classes("text-red-500 text-blue-500")
+    assert style.color == "blue-500"
+    style = resolve_tailwind_classes("bg-slate-50 bg-slate-950")
+    assert style.background == "slate-950"
+
+
+def test_color_group_does_not_shadow_other_groups() -> None:
+    style = resolve_tailwind_classes("text-center text-xs border-2")
+    assert style.color is None
+    assert style.border_color is None
+    assert style.align == "center"
+    assert style.border == "thick"
+
+
+def test_border_color_does_not_imply_border_style() -> None:
+    style = resolve_tailwind_classes("border-emerald-300")
+    assert style.border_color == "emerald-300"
+    assert style.border is None
+
+
+def test_invalid_shades_are_passthrough() -> None:
+    style = resolve_tailwind_classes("text-slate-475 bg-slate-1000")
+    assert style.color is None
+    assert style.background is None
+    assert style.passthrough_classes == ("text-slate-475", "bg-slate-1000")
+
+
+# ---------------------------------------------------------------------------
+# Resolver — spacing group
+# ---------------------------------------------------------------------------
+
+
+SPACING_UNIT_VALUES: tuple[tuple[str, float], ...] = (
+    ("0", 0),
+    ("0.5", 0.5),
+    ("1", 1),
+    ("1.5", 1.5),
+    ("2", 2),
+    ("2.5", 2.5),
+    ("3", 3),
+    ("3.5", 3.5),
+    ("4", 4),
+    ("5", 5),
+    ("6", 6),
+    ("7", 7),
+    ("8", 8),
+    ("9", 9),
+    ("10", 10),
+    ("11", 11),
+    ("12", 12),
+    ("14", 14),
+    ("16", 16),
+    ("20", 20),
+    ("24", 24),
+    ("28", 28),
+    ("32", 32),
+    ("36", 36),
+    ("40", 40),
+    ("44", 44),
+    ("48", 48),
+    ("52", 52),
+    ("56", 56),
+    ("60", 60),
+    ("64", 64),
+    ("72", 72),
+    ("80", 80),
+    ("96", 96),
+    ("px", 1),
+)
+
+
+@pytest.mark.parametrize(("suffix", "units"), SPACING_UNIT_VALUES)
+def test_padding_scale_aspect_corrected(suffix: str, units: float) -> None:
+    style = resolve_tailwind_classes(f"p-{suffix}")
+    vertical = expected_cells(units, vertical=True)
+    horizontal = expected_cells(units, vertical=False)
+    assert style.padding == Padding(
+        top=vertical, right=horizontal, bottom=vertical, left=horizontal
+    )
+
+
+@pytest.mark.parametrize(("suffix", "units"), SPACING_UNIT_VALUES)
+def test_margin_scale_aspect_corrected(suffix: str, units: float) -> None:
+    style = resolve_tailwind_classes(f"m-{suffix}")
+    vertical = expected_cells(units, vertical=True)
+    horizontal = expected_cells(units, vertical=False)
+    assert style.margin == Padding(
+        top=vertical, right=horizontal, bottom=vertical, left=horizontal
+    )
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("px-8", Padding(right=4, left=4)),
+        ("py-8", Padding(top=2, bottom=2)),
+        ("pt-4", Padding(top=1)),
+        ("pr-4", Padding(right=2)),
+        ("pb-4", Padding(bottom=1)),
+        ("pl-4", Padding(left=2)),
+        ("mx-8", Padding(right=4, left=4)),
+        ("my-8", Padding(top=2, bottom=2)),
+        ("mt-2", Padding(top=1)),
+        ("mr-2", Padding(right=1)),
+        ("mb-2", Padding(bottom=1)),
+        ("ml-2", Padding(left=1)),
+    ],
+)
+def test_per_side_and_axis_spacing(token: str, expected: Padding) -> None:
+    style = resolve_tailwind_classes(token)
+    result = style.padding if token.startswith("p") else style.margin
+    assert result == expected
+
+
+def test_spacing_sides_accumulate() -> None:
+    style = resolve_tailwind_classes("px-8 pt-4 pb-0")
+    assert style.padding == Padding(top=1, right=4, bottom=0, left=4)
+
+
+def test_spacing_later_token_overwrites_side() -> None:
+    style = resolve_tailwind_classes("p-4 pt-0")
+    assert style.padding == Padding(top=0, right=2, bottom=1, left=2)
+    style = resolve_tailwind_classes("pt-4 p-0")
+    assert style.padding == Padding()
+
+
+def test_padding_and_margin_are_independent() -> None:
+    style = resolve_tailwind_classes("p-4 m-2")
+    assert style.padding == Padding(top=1, right=2, bottom=1, left=2)
+    assert style.margin == Padding(top=1, right=1, bottom=1, left=1)
+
+
+def test_resolve_gap_variants() -> None:
+    assert resolve_tailwind_classes("gap-4").gap == 1
+    assert resolve_tailwind_classes("gap-y-4").gap == 1
+    assert resolve_tailwind_classes("gap-x-4").gap == 2
+    assert resolve_tailwind_classes("gap-0").gap == 0
+    assert resolve_tailwind_classes("gap-8 gap-2").gap == 1
+
+
+def test_unscaled_spacing_suffix_is_passthrough() -> None:
+    style = resolve_tailwind_classes("p-13 m-99 gap-17")
+    assert style.padding is None
+    assert style.margin is None
+    assert style.gap is None
+    assert style.passthrough_classes == ("p-13", "m-99", "gap-17")
+
+
+# ---------------------------------------------------------------------------
+# Resolver — border group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("border", "plain"),
+        ("border-2", "thick"),
+        ("border-4", "thick"),
+        ("border-8", "thick"),
+        ("border-double", "double"),
+    ],
+)
+def test_border_style_tokens(token: str, expected: str) -> None:
+    assert resolve_tailwind_classes(token).border == expected
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "rounded",
+        "rounded-sm",
+        "rounded-md",
+        "rounded-lg",
+        "rounded-xl",
+        "rounded-2xl",
+        "rounded-3xl",
+        "rounded-full",
+    ],
+)
+def test_rounded_tokens(token: str) -> None:
+    assert resolve_tailwind_classes(token).border == "rounded"
+
+
+def test_border_zero_and_rounded_none() -> None:
+    assert resolve_tailwind_classes("border-0").border is None
+    assert resolve_tailwind_classes("rounded-none").border is None
+
+
+def test_border_does_not_downgrade_existing_style() -> None:
+    assert resolve_tailwind_classes("border-2 border").border == "thick"
+    assert resolve_tailwind_classes("rounded border").border == "rounded"
+
+
+@pytest.mark.parametrize(
+    ("token", "sides"),
+    [
+        ("border-t", ("top",)),
+        ("border-r", ("right",)),
+        ("border-b", ("bottom",)),
+        ("border-l", ("left",)),
+        ("border-x", ("left", "right")),
+        ("border-y", ("top", "bottom")),
+    ],
+)
+def test_border_side_tokens(token: str, sides: tuple[str, ...]) -> None:
+    style = resolve_tailwind_classes(token)
+    assert style.border == "plain"
+    assert style.border_sides == sides
+
+
+def test_border_sides_accumulate_without_duplicates() -> None:
+    style = resolve_tailwind_classes("border-t border-x border-t")
+    assert style.border_sides == ("top", "left", "right")
+
+
+def test_full_border_leaves_sides_unset() -> None:
+    assert resolve_tailwind_classes("border").border_sides is None
+
+
+# ---------------------------------------------------------------------------
+# Resolver — typography group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("token", "modifier"),
+    [
+        ("font-semibold", "bold"),
+        ("font-bold", "bold"),
+        ("font-extrabold", "bold"),
+        ("font-black", "bold"),
+        ("font-thin", "dim"),
+        ("font-extralight", "dim"),
+        ("font-light", "dim"),
+        ("italic", "italic"),
+        ("underline", "underline"),
+        ("animate-pulse", "slow_blink"),
+    ],
+)
+def test_typography_modifier_tokens(token: str, modifier: str) -> None:
+    assert resolve_tailwind_classes(token).modifiers == (modifier,)
+
+
+def test_typography_modifiers_accumulate_in_order() -> None:
+    style = resolve_tailwind_classes("font-bold italic underline font-bold")
+    assert style.modifiers == ("bold", "italic", "underline")
+
+
+@pytest.mark.parametrize(
+    "token", ["font-normal", "font-medium", "not-italic", "no-underline"]
+)
+def test_typography_noop_tokens(token: str) -> None:
+    style = resolve_tailwind_classes(token)
+    assert style.modifiers == ()
+    assert style.passthrough_classes == ()
+
+
+@pytest.mark.parametrize(
+    ("token", "align"),
+    [
+        ("text-left", "left"),
+        ("text-center", "center"),
+        ("text-right", "right"),
+    ],
+)
+def test_alignment_tokens(token: str, align: str) -> None:
+    assert resolve_tailwind_classes(token).align == align
+
+
+def test_alignment_last_wins() -> None:
+    style = resolve_tailwind_classes("text-left text-right")
+    assert style.align == "right"
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "text-xs",
+        "text-sm",
+        "text-base",
+        "text-lg",
+        "text-xl",
+        "text-2xl",
+        "text-9xl",
+    ],
+)
+def test_text_sizes_are_passthrough(token: str) -> None:
+    style = resolve_tailwind_classes(token)
+    assert style.passthrough_classes == (token,)
+    assert style.color is None
+    assert style.align is None
+
+
+# ---------------------------------------------------------------------------
+# Resolver — sizing group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("w-full", Sizing.percent(100)),
+        ("h-full", Sizing.percent(100)),
+        ("w-screen", Sizing.percent(100)),
+        ("h-screen", Sizing.percent(100)),
+        ("w-fit", Sizing.fit()),
+        ("w-auto", Sizing.fit()),
+        ("w-min", Sizing.fit()),
+        ("w-max", Sizing.fit()),
+        ("h-fit", Sizing.fit()),
+        ("w-1/2", Sizing.ratio(1, 2)),
+        ("w-2/3", Sizing.ratio(2, 3)),
+        ("w-3/4", Sizing.ratio(3, 4)),
+        ("h-1/3", Sizing.ratio(1, 3)),
+        ("h-4/5", Sizing.ratio(4, 5)),
+        ("w-5/6", Sizing.ratio(5, 6)),
+    ],
+)
+def test_sizing_keyword_and_fraction_tokens(
+    token: str, expected: Sizing
+) -> None:
+    style = resolve_tailwind_classes(token)
+    result = style.width if token.startswith("w-") else style.height
+    assert result == expected
+
+
+@pytest.mark.parametrize(("suffix", "units"), SPACING_UNIT_VALUES)
+def test_sizing_numeric_scale(suffix: str, units: float) -> None:
+    style = resolve_tailwind_classes(f"w-{suffix} h-{suffix}")
+    assert style.width == Sizing.cells(expected_cells(units, vertical=False))
+    assert style.height == Sizing.cells(expected_cells(units, vertical=True))
+
+
+def test_sizing_axes_are_independent() -> None:
+    style = resolve_tailwind_classes("w-full h-4")
+    assert style.width == Sizing.percent(100)
+    assert style.height == Sizing.cells(1)
+
+
+def test_sizing_last_wins() -> None:
+    style = resolve_tailwind_classes("w-full w-1/2")
+    assert style.width == Sizing.ratio(1, 2)
+
+
+# ---------------------------------------------------------------------------
+# Resolver — flex group
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_flex_direction() -> None:
+    assert resolve_tailwind_classes("flex-col").direction == "vertical"
+    assert resolve_tailwind_classes("flex-row").direction == "horizontal"
+    assert resolve_tailwind_classes("flex-row flex-col").direction == (
+        "vertical"
+    )
+
+
+@pytest.mark.parametrize(
+    ("token", "weight"),
+    [
+        ("flex-1", 1),
+        ("flex-auto", 1),
+        ("grow", 1),
+        ("shrink", 1),
+        ("flex-initial", 0),
+        ("flex-none", 0),
+        ("grow-0", 0),
+        ("shrink-0", 0),
+    ],
+)
+def test_flex_weight_tokens_set_both_axes(token: str, weight: int) -> None:
+    style = resolve_tailwind_classes(token)
+    assert style.width == Sizing.fraction(weight)
+    assert style.height == Sizing.fraction(weight)
+
+
+def test_bare_flex_is_recognized_but_lowers_nothing() -> None:
+    style = resolve_tailwind_classes("flex")
+    assert style.passthrough_classes == ()
+    assert style.width is None
+    assert style.direction is None
+
+
+def test_explicit_sizing_after_flex_weight_wins() -> None:
+    style = resolve_tailwind_classes("flex-1 h-4")
+    assert style.height == Sizing.cells(1)
+    assert style.width == Sizing.fraction(1)
+
+
+# ---------------------------------------------------------------------------
+# Resolver — passthrough, input forms, caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "shadow-lg",
+        "hover:bg-red-500",
+        "focus:ring-2",
+        "md:flex-row",
+        "transition-colors",
+        "truncate",
+        "overflow-hidden",
+        "cursor-pointer",
+        "select-none",
+        "opacity-50",
+        "completely-made-up-class",
+    ],
+)
+def test_unlowerable_classes_are_passthrough(token: str) -> None:
+    style = resolve_tailwind_classes(token)
+    assert style.passthrough_classes == (token,)
+    assert style.color is None
+    assert style.background is None
+    assert style.border is None
+    assert style.padding is None
+    assert style.width is None
+
+
+def test_passthrough_preserves_order_among_lowered() -> None:
+    style = resolve_tailwind_classes("shadow p-2 truncate text-red-500")
+    assert style.passthrough_classes == ("shadow", "truncate")
+    assert style.classes == ("shadow", "p-2", "truncate", "text-red-500")
+
+
+def test_string_and_sequence_forms_are_equivalent() -> None:
+    from_string = resolve_tailwind_classes("p-2 text-red-500")
+    from_sequence = resolve_tailwind_classes(("p-2", "text-red-500"))
+    from_list = resolve_tailwind_classes(["p-2", "text-red-500"])
+    assert from_string == from_sequence == from_list
+
+
+def test_normalize_splits_embedded_spaces_and_collapses() -> None:
+    assert normalize_tailwind_classes("  p-2   m-1 ") == ("p-2", "m-1")
+    assert normalize_tailwind_classes(["p-2 m-1", "border"]) == (
+        "p-2",
+        "m-1",
+        "border",
+    )
+    assert normalize_tailwind_classes("") == ()
+
+
+def test_normalize_rejects_bad_types() -> None:
+    with pytest.raises(TypeError):
+        normalize_tailwind_classes(cast(Any, 3))
+    with pytest.raises(TypeError):
+        normalize_tailwind_classes(cast(Any, ("p-2", 3)))
+    with pytest.raises(TypeError):
+        normalize_tailwind_classes(cast(Any, None))
+
+
+def test_resolution_is_cached() -> None:
+    first = resolve_tailwind_classes("p-2 text-red-500")
+    second = resolve_tailwind_classes(("p-2", "text-red-500"))
+    assert first is second
+
+
+def test_register_tailwind_class_group() -> None:
+    from xnano.beta import tailwind
+
+    class _AccentGroup(tailwind.AbstractTailwindClassGroup):
+        def match(self, token: str) -> bool:
+            return token == "accent"
+
+        def apply(
+            self, token: str, style: tailwind._TailwindStyleBuilder
+        ) -> None:
+            style.color = "violet-500"
+
+    group = _AccentGroup()
+    tailwind.register_tailwind_class_group(group)
+    try:
+        assert resolve_tailwind_classes("accent").color == "violet-500"
+    finally:
+        tailwind._TAILWIND_CLASS_GROUPS.remove(group)
+        tailwind._resolve_tokens.cache_clear()
+
+
+def test_builtin_groups_match_before_registered_groups() -> None:
+    from xnano.beta import tailwind
+
+    class _HijackGroup(tailwind.AbstractTailwindClassGroup):
+        def match(self, token: str) -> bool:
+            return True
+
+        def apply(
+            self, token: str, style: tailwind._TailwindStyleBuilder
+        ) -> None:
+            style.color = "red-500"
+
+    group = _HijackGroup()
+    tailwind.register_tailwind_class_group(group)
+    try:
+        assert resolve_tailwind_classes("bg-blue-500").background == (
+            "blue-500"
+        )
+        assert resolve_tailwind_classes("shadow-lg").color == "red-500"
+    finally:
+        tailwind._TAILWIND_CLASS_GROUPS.remove(group)
+        tailwind._resolve_tokens.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Literal <-> runtime drift
+# ---------------------------------------------------------------------------
+
+
+def test_known_classes_sanity() -> None:
+    assert "text-slate-950" in KNOWN_TAILWIND_CLASSES
+    assert "p-0.5" in KNOWN_TAILWIND_CLASSES
+    assert "rounded-lg" in KNOWN_TAILWIND_CLASSES
+    assert "flex-col" in KNOWN_TAILWIND_CLASSES
+    assert "shadow-2xl" in KNOWN_TAILWIND_CLASSES
+    assert all(isinstance(name, str) for name in KNOWN_TAILWIND_CLASSES)
+
+
+def test_every_known_class_resolves_without_error() -> None:
+    for token in KNOWN_TAILWIND_CLASSES:
+        resolve_tailwind_classes((token,))
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        TailwindColorClass,
+        TailwindSpacingClass,
+        TailwindBorderClass,
+        TailwindSizingClass,
+        TailwindFlexClass,
+    ],
+    ids=["color", "spacing", "border", "sizing", "flex"],
+)
+def test_lowerable_literal_groups_never_fall_through(alias: object) -> None:
+    """Every Literal member of a lowerable group must match a handler.
+
+    Guards against drift between the generated Literal blocks and the
+    runtime group matchers — a member falling through to passthrough
+    means the Literal advertises a class the resolver cannot lower.
+    """
+    for token in literal_members(alias):
+        style = resolve_tailwind_classes((token,))
+        assert style.passthrough_classes == (), (
+            f"{token!r} advertised as lowerable but fell through"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Field(class_name=...)
+# ---------------------------------------------------------------------------
+
+
+def test_field_derives_attributes_from_class_name() -> None:
+    info = field_info(
+        default="hi",
+        class_name="m-2 p-2 border rounded-lg bg-slate-900 text-slate-100",
+    )
+    assert info.color == "slate-100"
+    assert info.background == "slate-900"
+    assert info.border == "rounded"
+    assert info.padding == Padding(top=1, right=1, bottom=1, left=1)
+    assert info.margin == Padding(top=1, right=1, bottom=1, left=1)
+    assert info.class_name == (
+        "m-2",
+        "p-2",
+        "border",
+        "rounded-lg",
+        "bg-slate-900",
+        "text-slate-100",
+    )
+
+
+def test_field_derives_sizing_direction_and_gap() -> None:
+    info = field_info(
+        default="hi",
+        class_name="w-1/2 h-4 flex-col gap-4 text-center font-bold",
+    )
+    assert info.width == Sizing.ratio(1, 2)
+    assert info.height == Sizing.cells(1)
+    assert info.direction == "vertical"
+    assert info.gap == 1
+    assert info.align == "center"
+    assert info.modifiers == ("bold",)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "attr", "expected"),
+    [
+        ({"color": "red"}, "color", "red"),
+        ({"background": "blue"}, "background", "blue"),
+        ({"border": "double"}, "border", "double"),
+        ({"padding": 3}, "padding", 3),
+        ({"margin": 2}, "margin", 2),
+        ({"width": "75%"}, "width", Sizing.percent(75)),
+        ({"height": 9}, "height", Sizing.cells(9)),
+        ({"align": "right"}, "align", "right"),
+        ({"direction": "horizontal"}, "direction", "horizontal"),
+        ({"gap": 5}, "gap", 5),
+        (
+            {"modifiers": ("underline",)},
+            "modifiers",
+            ("underline",),
+        ),
+    ],
+)
+def test_field_explicit_kwargs_win(
+    kwargs: dict[str, Any], attr: str, expected: Any
+) -> None:
+    info = field_info(
+        default="x",
+        class_name=(
+            "text-blue-500 bg-red-500 border p-1 m-1 w-full h-full "
+            "text-left flex-row gap-2 font-bold"
+        ),
+        **kwargs,
+    )
+    assert getattr(info, attr) == expected
+
+
+def test_field_accepts_sequence() -> None:
+    info = field_info(default="x", class_name=("p-2", "font-bold"))
+    assert info.modifiers == ("bold",)
+    assert info.class_name == ("p-2", "font-bold")
+
+
+def test_field_accepts_single_token() -> None:
+    info = field_info(default="x", class_name="text-red-500")
+    assert info.color == "red-500"
+    assert info.class_name == ("text-red-500",)
+
+
+def test_field_without_class_name_has_no_tokens() -> None:
+    info = field_info(default="x", color="red", padding=1)
+    assert info.class_name is None
+    assert info.margin is None
+
+
+def test_field_keeps_unknown_classes_in_tokens() -> None:
+    info = field_info(default="x", class_name="shadow-lg custom-thing")
+    assert info.class_name == ("shadow-lg", "custom-thing")
+    assert info.color is None
+
+
+# ---------------------------------------------------------------------------
+# grid_set_field
+# ---------------------------------------------------------------------------
+
+
+def test_grid_set_field_class_name_roundtrip() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        header: str = Field(default="hi")
+
+    app = App()
+    app.grid_set_field("header", class_name="bg-blue-500 p-2 font-bold")
+    info = app._grid_field_info("header")
+    assert info.background == "blue-500"
+    assert info.padding == Padding(top=1, right=1, bottom=1, left=1)
+    assert info.modifiers == ("bold",)
+    assert info.class_name == ("bg-blue-500", "p-2", "font-bold")
+
+
+def test_grid_set_field_explicit_key_wins_over_class_name() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        header: str = Field(default="hi")
+
+    app = App()
+    app.grid_set_field("header", color="red", class_name="text-blue-500")
+    info = app._grid_field_info("header")
+    assert info.color == "red"
+
+
+def test_grid_set_field_class_name_accepts_sequence() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        header: str = Field(default="hi")
+
+    app = App()
+    app.grid_set_field("header", class_name=("m-2", "border rounded"))
+    info = app._grid_field_info("header")
+    assert info.margin == Padding(top=1, right=1, bottom=1, left=1)
+    assert info.border == "rounded"
+    assert info.class_name == ("m-2", "border", "rounded")
+
+
+def test_grid_set_field_modifier_flags_toggle() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        header: str = Field(default="hi")
+
+    app = App()
+    app.grid_set_field("header", bold=True, italic=True)
+    assert app._grid_field_info("header").modifiers == ("bold", "italic")
+    app.grid_set_field("header", bold=False)
+    assert app._grid_field_info("header").modifiers == ("italic",)
+    app.grid_set_field("header", underline=True)
+    assert app._grid_field_info("header").modifiers == (
+        "italic",
+        "underline",
+    )
+
+
+def test_grid_set_field_modifier_flags_on_top_of_class_name() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        header: str = Field(default="hi")
+
+    app = App()
+    app.grid_set_field("header", class_name="font-bold", dim=True)
+    assert app._grid_field_info("header").modifiers == ("bold", "dim")
+
+
+def test_grid_set_field_modifier_flags_with_explicit_modifiers() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        header: str = Field(default="hi")
+
+    app = App()
+    app.grid_set_field("header", modifiers=("underline",), bold=True)
+    assert app._grid_field_info("header").modifiers == (
+        "underline",
+        "bold",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Terminal rendering
+# ---------------------------------------------------------------------------
+
+
+def render_grid_offscreen(grid: Any, *, cols: int = 30, rows: int = 9) -> str:
+    from tests.helpers import (
+        close_offscreen_app,
+        open_offscreen_app,
+        paint,
+    )
+
+    terminal = open_offscreen_app(grid, cols=cols, rows=rows)
+    try:
+        return paint(terminal, grid)
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_terminal_renders_class_name_field() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        content: str = Field(
+            default="hello",
+            class_name="border rounded p-2 m-2 text-red-500",
+        )
+
+    output = render_grid_offscreen(App())
+    assert "hello" in output
+    assert "╭" in output  # rounded border corner
+
+    lines = output.split("\n")
+    top_border_row = next(
+        index for index, line in enumerate(lines) if "╭" in line
+    )
+    # m-2 → 1-row top margin and 1-column left margin.
+    assert top_border_row == 1
+    assert lines[top_border_row].index("╭") == 1
+
+
+def test_terminal_class_name_matches_explicit_kwargs() -> None:
+    """Class-derived chrome must render identically to explicit kwargs."""
+    from xnano import Grid
+
+    class ByClass(Grid):
+        content: str = Field(
+            default="hello", class_name="border p-4 text-red-500"
+        )
+
+    class ByKwargs(Grid):
+        content: str = Field(
+            default="hello",
+            border="plain",
+            padding=(1, 2),
+            color="red-500",
+        )
+
+    assert render_grid_offscreen(ByClass()) == render_grid_offscreen(
+        ByKwargs()
+    )
+
+
+def test_terminal_margin_insets_content() -> None:
+    from xnano import Grid
+
+    class Plain(Grid):
+        content: str = Field(default="hello")
+
+    class WithMargin(Grid):
+        content: str = Field(default="hello", class_name="m-4")
+
+    plain_lines = render_grid_offscreen(Plain()).split("\n")
+    margin_lines = render_grid_offscreen(WithMargin()).split("\n")
+    plain_row = next(
+        index for index, line in enumerate(plain_lines) if "hello" in line
+    )
+    margin_row = next(
+        index for index, line in enumerate(margin_lines) if "hello" in line
+    )
+    # m-4 → 1 row of top margin and 2 columns of left margin.
+    assert margin_row == plain_row + 1
+    assert margin_lines[margin_row].index("hello") == (
+        plain_lines[plain_row].index("hello") + 2
+    )
+
+
+def test_terminal_asymmetric_margin_sides() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        content: str = Field(
+            default="hello", class_name="mt-4 ml-8 border"
+        )
+
+    lines = render_grid_offscreen(App()).split("\n")
+    top_border_row = next(
+        index for index, line in enumerate(lines) if "┌" in line
+    )
+    assert top_border_row == 1  # mt-4 → 1 row
+    assert lines[top_border_row].index("┌") == 4  # ml-8 → 4 columns
+
+
+def test_terminal_width_class_constrains_split() -> None:
+    from xnano import Grid
+
+    class App(Grid, direction="horizontal"):
+        left: str = Field(default="L", class_name="w-8 border")
+        right: str = Field(default="R", border="plain")
+
+    lines = render_grid_offscreen(App(), cols=30, rows=5).split("\n")
+    border_row = next(line for line in lines if "┌" in line)
+    # w-8 → a 4-column slot (cells sizing spans the whole slot,
+    # border included).
+    assert border_row.index("┐") - border_row.index("┌") == 3
+
+
+def test_terminal_height_class_constrains_split() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        top: str = Field(default="T", class_name="h-16 border")
+        bottom: str = Field(default="B")
+
+    lines = render_grid_offscreen(App(), cols=20, rows=10).split("\n")
+    top_row = next(index for index, l in enumerate(lines) if "┌" in l)
+    bottom_row = next(index for index, l in enumerate(lines) if "└" in l)
+    # h-16 → a 4-row slot (cells sizing spans the whole slot,
+    # border included).
+    assert bottom_row - top_row == 3
+
+
+def test_terminal_ignores_web_only_classes() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        content: str = Field(
+            default="hello",
+            class_name="shadow-lg transition hover:bg-red-500 truncate",
+        )
+
+    output = render_grid_offscreen(App())
+    assert "hello" in output
+
+
+def test_terminal_grid_with_multiple_class_name_fields() -> None:
+    from xnano import Grid
+
+    class App(Grid, gap=1):
+        header: str = Field(
+            default="Header", class_name="h-4 border-b font-bold"
+        )
+        body: str = Field(default="Body", class_name="flex-1 p-2")
+        footer: str = Field(default="Footer", class_name="h-4 text-center")
+
+    output = render_grid_offscreen(App(), cols=30, rows=12)
+    assert "Header" in output
+    assert "Body" in output
+    assert "Footer" in output
+
+
+# ---------------------------------------------------------------------------
+# Web rendering
+# ---------------------------------------------------------------------------
+
+
+def render_grid_html(grid: Any) -> str:
+    from xnano.beta.controllers.web import WebController
+
+    return WebController().render_grid_html(grid)
+
+
+def test_web_emits_raw_classes_verbatim() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        header: str = Field(
+            default="Dashboard",
+            class_name="p-2 bg-slate-900 text-slate-100 shadow-lg",
+        )
+
+    html = render_grid_html(App())
+    assert "bg-slate-900" in html
+    assert "text-slate-100" in html
+    assert "shadow-lg" in html
+    # Class-derived styling must not duplicate as inline styles.
+    assert "color: rgb" not in html
+    assert "background-color" not in html
+    assert "padding:" not in html
+
+
+def test_web_emits_unknown_classes_verbatim() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        body: str = Field(default="x", class_name="my-custom-class md:p-8")
+
+    html = render_grid_html(App())
+    assert "my-custom-class" in html
+    assert "md:p-8" in html
+
+
+def test_web_inline_style_when_kwarg_overrides_class() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        body: str = Field(
+            default="x", color="red", class_name="text-blue-500"
+        )
+
+    html = render_grid_html(App())
+    assert "text-blue-500" in html
+    assert "color: rgb(255, 0, 0)" in html
+
+
+def test_web_suppresses_covered_modifier_classes() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        body: str = Field(default="x", class_name="font-bold")
+
+    html = render_grid_html(App())
+    assert html.count("font-bold") == 1
+
+
+def test_web_suppresses_covered_alignment() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        body: str = Field(default="x", class_name="text-center")
+
+    html = render_grid_html(App())
+    assert html.count("text-center") == 1
+
+
+def test_web_suppresses_covered_sizing() -> None:
+    from xnano import Grid
+
+    class App(Grid, direction="horizontal"):
+        left: str = Field(default="L", class_name="w-1/2")
+        right: str = Field(default="R")
+
+    html = render_grid_html(App())
+    assert "w-1/2" in html
+    assert "flex-basis" not in html
+
+
+def test_web_inline_sizing_when_kwarg_overrides_class() -> None:
+    from xnano import Grid
+
+    class App(Grid, direction="horizontal"):
+        left: str = Field(default="L", width="75%", class_name="w-1/2")
+        right: str = Field(default="R")
+
+    html = render_grid_html(App())
+    assert "w-1/2" in html
+    assert "flex-basis: 75%" in html
+
+
+def test_web_suppresses_covered_frame_chrome() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        body: str = Field(default="x", class_name="border rounded-lg p-1")
+
+    html = render_grid_html(App())
+    assert html.count("rounded-lg") == 1
+    assert "padding:" not in html
+    assert "border-zinc-600" not in html
+
+
+def test_web_keeps_frame_chrome_without_class_name() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        body: str = Field(default="x", border="rounded", padding=1)
+
+    html = render_grid_html(App())
+    assert "rounded-lg" in html
+    assert "border-zinc-600" in html
+    assert "padding:" in html
+
+
+def test_web_flex_weight_class_replaces_flex_grow_style() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        body: str = Field(default="x", class_name="flex-1")
+
+    html = render_grid_html(App())
+    assert "flex-1" in html
+    assert "flex-grow" not in html
+
+
+def test_web_margin_classes_have_no_inline_margin() -> None:
+    from xnano import Grid
+
+    class App(Grid):
+        body: str = Field(default="x", class_name="m-4")
+
+    html = render_grid_html(App())
+    assert "m-4" in html
+    assert "margin" not in html

--- a/xnano/beta/__init__.py
+++ b/xnano/beta/__init__.py
@@ -13,14 +13,34 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from xnano.beta.commands import Command
     from xnano.beta.requests import on_get_request, on_post_request
+    from xnano.beta.tailwind import (
+        TailwindClass,
+        TailwindStyle,
+        register_tailwind_class_group,
+        resolve_tailwind_classes,
+    )
     from xnano.beta.web import Web
 
 
 __all__ = (
     "Command",
+    "TailwindClass",
+    "TailwindStyle",
     "on_get_request",
     "on_post_request",
+    "register_tailwind_class_group",
+    "resolve_tailwind_classes",
     "Web",
+)
+
+
+_TAILWIND_EXPORTS = frozenset(
+    {
+        "TailwindClass",
+        "TailwindStyle",
+        "register_tailwind_class_group",
+        "resolve_tailwind_classes",
+    }
 )
 
 
@@ -29,6 +49,11 @@ def __getattr__(name: str):
         from xnano.beta.commands import Command
 
         return Command
+
+    elif name in _TAILWIND_EXPORTS:
+        from xnano.beta import tailwind
+
+        return getattr(tailwind, name)
 
     elif name == "on_get_request":
         from xnano.beta.requests import on_get_request

--- a/xnano/beta/controllers/web.py
+++ b/xnano/beta/controllers/web.py
@@ -21,6 +21,7 @@ from xnano.core.controllers.abstract import (
 from xnano.types import Area
 
 if TYPE_CHECKING:
+    from xnano.beta.tailwind import TailwindStyle
     from xnano.core.controllers.abstract import AbstractLayoutConstraint
     from xnano.fields import GridFieldInfo
     from xnano.frame import Frame
@@ -63,7 +64,9 @@ class _HtmlElement:
         parts: list[str] = [f"<{tag}"]
 
         if self.classes:
-            class_attr = " ".join(self.classes)
+            # De-duplicate (first occurrence wins) — raw Tailwind
+            # classes and frame-derived classes can overlap.
+            class_attr = " ".join(dict.fromkeys(self.classes))
             parts.append(f' class="{html.escape(class_attr, quote=True)}"')
 
         if self.styles:
@@ -244,14 +247,27 @@ class WebController(AbstractController):
 
         return area
 
-    def _apply_frame(self, element: _HtmlElement, frame: "Frame") -> None:
+    def _apply_frame(
+        self,
+        element: _HtmlElement,
+        frame: "Frame",
+        resolved: "TailwindStyle | None" = None,
+    ) -> None:
         """Apply frame chrome (border, title, padding) to an element.
 
         Args:
             element: The HTML element to decorate.
             frame: Frame with border, title, padding, etc.
+            resolved: The field's lowered Tailwind classes, when it has
+                any — frame values the classes already cover are
+                skipped because the raw classes style them natively.
         """
-        if frame.border is not None:
+        border_covered = (
+            resolved is not None
+            and resolved.border is not None
+            and frame.border == resolved.border
+        )
+        if frame.border is not None and not border_covered:
             element.classes.append("border")
             if frame.border == "rounded":
                 element.classes.append("rounded-lg")
@@ -262,9 +278,16 @@ class WebController(AbstractController):
             elif frame.border == "thick":
                 element.classes.append("border-2")
 
+        if frame.border is not None:
+            border_color_covered = (
+                resolved is not None
+                and resolved.border_color is not None
+                and frame.border_color == resolved.border_color
+            )
             if frame.border_color is None:
-                element.classes.append("border-zinc-600")
-            else:
+                if not border_covered:
+                    element.classes.append("border-zinc-600")
+            elif not border_color_covered:
                 from xnano.color import Color
 
                 try:
@@ -275,7 +298,12 @@ class WebController(AbstractController):
                 except Exception:
                     pass
 
-        if frame.background is not None:
+        background_covered = (
+            resolved is not None
+            and resolved.background is not None
+            and frame.background == resolved.background
+        )
+        if frame.background is not None and not background_covered:
             from xnano.color import Color
 
             try:
@@ -290,12 +318,18 @@ class WebController(AbstractController):
             from xnano.types import Padding
 
             padding = Padding.parse(frame.padding)
-            element.styles["padding"] = (
-                f"{padding.top * 0.25}rem "
-                f"{padding.right * 0.5}rem "
-                f"{padding.bottom * 0.25}rem "
-                f"{padding.left * 0.5}rem"
+            padding_covered = (
+                resolved is not None
+                and resolved.padding is not None
+                and padding == resolved.padding
             )
+            if not padding_covered:
+                element.styles["padding"] = (
+                    f"{padding.top * 0.25}rem "
+                    f"{padding.right * 0.5}rem "
+                    f"{padding.bottom * 0.25}rem "
+                    f"{padding.left * 0.5}rem"
+                )
 
         if frame.title is not None:
             element.classes.append("relative")
@@ -310,7 +344,10 @@ class WebController(AbstractController):
             element.children.insert(0, title_element)
 
     def _apply_field_sizing(
-        self, element: _HtmlElement, field: "GridFieldInfo | None"
+        self,
+        element: _HtmlElement,
+        field: "GridFieldInfo | None",
+        resolved: "TailwindStyle | None" = None,
     ) -> None:
         """Apply width/height sizing to a field wrapper element.
 
@@ -320,11 +357,25 @@ class WebController(AbstractController):
         Args:
             element: The HTML element to size.
             field: The field with width/height sizing info (or None).
+            resolved: The field's lowered Tailwind classes, when it has
+                any — sizing the classes already cover is skipped
+                because the raw classes size the element natively.
         """
         if field is None:
             return
 
-        if field.width is not None:
+        width_covered = (
+            resolved is not None
+            and resolved.width is not None
+            and field.width == resolved.width
+        )
+        height_covered = (
+            resolved is not None
+            and resolved.height is not None
+            and field.height == resolved.height
+        )
+
+        if field.width is not None and not width_covered:
             sizing = field.width
             if sizing.kind == "fraction":
                 element.styles["flex-grow"] = str(sizing.value)
@@ -337,7 +388,7 @@ class WebController(AbstractController):
             elif sizing.kind == "fit":
                 element.classes.append("flex-none")
 
-        if field.height is not None:
+        if field.height is not None and not height_covered:
             sizing = field.height
             if sizing.kind == "cells":
                 element.styles["height"] = f"{sizing.value * 1.5}rem"
@@ -428,25 +479,67 @@ class WebController(AbstractController):
 
         wrapper = _HtmlElement()
 
+        resolved: "TailwindStyle | None" = None
+        if field is not None and field.class_name:
+            from xnano.beta.tailwind import resolve_tailwind_classes
+
+            resolved = resolve_tailwind_classes(field.class_name)
+            # Raw classes go out verbatim — the browser's Tailwind
+            # runtime honors every one, including classes the terminal
+            # cannot lower (shadow-*, hover:*, ...).
+            wrapper.classes.extend(field.class_name)
+
         if field is not None:
-            self._apply_field_sizing(wrapper, field)
+            self._apply_field_sizing(wrapper, field, resolved)
 
         if field is not None:
             from xnano.beta.nodes.web import build_style_attrs
 
+            # A derived inline style is skipped when the merged field
+            # value equals the class-derived one (the raw class already
+            # covers it); a differing value means an explicit kwarg
+            # overrode the class, and inline styles beat classes.
+            def _covered(field_value: Any, derived_value: Any) -> bool:
+                return (
+                    resolved is not None
+                    and derived_value is not None
+                    and field_value == derived_value
+                )
+
+            derived_modifiers = resolved.modifiers if resolved else None
             classes, styles = build_style_attrs(
-                color=field.color,
-                background=field.background,
-                modifiers=(
-                    tuple(field.modifiers) if field.modifiers else None
+                color=(
+                    None
+                    if _covered(field.color, resolved and resolved.color)
+                    else field.color
                 ),
-                align=field.align,
+                background=(
+                    None
+                    if _covered(
+                        field.background, resolved and resolved.background
+                    )
+                    else field.background
+                ),
+                modifiers=(
+                    None
+                    if (
+                        field.modifiers
+                        and derived_modifiers
+                        and tuple(field.modifiers) == derived_modifiers
+                    )
+                    else (tuple(field.modifiers) if field.modifiers else None)
+                ),
+                align=(
+                    None
+                    if _covered(field.align, resolved and resolved.align)
+                    else field.align
+                ),
             )
             wrapper.classes.extend(classes)
             wrapper.styles.update(styles)
 
         if self._pending_frame is not None:
-            self._apply_frame(wrapper, self._pending_frame)
+            self._apply_frame(wrapper, self._pending_frame, resolved)
             self._pending_frame = None
 
         if effect_key is not None and self._grid_stack:

--- a/xnano/beta/tailwind.py
+++ b/xnano/beta/tailwind.py
@@ -1,0 +1,2263 @@
+"""xnano.beta.tailwind
+
+---
+
+Tailwind CSS utility-class support for grids, shared by the terminal
+and web backends. The ``TailwindClass`` Literal alias enumerates every
+supported class; ``resolve_tailwind_classes`` lowers a class string or
+sequence into a ``TailwindStyle`` expressed in xnano's own vocabulary
+(``Color`` bindings, ``Padding``, ``Sizing``, borders, modifiers).
+
+The terminal backend renders the lowered values through the existing
+field pipeline; classes with no terminal equivalent are silently
+ignored there and carried verbatim to the web backend through
+``TailwindStyle.passthrough_classes``.
+
+Resolution is organized as one handler per utility group (color,
+spacing, border, typography, sizing, flex), mirroring the controller
+and node plugin patterns — register additional groups with
+``register_tailwind_class_group``.
+"""
+
+from __future__ import annotations
+
+import abc
+import dataclasses
+import functools
+import math
+import typing
+from typing import Literal, Sequence, TypeAlias, Union
+
+from xnano import types
+from xnano.color import _TAILWIND_NAMES, _TAILWIND_SHADES, ColorLike
+from xnano.sizing import Sizing
+
+
+# --- generated: do not hand-edit below this marker -------------------
+# Regenerate with ``uv run python scripts/generate_tailwind_literal.py``
+# and replace everything between the generated markers.
+
+TailwindColorClass: TypeAlias = Literal[
+    "text-black",
+    "text-white",
+    "text-amber-50",
+    "text-amber-100",
+    "text-amber-200",
+    "text-amber-300",
+    "text-amber-400",
+    "text-amber-500",
+    "text-amber-600",
+    "text-amber-700",
+    "text-amber-800",
+    "text-amber-900",
+    "text-amber-950",
+    "text-blue-50",
+    "text-blue-100",
+    "text-blue-200",
+    "text-blue-300",
+    "text-blue-400",
+    "text-blue-500",
+    "text-blue-600",
+    "text-blue-700",
+    "text-blue-800",
+    "text-blue-900",
+    "text-blue-950",
+    "text-cyan-50",
+    "text-cyan-100",
+    "text-cyan-200",
+    "text-cyan-300",
+    "text-cyan-400",
+    "text-cyan-500",
+    "text-cyan-600",
+    "text-cyan-700",
+    "text-cyan-800",
+    "text-cyan-900",
+    "text-cyan-950",
+    "text-emerald-50",
+    "text-emerald-100",
+    "text-emerald-200",
+    "text-emerald-300",
+    "text-emerald-400",
+    "text-emerald-500",
+    "text-emerald-600",
+    "text-emerald-700",
+    "text-emerald-800",
+    "text-emerald-900",
+    "text-emerald-950",
+    "text-fuchsia-50",
+    "text-fuchsia-100",
+    "text-fuchsia-200",
+    "text-fuchsia-300",
+    "text-fuchsia-400",
+    "text-fuchsia-500",
+    "text-fuchsia-600",
+    "text-fuchsia-700",
+    "text-fuchsia-800",
+    "text-fuchsia-900",
+    "text-fuchsia-950",
+    "text-gray-50",
+    "text-gray-100",
+    "text-gray-200",
+    "text-gray-300",
+    "text-gray-400",
+    "text-gray-500",
+    "text-gray-600",
+    "text-gray-700",
+    "text-gray-800",
+    "text-gray-900",
+    "text-gray-950",
+    "text-green-50",
+    "text-green-100",
+    "text-green-200",
+    "text-green-300",
+    "text-green-400",
+    "text-green-500",
+    "text-green-600",
+    "text-green-700",
+    "text-green-800",
+    "text-green-900",
+    "text-green-950",
+    "text-indigo-50",
+    "text-indigo-100",
+    "text-indigo-200",
+    "text-indigo-300",
+    "text-indigo-400",
+    "text-indigo-500",
+    "text-indigo-600",
+    "text-indigo-700",
+    "text-indigo-800",
+    "text-indigo-900",
+    "text-indigo-950",
+    "text-lime-50",
+    "text-lime-100",
+    "text-lime-200",
+    "text-lime-300",
+    "text-lime-400",
+    "text-lime-500",
+    "text-lime-600",
+    "text-lime-700",
+    "text-lime-800",
+    "text-lime-900",
+    "text-lime-950",
+    "text-neutral-50",
+    "text-neutral-100",
+    "text-neutral-200",
+    "text-neutral-300",
+    "text-neutral-400",
+    "text-neutral-500",
+    "text-neutral-600",
+    "text-neutral-700",
+    "text-neutral-800",
+    "text-neutral-900",
+    "text-neutral-950",
+    "text-orange-50",
+    "text-orange-100",
+    "text-orange-200",
+    "text-orange-300",
+    "text-orange-400",
+    "text-orange-500",
+    "text-orange-600",
+    "text-orange-700",
+    "text-orange-800",
+    "text-orange-900",
+    "text-orange-950",
+    "text-pink-50",
+    "text-pink-100",
+    "text-pink-200",
+    "text-pink-300",
+    "text-pink-400",
+    "text-pink-500",
+    "text-pink-600",
+    "text-pink-700",
+    "text-pink-800",
+    "text-pink-900",
+    "text-pink-950",
+    "text-purple-50",
+    "text-purple-100",
+    "text-purple-200",
+    "text-purple-300",
+    "text-purple-400",
+    "text-purple-500",
+    "text-purple-600",
+    "text-purple-700",
+    "text-purple-800",
+    "text-purple-900",
+    "text-purple-950",
+    "text-red-50",
+    "text-red-100",
+    "text-red-200",
+    "text-red-300",
+    "text-red-400",
+    "text-red-500",
+    "text-red-600",
+    "text-red-700",
+    "text-red-800",
+    "text-red-900",
+    "text-red-950",
+    "text-rose-50",
+    "text-rose-100",
+    "text-rose-200",
+    "text-rose-300",
+    "text-rose-400",
+    "text-rose-500",
+    "text-rose-600",
+    "text-rose-700",
+    "text-rose-800",
+    "text-rose-900",
+    "text-rose-950",
+    "text-sky-50",
+    "text-sky-100",
+    "text-sky-200",
+    "text-sky-300",
+    "text-sky-400",
+    "text-sky-500",
+    "text-sky-600",
+    "text-sky-700",
+    "text-sky-800",
+    "text-sky-900",
+    "text-sky-950",
+    "text-slate-50",
+    "text-slate-100",
+    "text-slate-200",
+    "text-slate-300",
+    "text-slate-400",
+    "text-slate-500",
+    "text-slate-600",
+    "text-slate-700",
+    "text-slate-800",
+    "text-slate-900",
+    "text-slate-950",
+    "text-stone-50",
+    "text-stone-100",
+    "text-stone-200",
+    "text-stone-300",
+    "text-stone-400",
+    "text-stone-500",
+    "text-stone-600",
+    "text-stone-700",
+    "text-stone-800",
+    "text-stone-900",
+    "text-stone-950",
+    "text-teal-50",
+    "text-teal-100",
+    "text-teal-200",
+    "text-teal-300",
+    "text-teal-400",
+    "text-teal-500",
+    "text-teal-600",
+    "text-teal-700",
+    "text-teal-800",
+    "text-teal-900",
+    "text-teal-950",
+    "text-violet-50",
+    "text-violet-100",
+    "text-violet-200",
+    "text-violet-300",
+    "text-violet-400",
+    "text-violet-500",
+    "text-violet-600",
+    "text-violet-700",
+    "text-violet-800",
+    "text-violet-900",
+    "text-violet-950",
+    "text-yellow-50",
+    "text-yellow-100",
+    "text-yellow-200",
+    "text-yellow-300",
+    "text-yellow-400",
+    "text-yellow-500",
+    "text-yellow-600",
+    "text-yellow-700",
+    "text-yellow-800",
+    "text-yellow-900",
+    "text-yellow-950",
+    "text-zinc-50",
+    "text-zinc-100",
+    "text-zinc-200",
+    "text-zinc-300",
+    "text-zinc-400",
+    "text-zinc-500",
+    "text-zinc-600",
+    "text-zinc-700",
+    "text-zinc-800",
+    "text-zinc-900",
+    "text-zinc-950",
+    "bg-black",
+    "bg-white",
+    "bg-amber-50",
+    "bg-amber-100",
+    "bg-amber-200",
+    "bg-amber-300",
+    "bg-amber-400",
+    "bg-amber-500",
+    "bg-amber-600",
+    "bg-amber-700",
+    "bg-amber-800",
+    "bg-amber-900",
+    "bg-amber-950",
+    "bg-blue-50",
+    "bg-blue-100",
+    "bg-blue-200",
+    "bg-blue-300",
+    "bg-blue-400",
+    "bg-blue-500",
+    "bg-blue-600",
+    "bg-blue-700",
+    "bg-blue-800",
+    "bg-blue-900",
+    "bg-blue-950",
+    "bg-cyan-50",
+    "bg-cyan-100",
+    "bg-cyan-200",
+    "bg-cyan-300",
+    "bg-cyan-400",
+    "bg-cyan-500",
+    "bg-cyan-600",
+    "bg-cyan-700",
+    "bg-cyan-800",
+    "bg-cyan-900",
+    "bg-cyan-950",
+    "bg-emerald-50",
+    "bg-emerald-100",
+    "bg-emerald-200",
+    "bg-emerald-300",
+    "bg-emerald-400",
+    "bg-emerald-500",
+    "bg-emerald-600",
+    "bg-emerald-700",
+    "bg-emerald-800",
+    "bg-emerald-900",
+    "bg-emerald-950",
+    "bg-fuchsia-50",
+    "bg-fuchsia-100",
+    "bg-fuchsia-200",
+    "bg-fuchsia-300",
+    "bg-fuchsia-400",
+    "bg-fuchsia-500",
+    "bg-fuchsia-600",
+    "bg-fuchsia-700",
+    "bg-fuchsia-800",
+    "bg-fuchsia-900",
+    "bg-fuchsia-950",
+    "bg-gray-50",
+    "bg-gray-100",
+    "bg-gray-200",
+    "bg-gray-300",
+    "bg-gray-400",
+    "bg-gray-500",
+    "bg-gray-600",
+    "bg-gray-700",
+    "bg-gray-800",
+    "bg-gray-900",
+    "bg-gray-950",
+    "bg-green-50",
+    "bg-green-100",
+    "bg-green-200",
+    "bg-green-300",
+    "bg-green-400",
+    "bg-green-500",
+    "bg-green-600",
+    "bg-green-700",
+    "bg-green-800",
+    "bg-green-900",
+    "bg-green-950",
+    "bg-indigo-50",
+    "bg-indigo-100",
+    "bg-indigo-200",
+    "bg-indigo-300",
+    "bg-indigo-400",
+    "bg-indigo-500",
+    "bg-indigo-600",
+    "bg-indigo-700",
+    "bg-indigo-800",
+    "bg-indigo-900",
+    "bg-indigo-950",
+    "bg-lime-50",
+    "bg-lime-100",
+    "bg-lime-200",
+    "bg-lime-300",
+    "bg-lime-400",
+    "bg-lime-500",
+    "bg-lime-600",
+    "bg-lime-700",
+    "bg-lime-800",
+    "bg-lime-900",
+    "bg-lime-950",
+    "bg-neutral-50",
+    "bg-neutral-100",
+    "bg-neutral-200",
+    "bg-neutral-300",
+    "bg-neutral-400",
+    "bg-neutral-500",
+    "bg-neutral-600",
+    "bg-neutral-700",
+    "bg-neutral-800",
+    "bg-neutral-900",
+    "bg-neutral-950",
+    "bg-orange-50",
+    "bg-orange-100",
+    "bg-orange-200",
+    "bg-orange-300",
+    "bg-orange-400",
+    "bg-orange-500",
+    "bg-orange-600",
+    "bg-orange-700",
+    "bg-orange-800",
+    "bg-orange-900",
+    "bg-orange-950",
+    "bg-pink-50",
+    "bg-pink-100",
+    "bg-pink-200",
+    "bg-pink-300",
+    "bg-pink-400",
+    "bg-pink-500",
+    "bg-pink-600",
+    "bg-pink-700",
+    "bg-pink-800",
+    "bg-pink-900",
+    "bg-pink-950",
+    "bg-purple-50",
+    "bg-purple-100",
+    "bg-purple-200",
+    "bg-purple-300",
+    "bg-purple-400",
+    "bg-purple-500",
+    "bg-purple-600",
+    "bg-purple-700",
+    "bg-purple-800",
+    "bg-purple-900",
+    "bg-purple-950",
+    "bg-red-50",
+    "bg-red-100",
+    "bg-red-200",
+    "bg-red-300",
+    "bg-red-400",
+    "bg-red-500",
+    "bg-red-600",
+    "bg-red-700",
+    "bg-red-800",
+    "bg-red-900",
+    "bg-red-950",
+    "bg-rose-50",
+    "bg-rose-100",
+    "bg-rose-200",
+    "bg-rose-300",
+    "bg-rose-400",
+    "bg-rose-500",
+    "bg-rose-600",
+    "bg-rose-700",
+    "bg-rose-800",
+    "bg-rose-900",
+    "bg-rose-950",
+    "bg-sky-50",
+    "bg-sky-100",
+    "bg-sky-200",
+    "bg-sky-300",
+    "bg-sky-400",
+    "bg-sky-500",
+    "bg-sky-600",
+    "bg-sky-700",
+    "bg-sky-800",
+    "bg-sky-900",
+    "bg-sky-950",
+    "bg-slate-50",
+    "bg-slate-100",
+    "bg-slate-200",
+    "bg-slate-300",
+    "bg-slate-400",
+    "bg-slate-500",
+    "bg-slate-600",
+    "bg-slate-700",
+    "bg-slate-800",
+    "bg-slate-900",
+    "bg-slate-950",
+    "bg-stone-50",
+    "bg-stone-100",
+    "bg-stone-200",
+    "bg-stone-300",
+    "bg-stone-400",
+    "bg-stone-500",
+    "bg-stone-600",
+    "bg-stone-700",
+    "bg-stone-800",
+    "bg-stone-900",
+    "bg-stone-950",
+    "bg-teal-50",
+    "bg-teal-100",
+    "bg-teal-200",
+    "bg-teal-300",
+    "bg-teal-400",
+    "bg-teal-500",
+    "bg-teal-600",
+    "bg-teal-700",
+    "bg-teal-800",
+    "bg-teal-900",
+    "bg-teal-950",
+    "bg-violet-50",
+    "bg-violet-100",
+    "bg-violet-200",
+    "bg-violet-300",
+    "bg-violet-400",
+    "bg-violet-500",
+    "bg-violet-600",
+    "bg-violet-700",
+    "bg-violet-800",
+    "bg-violet-900",
+    "bg-violet-950",
+    "bg-yellow-50",
+    "bg-yellow-100",
+    "bg-yellow-200",
+    "bg-yellow-300",
+    "bg-yellow-400",
+    "bg-yellow-500",
+    "bg-yellow-600",
+    "bg-yellow-700",
+    "bg-yellow-800",
+    "bg-yellow-900",
+    "bg-yellow-950",
+    "bg-zinc-50",
+    "bg-zinc-100",
+    "bg-zinc-200",
+    "bg-zinc-300",
+    "bg-zinc-400",
+    "bg-zinc-500",
+    "bg-zinc-600",
+    "bg-zinc-700",
+    "bg-zinc-800",
+    "bg-zinc-900",
+    "bg-zinc-950",
+    "border-black",
+    "border-white",
+    "border-amber-50",
+    "border-amber-100",
+    "border-amber-200",
+    "border-amber-300",
+    "border-amber-400",
+    "border-amber-500",
+    "border-amber-600",
+    "border-amber-700",
+    "border-amber-800",
+    "border-amber-900",
+    "border-amber-950",
+    "border-blue-50",
+    "border-blue-100",
+    "border-blue-200",
+    "border-blue-300",
+    "border-blue-400",
+    "border-blue-500",
+    "border-blue-600",
+    "border-blue-700",
+    "border-blue-800",
+    "border-blue-900",
+    "border-blue-950",
+    "border-cyan-50",
+    "border-cyan-100",
+    "border-cyan-200",
+    "border-cyan-300",
+    "border-cyan-400",
+    "border-cyan-500",
+    "border-cyan-600",
+    "border-cyan-700",
+    "border-cyan-800",
+    "border-cyan-900",
+    "border-cyan-950",
+    "border-emerald-50",
+    "border-emerald-100",
+    "border-emerald-200",
+    "border-emerald-300",
+    "border-emerald-400",
+    "border-emerald-500",
+    "border-emerald-600",
+    "border-emerald-700",
+    "border-emerald-800",
+    "border-emerald-900",
+    "border-emerald-950",
+    "border-fuchsia-50",
+    "border-fuchsia-100",
+    "border-fuchsia-200",
+    "border-fuchsia-300",
+    "border-fuchsia-400",
+    "border-fuchsia-500",
+    "border-fuchsia-600",
+    "border-fuchsia-700",
+    "border-fuchsia-800",
+    "border-fuchsia-900",
+    "border-fuchsia-950",
+    "border-gray-50",
+    "border-gray-100",
+    "border-gray-200",
+    "border-gray-300",
+    "border-gray-400",
+    "border-gray-500",
+    "border-gray-600",
+    "border-gray-700",
+    "border-gray-800",
+    "border-gray-900",
+    "border-gray-950",
+    "border-green-50",
+    "border-green-100",
+    "border-green-200",
+    "border-green-300",
+    "border-green-400",
+    "border-green-500",
+    "border-green-600",
+    "border-green-700",
+    "border-green-800",
+    "border-green-900",
+    "border-green-950",
+    "border-indigo-50",
+    "border-indigo-100",
+    "border-indigo-200",
+    "border-indigo-300",
+    "border-indigo-400",
+    "border-indigo-500",
+    "border-indigo-600",
+    "border-indigo-700",
+    "border-indigo-800",
+    "border-indigo-900",
+    "border-indigo-950",
+    "border-lime-50",
+    "border-lime-100",
+    "border-lime-200",
+    "border-lime-300",
+    "border-lime-400",
+    "border-lime-500",
+    "border-lime-600",
+    "border-lime-700",
+    "border-lime-800",
+    "border-lime-900",
+    "border-lime-950",
+    "border-neutral-50",
+    "border-neutral-100",
+    "border-neutral-200",
+    "border-neutral-300",
+    "border-neutral-400",
+    "border-neutral-500",
+    "border-neutral-600",
+    "border-neutral-700",
+    "border-neutral-800",
+    "border-neutral-900",
+    "border-neutral-950",
+    "border-orange-50",
+    "border-orange-100",
+    "border-orange-200",
+    "border-orange-300",
+    "border-orange-400",
+    "border-orange-500",
+    "border-orange-600",
+    "border-orange-700",
+    "border-orange-800",
+    "border-orange-900",
+    "border-orange-950",
+    "border-pink-50",
+    "border-pink-100",
+    "border-pink-200",
+    "border-pink-300",
+    "border-pink-400",
+    "border-pink-500",
+    "border-pink-600",
+    "border-pink-700",
+    "border-pink-800",
+    "border-pink-900",
+    "border-pink-950",
+    "border-purple-50",
+    "border-purple-100",
+    "border-purple-200",
+    "border-purple-300",
+    "border-purple-400",
+    "border-purple-500",
+    "border-purple-600",
+    "border-purple-700",
+    "border-purple-800",
+    "border-purple-900",
+    "border-purple-950",
+    "border-red-50",
+    "border-red-100",
+    "border-red-200",
+    "border-red-300",
+    "border-red-400",
+    "border-red-500",
+    "border-red-600",
+    "border-red-700",
+    "border-red-800",
+    "border-red-900",
+    "border-red-950",
+    "border-rose-50",
+    "border-rose-100",
+    "border-rose-200",
+    "border-rose-300",
+    "border-rose-400",
+    "border-rose-500",
+    "border-rose-600",
+    "border-rose-700",
+    "border-rose-800",
+    "border-rose-900",
+    "border-rose-950",
+    "border-sky-50",
+    "border-sky-100",
+    "border-sky-200",
+    "border-sky-300",
+    "border-sky-400",
+    "border-sky-500",
+    "border-sky-600",
+    "border-sky-700",
+    "border-sky-800",
+    "border-sky-900",
+    "border-sky-950",
+    "border-slate-50",
+    "border-slate-100",
+    "border-slate-200",
+    "border-slate-300",
+    "border-slate-400",
+    "border-slate-500",
+    "border-slate-600",
+    "border-slate-700",
+    "border-slate-800",
+    "border-slate-900",
+    "border-slate-950",
+    "border-stone-50",
+    "border-stone-100",
+    "border-stone-200",
+    "border-stone-300",
+    "border-stone-400",
+    "border-stone-500",
+    "border-stone-600",
+    "border-stone-700",
+    "border-stone-800",
+    "border-stone-900",
+    "border-stone-950",
+    "border-teal-50",
+    "border-teal-100",
+    "border-teal-200",
+    "border-teal-300",
+    "border-teal-400",
+    "border-teal-500",
+    "border-teal-600",
+    "border-teal-700",
+    "border-teal-800",
+    "border-teal-900",
+    "border-teal-950",
+    "border-violet-50",
+    "border-violet-100",
+    "border-violet-200",
+    "border-violet-300",
+    "border-violet-400",
+    "border-violet-500",
+    "border-violet-600",
+    "border-violet-700",
+    "border-violet-800",
+    "border-violet-900",
+    "border-violet-950",
+    "border-yellow-50",
+    "border-yellow-100",
+    "border-yellow-200",
+    "border-yellow-300",
+    "border-yellow-400",
+    "border-yellow-500",
+    "border-yellow-600",
+    "border-yellow-700",
+    "border-yellow-800",
+    "border-yellow-900",
+    "border-yellow-950",
+    "border-zinc-50",
+    "border-zinc-100",
+    "border-zinc-200",
+    "border-zinc-300",
+    "border-zinc-400",
+    "border-zinc-500",
+    "border-zinc-600",
+    "border-zinc-700",
+    "border-zinc-800",
+    "border-zinc-900",
+    "border-zinc-950",
+]
+
+
+TailwindSpacingClass: TypeAlias = Literal[
+    "p-0",
+    "p-0.5",
+    "p-1",
+    "p-1.5",
+    "p-2",
+    "p-2.5",
+    "p-3",
+    "p-3.5",
+    "p-4",
+    "p-5",
+    "p-6",
+    "p-7",
+    "p-8",
+    "p-9",
+    "p-10",
+    "p-11",
+    "p-12",
+    "p-14",
+    "p-16",
+    "p-20",
+    "p-24",
+    "p-28",
+    "p-32",
+    "p-36",
+    "p-40",
+    "p-44",
+    "p-48",
+    "p-52",
+    "p-56",
+    "p-60",
+    "p-64",
+    "p-72",
+    "p-80",
+    "p-96",
+    "p-px",
+    "px-0",
+    "px-0.5",
+    "px-1",
+    "px-1.5",
+    "px-2",
+    "px-2.5",
+    "px-3",
+    "px-3.5",
+    "px-4",
+    "px-5",
+    "px-6",
+    "px-7",
+    "px-8",
+    "px-9",
+    "px-10",
+    "px-11",
+    "px-12",
+    "px-14",
+    "px-16",
+    "px-20",
+    "px-24",
+    "px-28",
+    "px-32",
+    "px-36",
+    "px-40",
+    "px-44",
+    "px-48",
+    "px-52",
+    "px-56",
+    "px-60",
+    "px-64",
+    "px-72",
+    "px-80",
+    "px-96",
+    "px-px",
+    "py-0",
+    "py-0.5",
+    "py-1",
+    "py-1.5",
+    "py-2",
+    "py-2.5",
+    "py-3",
+    "py-3.5",
+    "py-4",
+    "py-5",
+    "py-6",
+    "py-7",
+    "py-8",
+    "py-9",
+    "py-10",
+    "py-11",
+    "py-12",
+    "py-14",
+    "py-16",
+    "py-20",
+    "py-24",
+    "py-28",
+    "py-32",
+    "py-36",
+    "py-40",
+    "py-44",
+    "py-48",
+    "py-52",
+    "py-56",
+    "py-60",
+    "py-64",
+    "py-72",
+    "py-80",
+    "py-96",
+    "py-px",
+    "pt-0",
+    "pt-0.5",
+    "pt-1",
+    "pt-1.5",
+    "pt-2",
+    "pt-2.5",
+    "pt-3",
+    "pt-3.5",
+    "pt-4",
+    "pt-5",
+    "pt-6",
+    "pt-7",
+    "pt-8",
+    "pt-9",
+    "pt-10",
+    "pt-11",
+    "pt-12",
+    "pt-14",
+    "pt-16",
+    "pt-20",
+    "pt-24",
+    "pt-28",
+    "pt-32",
+    "pt-36",
+    "pt-40",
+    "pt-44",
+    "pt-48",
+    "pt-52",
+    "pt-56",
+    "pt-60",
+    "pt-64",
+    "pt-72",
+    "pt-80",
+    "pt-96",
+    "pt-px",
+    "pr-0",
+    "pr-0.5",
+    "pr-1",
+    "pr-1.5",
+    "pr-2",
+    "pr-2.5",
+    "pr-3",
+    "pr-3.5",
+    "pr-4",
+    "pr-5",
+    "pr-6",
+    "pr-7",
+    "pr-8",
+    "pr-9",
+    "pr-10",
+    "pr-11",
+    "pr-12",
+    "pr-14",
+    "pr-16",
+    "pr-20",
+    "pr-24",
+    "pr-28",
+    "pr-32",
+    "pr-36",
+    "pr-40",
+    "pr-44",
+    "pr-48",
+    "pr-52",
+    "pr-56",
+    "pr-60",
+    "pr-64",
+    "pr-72",
+    "pr-80",
+    "pr-96",
+    "pr-px",
+    "pb-0",
+    "pb-0.5",
+    "pb-1",
+    "pb-1.5",
+    "pb-2",
+    "pb-2.5",
+    "pb-3",
+    "pb-3.5",
+    "pb-4",
+    "pb-5",
+    "pb-6",
+    "pb-7",
+    "pb-8",
+    "pb-9",
+    "pb-10",
+    "pb-11",
+    "pb-12",
+    "pb-14",
+    "pb-16",
+    "pb-20",
+    "pb-24",
+    "pb-28",
+    "pb-32",
+    "pb-36",
+    "pb-40",
+    "pb-44",
+    "pb-48",
+    "pb-52",
+    "pb-56",
+    "pb-60",
+    "pb-64",
+    "pb-72",
+    "pb-80",
+    "pb-96",
+    "pb-px",
+    "pl-0",
+    "pl-0.5",
+    "pl-1",
+    "pl-1.5",
+    "pl-2",
+    "pl-2.5",
+    "pl-3",
+    "pl-3.5",
+    "pl-4",
+    "pl-5",
+    "pl-6",
+    "pl-7",
+    "pl-8",
+    "pl-9",
+    "pl-10",
+    "pl-11",
+    "pl-12",
+    "pl-14",
+    "pl-16",
+    "pl-20",
+    "pl-24",
+    "pl-28",
+    "pl-32",
+    "pl-36",
+    "pl-40",
+    "pl-44",
+    "pl-48",
+    "pl-52",
+    "pl-56",
+    "pl-60",
+    "pl-64",
+    "pl-72",
+    "pl-80",
+    "pl-96",
+    "pl-px",
+    "m-0",
+    "m-0.5",
+    "m-1",
+    "m-1.5",
+    "m-2",
+    "m-2.5",
+    "m-3",
+    "m-3.5",
+    "m-4",
+    "m-5",
+    "m-6",
+    "m-7",
+    "m-8",
+    "m-9",
+    "m-10",
+    "m-11",
+    "m-12",
+    "m-14",
+    "m-16",
+    "m-20",
+    "m-24",
+    "m-28",
+    "m-32",
+    "m-36",
+    "m-40",
+    "m-44",
+    "m-48",
+    "m-52",
+    "m-56",
+    "m-60",
+    "m-64",
+    "m-72",
+    "m-80",
+    "m-96",
+    "m-px",
+    "mx-0",
+    "mx-0.5",
+    "mx-1",
+    "mx-1.5",
+    "mx-2",
+    "mx-2.5",
+    "mx-3",
+    "mx-3.5",
+    "mx-4",
+    "mx-5",
+    "mx-6",
+    "mx-7",
+    "mx-8",
+    "mx-9",
+    "mx-10",
+    "mx-11",
+    "mx-12",
+    "mx-14",
+    "mx-16",
+    "mx-20",
+    "mx-24",
+    "mx-28",
+    "mx-32",
+    "mx-36",
+    "mx-40",
+    "mx-44",
+    "mx-48",
+    "mx-52",
+    "mx-56",
+    "mx-60",
+    "mx-64",
+    "mx-72",
+    "mx-80",
+    "mx-96",
+    "mx-px",
+    "my-0",
+    "my-0.5",
+    "my-1",
+    "my-1.5",
+    "my-2",
+    "my-2.5",
+    "my-3",
+    "my-3.5",
+    "my-4",
+    "my-5",
+    "my-6",
+    "my-7",
+    "my-8",
+    "my-9",
+    "my-10",
+    "my-11",
+    "my-12",
+    "my-14",
+    "my-16",
+    "my-20",
+    "my-24",
+    "my-28",
+    "my-32",
+    "my-36",
+    "my-40",
+    "my-44",
+    "my-48",
+    "my-52",
+    "my-56",
+    "my-60",
+    "my-64",
+    "my-72",
+    "my-80",
+    "my-96",
+    "my-px",
+    "mt-0",
+    "mt-0.5",
+    "mt-1",
+    "mt-1.5",
+    "mt-2",
+    "mt-2.5",
+    "mt-3",
+    "mt-3.5",
+    "mt-4",
+    "mt-5",
+    "mt-6",
+    "mt-7",
+    "mt-8",
+    "mt-9",
+    "mt-10",
+    "mt-11",
+    "mt-12",
+    "mt-14",
+    "mt-16",
+    "mt-20",
+    "mt-24",
+    "mt-28",
+    "mt-32",
+    "mt-36",
+    "mt-40",
+    "mt-44",
+    "mt-48",
+    "mt-52",
+    "mt-56",
+    "mt-60",
+    "mt-64",
+    "mt-72",
+    "mt-80",
+    "mt-96",
+    "mt-px",
+    "mr-0",
+    "mr-0.5",
+    "mr-1",
+    "mr-1.5",
+    "mr-2",
+    "mr-2.5",
+    "mr-3",
+    "mr-3.5",
+    "mr-4",
+    "mr-5",
+    "mr-6",
+    "mr-7",
+    "mr-8",
+    "mr-9",
+    "mr-10",
+    "mr-11",
+    "mr-12",
+    "mr-14",
+    "mr-16",
+    "mr-20",
+    "mr-24",
+    "mr-28",
+    "mr-32",
+    "mr-36",
+    "mr-40",
+    "mr-44",
+    "mr-48",
+    "mr-52",
+    "mr-56",
+    "mr-60",
+    "mr-64",
+    "mr-72",
+    "mr-80",
+    "mr-96",
+    "mr-px",
+    "mb-0",
+    "mb-0.5",
+    "mb-1",
+    "mb-1.5",
+    "mb-2",
+    "mb-2.5",
+    "mb-3",
+    "mb-3.5",
+    "mb-4",
+    "mb-5",
+    "mb-6",
+    "mb-7",
+    "mb-8",
+    "mb-9",
+    "mb-10",
+    "mb-11",
+    "mb-12",
+    "mb-14",
+    "mb-16",
+    "mb-20",
+    "mb-24",
+    "mb-28",
+    "mb-32",
+    "mb-36",
+    "mb-40",
+    "mb-44",
+    "mb-48",
+    "mb-52",
+    "mb-56",
+    "mb-60",
+    "mb-64",
+    "mb-72",
+    "mb-80",
+    "mb-96",
+    "mb-px",
+    "ml-0",
+    "ml-0.5",
+    "ml-1",
+    "ml-1.5",
+    "ml-2",
+    "ml-2.5",
+    "ml-3",
+    "ml-3.5",
+    "ml-4",
+    "ml-5",
+    "ml-6",
+    "ml-7",
+    "ml-8",
+    "ml-9",
+    "ml-10",
+    "ml-11",
+    "ml-12",
+    "ml-14",
+    "ml-16",
+    "ml-20",
+    "ml-24",
+    "ml-28",
+    "ml-32",
+    "ml-36",
+    "ml-40",
+    "ml-44",
+    "ml-48",
+    "ml-52",
+    "ml-56",
+    "ml-60",
+    "ml-64",
+    "ml-72",
+    "ml-80",
+    "ml-96",
+    "ml-px",
+    "gap-0",
+    "gap-0.5",
+    "gap-1",
+    "gap-1.5",
+    "gap-2",
+    "gap-2.5",
+    "gap-3",
+    "gap-3.5",
+    "gap-4",
+    "gap-5",
+    "gap-6",
+    "gap-7",
+    "gap-8",
+    "gap-9",
+    "gap-10",
+    "gap-11",
+    "gap-12",
+    "gap-14",
+    "gap-16",
+    "gap-20",
+    "gap-24",
+    "gap-28",
+    "gap-32",
+    "gap-36",
+    "gap-40",
+    "gap-44",
+    "gap-48",
+    "gap-52",
+    "gap-56",
+    "gap-60",
+    "gap-64",
+    "gap-72",
+    "gap-80",
+    "gap-96",
+    "gap-px",
+    "gap-x-0",
+    "gap-x-0.5",
+    "gap-x-1",
+    "gap-x-1.5",
+    "gap-x-2",
+    "gap-x-2.5",
+    "gap-x-3",
+    "gap-x-3.5",
+    "gap-x-4",
+    "gap-x-5",
+    "gap-x-6",
+    "gap-x-7",
+    "gap-x-8",
+    "gap-x-9",
+    "gap-x-10",
+    "gap-x-11",
+    "gap-x-12",
+    "gap-x-14",
+    "gap-x-16",
+    "gap-x-20",
+    "gap-x-24",
+    "gap-x-28",
+    "gap-x-32",
+    "gap-x-36",
+    "gap-x-40",
+    "gap-x-44",
+    "gap-x-48",
+    "gap-x-52",
+    "gap-x-56",
+    "gap-x-60",
+    "gap-x-64",
+    "gap-x-72",
+    "gap-x-80",
+    "gap-x-96",
+    "gap-x-px",
+    "gap-y-0",
+    "gap-y-0.5",
+    "gap-y-1",
+    "gap-y-1.5",
+    "gap-y-2",
+    "gap-y-2.5",
+    "gap-y-3",
+    "gap-y-3.5",
+    "gap-y-4",
+    "gap-y-5",
+    "gap-y-6",
+    "gap-y-7",
+    "gap-y-8",
+    "gap-y-9",
+    "gap-y-10",
+    "gap-y-11",
+    "gap-y-12",
+    "gap-y-14",
+    "gap-y-16",
+    "gap-y-20",
+    "gap-y-24",
+    "gap-y-28",
+    "gap-y-32",
+    "gap-y-36",
+    "gap-y-40",
+    "gap-y-44",
+    "gap-y-48",
+    "gap-y-52",
+    "gap-y-56",
+    "gap-y-60",
+    "gap-y-64",
+    "gap-y-72",
+    "gap-y-80",
+    "gap-y-96",
+    "gap-y-px",
+]
+
+
+TailwindBorderClass: TypeAlias = Literal[
+    "border",
+    "border-0",
+    "border-2",
+    "border-4",
+    "border-8",
+    "border-double",
+    "border-t",
+    "border-r",
+    "border-b",
+    "border-l",
+    "border-x",
+    "border-y",
+    "rounded",
+    "rounded-none",
+    "rounded-sm",
+    "rounded-md",
+    "rounded-lg",
+    "rounded-xl",
+    "rounded-2xl",
+    "rounded-3xl",
+    "rounded-full",
+]
+
+
+TailwindTypographyClass: TypeAlias = Literal[
+    "font-thin",
+    "font-extralight",
+    "font-light",
+    "font-normal",
+    "font-medium",
+    "font-semibold",
+    "font-bold",
+    "font-extrabold",
+    "font-black",
+    "italic",
+    "not-italic",
+    "underline",
+    "no-underline",
+    "line-through",
+    "animate-pulse",
+    "text-left",
+    "text-center",
+    "text-right",
+    "text-xs",
+    "text-sm",
+    "text-base",
+    "text-lg",
+    "text-xl",
+    "text-2xl",
+    "text-3xl",
+    "text-4xl",
+    "text-5xl",
+    "text-6xl",
+    "text-7xl",
+    "text-8xl",
+    "text-9xl",
+]
+
+
+TailwindSizingClass: TypeAlias = Literal[
+    "w-0",
+    "w-0.5",
+    "w-1",
+    "w-1.5",
+    "w-2",
+    "w-2.5",
+    "w-3",
+    "w-3.5",
+    "w-4",
+    "w-5",
+    "w-6",
+    "w-7",
+    "w-8",
+    "w-9",
+    "w-10",
+    "w-11",
+    "w-12",
+    "w-14",
+    "w-16",
+    "w-20",
+    "w-24",
+    "w-28",
+    "w-32",
+    "w-36",
+    "w-40",
+    "w-44",
+    "w-48",
+    "w-52",
+    "w-56",
+    "w-60",
+    "w-64",
+    "w-72",
+    "w-80",
+    "w-96",
+    "w-px",
+    "w-1/2",
+    "w-1/3",
+    "w-2/3",
+    "w-1/4",
+    "w-2/4",
+    "w-3/4",
+    "w-1/5",
+    "w-2/5",
+    "w-3/5",
+    "w-4/5",
+    "w-1/6",
+    "w-5/6",
+    "w-full",
+    "w-screen",
+    "w-fit",
+    "w-auto",
+    "w-min",
+    "w-max",
+    "h-0",
+    "h-0.5",
+    "h-1",
+    "h-1.5",
+    "h-2",
+    "h-2.5",
+    "h-3",
+    "h-3.5",
+    "h-4",
+    "h-5",
+    "h-6",
+    "h-7",
+    "h-8",
+    "h-9",
+    "h-10",
+    "h-11",
+    "h-12",
+    "h-14",
+    "h-16",
+    "h-20",
+    "h-24",
+    "h-28",
+    "h-32",
+    "h-36",
+    "h-40",
+    "h-44",
+    "h-48",
+    "h-52",
+    "h-56",
+    "h-60",
+    "h-64",
+    "h-72",
+    "h-80",
+    "h-96",
+    "h-px",
+    "h-1/2",
+    "h-1/3",
+    "h-2/3",
+    "h-1/4",
+    "h-2/4",
+    "h-3/4",
+    "h-1/5",
+    "h-2/5",
+    "h-3/5",
+    "h-4/5",
+    "h-1/6",
+    "h-5/6",
+    "h-full",
+    "h-screen",
+    "h-fit",
+    "h-auto",
+    "h-min",
+    "h-max",
+]
+
+
+TailwindFlexClass: TypeAlias = Literal[
+    "flex",
+    "flex-row",
+    "flex-col",
+    "flex-1",
+    "flex-auto",
+    "flex-initial",
+    "flex-none",
+    "grow",
+    "grow-0",
+    "shrink",
+    "shrink-0",
+]
+
+
+TailwindPassthroughClass: TypeAlias = Literal[
+    "shadow",
+    "shadow-sm",
+    "shadow-md",
+    "shadow-lg",
+    "shadow-xl",
+    "shadow-2xl",
+    "shadow-inner",
+    "shadow-none",
+    "transition",
+    "transition-all",
+    "transition-colors",
+    "transition-opacity",
+    "transition-shadow",
+    "transition-transform",
+    "truncate",
+    "overflow-hidden",
+    "overflow-auto",
+    "overflow-scroll",
+    "overflow-visible",
+    "opacity-0",
+    "opacity-25",
+    "opacity-50",
+    "opacity-60",
+    "opacity-75",
+    "opacity-100",
+    "cursor-pointer",
+    "cursor-default",
+    "select-none",
+    "select-text",
+]
+
+# --- end generated ----------------------------------------------------
+
+
+TailwindClass: TypeAlias = Union[
+    TailwindColorClass,
+    TailwindSpacingClass,
+    TailwindBorderClass,
+    TailwindTypographyClass,
+    TailwindSizingClass,
+    TailwindFlexClass,
+    TailwindPassthroughClass,
+]
+"""Every Tailwind CSS utility class accepted by ``class_name``.
+
+Unknown strings are still accepted at runtime — they resolve to
+``TailwindStyle.passthrough_classes`` (emitted verbatim on the web,
+ignored on the terminal). The Literal exists for autocomplete and
+static checking, not runtime gating.
+"""
+
+
+def _literal_values(alias: object) -> frozenset[str]:
+    """Collect the string members of a union of Literal aliases."""
+    values: set[str] = set()
+    for member in typing.get_args(alias):
+        values.update(typing.get_args(member))
+    return frozenset(values)
+
+
+KNOWN_TAILWIND_CLASSES: frozenset[str] = _literal_values(TailwindClass)
+"""Runtime set of every ``TailwindClass`` Literal member."""
+
+
+_SPACING_UNITS: frozenset[str] = frozenset(
+    [
+        "0",
+        "0.5",
+        "1",
+        "1.5",
+        "2",
+        "2.5",
+        "3",
+        "3.5",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "14",
+        "16",
+        "20",
+        "24",
+        "28",
+        "32",
+        "36",
+        "40",
+        "44",
+        "48",
+        "52",
+        "56",
+        "60",
+        "64",
+        "72",
+        "80",
+        "96",
+        "px",
+    ]
+)
+
+
+def _units_for_suffix(suffix: str) -> float:
+    """Return the Tailwind unit count for a spacing-scale suffix."""
+    if suffix == "px":
+        return 1.0
+    return float(suffix)
+
+
+def _cells_for_units(units: float, direction: types.Direction) -> int:
+    """Aspect-corrected Tailwind-unit to terminal-cell conversion.
+
+    One Tailwind unit is 0.25rem; a terminal cell is roughly twice as
+    tall as it is wide, so ``n`` units lower to ``floor(n / 4 + 0.5)``
+    rows vertically and ``floor(n / 2 + 0.5)`` columns horizontally,
+    with a minimum of one cell for nonzero ``n``. Half-up rounding is
+    explicit so results never depend on banker's rounding.
+    """
+    if units <= 0:
+        return 0
+    divisor = 4 if direction == "vertical" else 2
+    return max(1, math.floor(units / divisor + 0.5))
+
+
+@dataclasses.dataclass(slots=True)
+class _TailwindStyleBuilder:
+    """Mutable accumulator the class-group handlers write into."""
+
+    color: ColorLike | None = None
+    background: ColorLike | None = None
+    border: types.Border | None = None
+    border_color: ColorLike | None = None
+    border_sides: list[types.Side] = dataclasses.field(default_factory=list)
+    padding_sides: dict[str, int] = dataclasses.field(default_factory=dict)
+    margin_sides: dict[str, int] = dataclasses.field(default_factory=dict)
+    gap: int | None = None
+    width: Sizing | None = None
+    height: Sizing | None = None
+    modifiers: list[types.CharacterModifier] = dataclasses.field(
+        default_factory=list
+    )
+    align: types.Alignment | None = None
+    direction: types.Direction | None = None
+    passthrough: list[str] = dataclasses.field(default_factory=list)
+
+    def add_modifier(self, modifier: types.CharacterModifier) -> None:
+        """Append a character modifier once, preserving order."""
+        if modifier not in self.modifiers:
+            self.modifiers.append(modifier)
+
+    def add_border_side(self, side: types.Side) -> None:
+        """Append a border side once, preserving order."""
+        if side not in self.border_sides:
+            self.border_sides.append(side)
+
+    def set_spacing(
+        self,
+        sides: dict[str, int],
+        prefix_axis: str,
+        units: float,
+    ) -> None:
+        """Assign aspect-corrected cells onto the sides ``prefix_axis``
+        selects.
+
+        ``prefix_axis`` is the single-character axis/side code from the
+        class prefix: ``""`` for all sides, ``"x"``/``"y"`` for an
+        axis, or ``"t"``/``"r"``/``"b"``/``"l"`` for one side.
+        """
+        vertical = _cells_for_units(units, "vertical")
+        horizontal = _cells_for_units(units, "horizontal")
+        if prefix_axis == "":
+            sides.update(
+                top=vertical, bottom=vertical, left=horizontal,
+                right=horizontal,
+            )
+        elif prefix_axis == "x":
+            sides.update(left=horizontal, right=horizontal)
+        elif prefix_axis == "y":
+            sides.update(top=vertical, bottom=vertical)
+        elif prefix_axis == "t":
+            sides["top"] = vertical
+        elif prefix_axis == "b":
+            sides["bottom"] = vertical
+        elif prefix_axis == "l":
+            sides["left"] = horizontal
+        elif prefix_axis == "r":
+            sides["right"] = horizontal
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class TailwindStyle:
+    """The lowered result of resolving a set of Tailwind classes.
+
+    Attributes:
+        color: Foreground color binding derived from ``text-*``.
+        background: Background color binding derived from ``bg-*``.
+        border: Border style derived from ``border*`` / ``rounded*``.
+        border_color: Border color binding derived from
+            ``border-{palette}-{shade}``.
+        border_sides: Border sides derived from ``border-t|r|b|l|x|y``.
+        padding: Aspect-corrected padding derived from ``p*-{n}``.
+        margin: Aspect-corrected margin derived from ``m*-{n}``.
+        gap: Gap in cells derived from ``gap-*``.
+        width: Horizontal sizing derived from ``w-*`` / flex classes.
+        height: Vertical sizing derived from ``h-*`` / flex classes.
+        modifiers: Character modifiers derived from typography classes.
+        align: Alignment derived from ``text-left|center|right``.
+        direction: Layout direction derived from ``flex-row|col``.
+        passthrough_classes: Tokens no handler lowered — carried
+            verbatim to the web backend, ignored on the terminal.
+        classes: The original full token list, in order.
+    """
+
+    color: ColorLike | None = None
+    """Foreground color binding derived from ``text-*``."""
+    background: ColorLike | None = None
+    """Background color binding derived from ``bg-*``."""
+    border: types.Border | None = None
+    """Border style derived from ``border*`` / ``rounded*``."""
+    border_color: ColorLike | None = None
+    """Border color binding derived from ``border-{palette}-{shade}``."""
+    border_sides: tuple[types.Side, ...] | None = None
+    """Border sides derived from ``border-t|r|b|l|x|y``."""
+    padding: types.Padding | None = None
+    """Aspect-corrected padding derived from ``p*-{n}``."""
+    margin: types.Padding | None = None
+    """Aspect-corrected margin derived from ``m*-{n}``."""
+    gap: int | None = None
+    """Gap in cells derived from ``gap-*``."""
+    width: Sizing | None = None
+    """Horizontal sizing derived from ``w-*`` / flex classes."""
+    height: Sizing | None = None
+    """Vertical sizing derived from ``h-*`` / flex classes."""
+    modifiers: tuple[types.CharacterModifier, ...] = ()
+    """Character modifiers derived from typography classes."""
+    align: types.Alignment | None = None
+    """Alignment derived from ``text-left|center|right``."""
+    direction: types.Direction | None = None
+    """Layout direction derived from ``flex-row|col``."""
+    passthrough_classes: tuple[str, ...] = ()
+    """Tokens no handler lowered — web-only or unknown classes."""
+    classes: tuple[str, ...] = ()
+    """The original full token list, in order."""
+
+
+class AbstractTailwindClassGroup(abc.ABC):
+    """One resolver per Tailwind utility group.
+
+    Subclass and register with ``register_tailwind_class_group`` to
+    teach the resolver a new group of classes — built-in groups are
+    never edited to add one. Tokens no group matches flow to
+    ``TailwindStyle.passthrough_classes`` automatically, so groups are
+    only needed for classes that lower into terminal vocabulary.
+    """
+
+    @abc.abstractmethod
+    def match(self, token: str) -> bool:
+        """Return whether this group can lower ``token``."""
+
+    @abc.abstractmethod
+    def apply(self, token: str, style: _TailwindStyleBuilder) -> None:
+        """Lower ``token`` into the style accumulator."""
+
+
+def _color_binding_from_suffix(suffix: str) -> str | None:
+    """Return a ``ColorLike`` binding for a class suffix, or ``None``.
+
+    Accepts ``black``/``white`` and ``{palette}-{shade}`` forms; other
+    suffixes (``text-left``, ``text-xs``, ``border-2``) return ``None``
+    so color classes never shadow the other groups.
+    """
+    if suffix in ("black", "white"):
+        return suffix
+    parts = suffix.rsplit("-", 1)
+    if len(parts) != 2 or parts[0] not in _TAILWIND_NAMES:
+        return None
+    try:
+        shade = int(parts[1])
+    except ValueError:
+        return None
+    if shade not in _TAILWIND_SHADES:
+        return None
+    return suffix
+
+
+class ColorClassGroup(AbstractTailwindClassGroup):
+    """``text-*`` / ``bg-*`` / ``border-*`` palette color classes."""
+
+    def match(self, token: str) -> bool:
+        for prefix in ("text-", "bg-", "border-"):
+            if token.startswith(prefix):
+                suffix = token[len(prefix):]
+                return _color_binding_from_suffix(suffix) is not None
+        return False
+
+    def apply(self, token: str, style: _TailwindStyleBuilder) -> None:
+        if token.startswith("text-"):
+            style.color = token[len("text-"):]
+        elif token.startswith("bg-"):
+            style.background = token[len("bg-"):]
+        else:
+            style.border_color = token[len("border-"):]
+
+
+class SpacingClassGroup(AbstractTailwindClassGroup):
+    """``p*-{n}`` / ``m*-{n}`` / ``gap-*`` spacing classes."""
+
+    def _parse(self, token: str) -> tuple[str, str, str] | None:
+        """Split a spacing token into (kind, axis code, unit suffix)."""
+        prefix, _, suffix = token.rpartition("-")
+        if not prefix or suffix not in _SPACING_UNITS:
+            return None
+        if prefix in ("gap", "gap-x", "gap-y"):
+            return ("gap", prefix[4:], suffix)
+        if len(prefix) == 1 and prefix in ("p", "m"):
+            return (prefix, "", suffix)
+        if (
+            len(prefix) == 2
+            and prefix[0] in ("p", "m")
+            and prefix[1] in ("x", "y", "t", "r", "b", "l")
+        ):
+            return (prefix[0], prefix[1], suffix)
+        return None
+
+    def match(self, token: str) -> bool:
+        return self._parse(token) is not None
+
+    def apply(self, token: str, style: _TailwindStyleBuilder) -> None:
+        parsed = self._parse(token)
+        if parsed is None:
+            return
+        kind, axis, suffix = parsed
+        units = _units_for_suffix(suffix)
+        if kind == "gap":
+            gap_direction: types.Direction = (
+                "horizontal" if axis == "x" else "vertical"
+            )
+            style.gap = _cells_for_units(units, gap_direction)
+        elif kind == "p":
+            style.set_spacing(style.padding_sides, axis, units)
+        else:
+            style.set_spacing(style.margin_sides, axis, units)
+
+
+_BORDER_STYLE_TOKENS: dict[str, types.Border | None] = {
+    "border": "plain",
+    "border-0": None,
+    "border-2": "thick",
+    "border-4": "thick",
+    "border-8": "thick",
+    "border-double": "double",
+}
+
+_BORDER_SIDE_TOKENS: dict[str, tuple[types.Side, ...]] = {
+    "border-t": ("top",),
+    "border-r": ("right",),
+    "border-b": ("bottom",),
+    "border-l": ("left",),
+    "border-x": ("left", "right"),
+    "border-y": ("top", "bottom"),
+}
+
+_ROUNDED_TOKENS: frozenset[str] = frozenset(
+    [
+        "rounded",
+        "rounded-sm",
+        "rounded-md",
+        "rounded-lg",
+        "rounded-xl",
+        "rounded-2xl",
+        "rounded-3xl",
+        "rounded-full",
+    ]
+)
+
+
+class BorderClassGroup(AbstractTailwindClassGroup):
+    """``border*`` style/side classes and ``rounded*`` radii."""
+
+    def match(self, token: str) -> bool:
+        return (
+            token in _BORDER_STYLE_TOKENS
+            or token in _BORDER_SIDE_TOKENS
+            or token in _ROUNDED_TOKENS
+            or token == "rounded-none"
+        )
+
+    def apply(self, token: str, style: _TailwindStyleBuilder) -> None:
+        if token in _BORDER_SIDE_TOKENS:
+            if style.border is None:
+                style.border = "plain"
+            for side in _BORDER_SIDE_TOKENS[token]:
+                style.add_border_side(side)
+            return
+        if token in _ROUNDED_TOKENS:
+            style.border = "rounded"
+            return
+        if token == "rounded-none":
+            return
+        if token == "border" and style.border is not None:
+            # ``border`` only establishes a default style; it never
+            # downgrades a width or radius another token already set.
+            return
+        style.border = _BORDER_STYLE_TOKENS[token]
+
+
+_TYPOGRAPHY_MODIFIER_TOKENS: dict[str, types.CharacterModifier] = {
+    "font-semibold": "bold",
+    "font-bold": "bold",
+    "font-extrabold": "bold",
+    "font-black": "bold",
+    "font-thin": "dim",
+    "font-extralight": "dim",
+    "font-light": "dim",
+    "italic": "italic",
+    "underline": "underline",
+    "animate-pulse": "slow_blink",
+}
+
+_TYPOGRAPHY_ALIGN_TOKENS: dict[str, types.Alignment] = {
+    "text-left": "left",
+    "text-center": "center",
+    "text-right": "right",
+}
+
+_TYPOGRAPHY_NOOP_TOKENS: frozenset[str] = frozenset(
+    ["font-normal", "font-medium", "not-italic", "no-underline"]
+)
+
+
+class TypographyClassGroup(AbstractTailwindClassGroup):
+    """Font weight/style, text decoration, and alignment classes.
+
+    ``font-semibold`` and heavier lower to the ``bold`` modifier;
+    ``font-light`` and lighter approximate as ``dim``. ``text-{size}``
+    classes have no terminal equivalent and stay passthrough.
+    """
+
+    def match(self, token: str) -> bool:
+        return (
+            token in _TYPOGRAPHY_MODIFIER_TOKENS
+            or token in _TYPOGRAPHY_ALIGN_TOKENS
+            or token in _TYPOGRAPHY_NOOP_TOKENS
+        )
+
+    def apply(self, token: str, style: _TailwindStyleBuilder) -> None:
+        modifier = _TYPOGRAPHY_MODIFIER_TOKENS.get(token)
+        if modifier is not None:
+            style.add_modifier(modifier)
+            return
+        align = _TYPOGRAPHY_ALIGN_TOKENS.get(token)
+        if align is not None:
+            style.align = align
+
+
+_SIZING_FULL_TOKENS: frozenset[str] = frozenset(["full", "screen"])
+_SIZING_FIT_TOKENS: frozenset[str] = frozenset(["fit", "auto", "min", "max"])
+
+
+class SizingClassGroup(AbstractTailwindClassGroup):
+    """``w-*`` / ``h-*`` width and height classes."""
+
+    def _parse(self, token: str) -> tuple[types.Direction, str] | None:
+        if token.startswith("w-"):
+            return ("horizontal", token[2:])
+        if token.startswith("h-"):
+            return ("vertical", token[2:])
+        return None
+
+    def _sizing_for_suffix(
+        self, suffix: str, direction: types.Direction
+    ) -> Sizing | None:
+        if suffix in _SIZING_FULL_TOKENS:
+            return Sizing.percent(100)
+        if suffix in _SIZING_FIT_TOKENS:
+            return Sizing.fit()
+        if "/" in suffix:
+            numerator, _, denominator = suffix.partition("/")
+            try:
+                return Sizing.ratio(int(numerator), int(denominator))
+            except ValueError:
+                return None
+        if suffix in _SPACING_UNITS:
+            return Sizing.cells(
+                _cells_for_units(_units_for_suffix(suffix), direction)
+            )
+        return None
+
+    def match(self, token: str) -> bool:
+        parsed = self._parse(token)
+        if parsed is None:
+            return False
+        direction, suffix = parsed
+        return self._sizing_for_suffix(suffix, direction) is not None
+
+    def apply(self, token: str, style: _TailwindStyleBuilder) -> None:
+        parsed = self._parse(token)
+        if parsed is None:
+            return
+        direction, suffix = parsed
+        sizing = self._sizing_for_suffix(suffix, direction)
+        if sizing is None:
+            return
+        if direction == "horizontal":
+            style.width = sizing
+        else:
+            style.height = sizing
+
+
+_FLEX_DIRECTION_TOKENS: dict[str, types.Direction] = {
+    "flex-row": "horizontal",
+    "flex-col": "vertical",
+}
+
+_FLEX_WEIGHT_TOKENS: frozenset[str] = frozenset(
+    [
+        "flex-1",
+        "flex-auto",
+        "flex-initial",
+        "flex-none",
+        "grow",
+        "grow-0",
+        "shrink",
+        "shrink-0",
+    ]
+)
+
+
+class FlexClassGroup(AbstractTailwindClassGroup):
+    """``flex`` direction and grow/shrink weight classes.
+
+    Weight classes lower to a fraction ``Sizing`` on both axes — a
+    fill sizing on the cross axis leaves the slot unchanged, so the
+    weight only takes effect along the parent's layout direction.
+    """
+
+    def match(self, token: str) -> bool:
+        return (
+            token == "flex"
+            or token in _FLEX_DIRECTION_TOKENS
+            or token in _FLEX_WEIGHT_TOKENS
+        )
+
+    def apply(self, token: str, style: _TailwindStyleBuilder) -> None:
+        direction = _FLEX_DIRECTION_TOKENS.get(token)
+        if direction is not None:
+            style.direction = direction
+            return
+        if token in _FLEX_WEIGHT_TOKENS:
+            sizing = Sizing.parse(token)
+            style.width = sizing
+            style.height = sizing
+
+
+_TAILWIND_CLASS_GROUPS: list[AbstractTailwindClassGroup] = [
+    ColorClassGroup(),
+    SpacingClassGroup(),
+    BorderClassGroup(),
+    TypographyClassGroup(),
+    SizingClassGroup(),
+    FlexClassGroup(),
+]
+
+
+def register_tailwind_class_group(
+    group: AbstractTailwindClassGroup,
+) -> None:
+    """Register an additional class-group resolver.
+
+    Registered groups match after the built-in groups, in registration
+    order. Registration clears the resolver cache so already-resolved
+    class lists pick up the new group.
+
+    Args:
+        group: The class-group resolver to append.
+    """
+    _TAILWIND_CLASS_GROUPS.append(group)
+    _resolve_tokens.cache_clear()
+
+
+def normalize_tailwind_classes(
+    class_name: str | Sequence[str],
+) -> tuple[str, ...]:
+    """Normalize a class string or sequence into a token tuple.
+
+    Args:
+        class_name: A space-separated class string, or a sequence of
+            individual class tokens.
+
+    Returns:
+        The individual class tokens, in order.
+
+    Raises:
+        TypeError: If ``class_name`` is not a string or a sequence of
+            strings.
+    """
+    if isinstance(class_name, str):
+        return tuple(class_name.split())
+    if isinstance(class_name, Sequence):
+        tokens: list[str] = []
+        for token in class_name:
+            if not isinstance(token, str):
+                raise TypeError(
+                    "class_name sequence entries must be strings, got "
+                    f"{type(token).__name__!r}"
+                )
+            tokens.extend(token.split())
+        return tuple(tokens)
+    raise TypeError(
+        "class_name must be a string or a sequence of strings, got "
+        f"{type(class_name).__name__!r}"
+    )
+
+
+@functools.lru_cache(maxsize=512)
+def _resolve_tokens(tokens: tuple[str, ...]) -> TailwindStyle:
+    builder = _TailwindStyleBuilder()
+    for token in tokens:
+        for group in _TAILWIND_CLASS_GROUPS:
+            if group.match(token):
+                group.apply(token, builder)
+                break
+        else:
+            builder.passthrough.append(token)
+
+    padding = (
+        types.Padding(**builder.padding_sides)
+        if builder.padding_sides
+        else None
+    )
+    margin = (
+        types.Padding(**builder.margin_sides)
+        if builder.margin_sides
+        else None
+    )
+    return TailwindStyle(
+        color=builder.color,
+        background=builder.background,
+        border=builder.border,
+        border_color=builder.border_color,
+        border_sides=(
+            tuple(builder.border_sides) if builder.border_sides else None
+        ),
+        padding=padding,
+        margin=margin,
+        gap=builder.gap,
+        width=builder.width,
+        height=builder.height,
+        modifiers=tuple(builder.modifiers),
+        align=builder.align,
+        direction=builder.direction,
+        passthrough_classes=tuple(builder.passthrough),
+        classes=tokens,
+    )
+
+
+def resolve_tailwind_classes(
+    class_name: str | Sequence[str],
+) -> TailwindStyle:
+    """Lower Tailwind classes into a ``TailwindStyle``.
+
+    Tokens are matched against the registered class groups in order;
+    the first matching group lowers the token. Within one attribute a
+    later token overrides an earlier one, while padding, margin,
+    border sides, and modifiers accumulate. Tokens no group matches
+    (web-only utilities, unknown strings) land in
+    ``TailwindStyle.passthrough_classes``.
+
+    Args:
+        class_name: A space-separated class string, or a sequence of
+            individual class tokens.
+
+    Returns:
+        The lowered ``TailwindStyle``.
+    """
+    return _resolve_tokens(normalize_tailwind_classes(class_name))
+
+
+__all__ = (
+    "AbstractTailwindClassGroup",
+    "BorderClassGroup",
+    "ColorClassGroup",
+    "FlexClassGroup",
+    "KNOWN_TAILWIND_CLASSES",
+    "SizingClassGroup",
+    "SpacingClassGroup",
+    "TailwindBorderClass",
+    "TailwindClass",
+    "TailwindColorClass",
+    "TailwindFlexClass",
+    "TailwindPassthroughClass",
+    "TailwindSizingClass",
+    "TailwindSpacingClass",
+    "TailwindStyle",
+    "TailwindTypographyClass",
+    "TypographyClassGroup",
+    "normalize_tailwind_classes",
+    "register_tailwind_class_group",
+    "resolve_tailwind_classes",
+)

--- a/xnano/fields.py
+++ b/xnano/fields.py
@@ -17,15 +17,40 @@ Example:
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Callable, Literal, Sequence, TypeVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Literal,
+    Sequence,
+    TypeAlias,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from xnano import types
 from xnano.color import ColorLike
 from xnano.frame import Frame, FrameTitlePosition
 from xnano.sizing import Sizing, SizingLike
 
+if TYPE_CHECKING:
+    from xnano.beta.tailwind import TailwindClass
+
 
 UNSET = object()
+
+
+ClassNameLike: TypeAlias = Union[
+    "TailwindClass",
+    str,
+    "list[TailwindClass | str]",
+]
+"""Tailwind classes as a single class, a space-separated string, or a
+list of class tokens. See ``xnano.beta.tailwind.TailwindClass`` for the
+full supported vocabulary; unknown tokens are carried verbatim to the
+web backend and ignored by the terminal.
+"""
 
 
 def _normalize_slide_axes(
@@ -173,6 +198,20 @@ class GridFieldInfo:
     """The padding to be applied around the content area of this field."""
     slide: list[str] | None = None
     """The axes along which this field may slide within its parent grid."""
+    class_name: tuple[str, ...] | None = None
+    """Tailwind CSS class tokens attached to this field.
+
+    Normalized from the ``class_name`` argument to ``Field``. The web
+    backend emits these classes verbatim; the terminal backend renders
+    through the lowered attributes instead.
+    """
+    margin: types.PaddingLike | None = None
+    """The margin to be applied around the outer area of this field.
+
+    Also populated by Tailwind ``m*-{n}`` classes through
+    ``class_name``; the terminal insets the field's slot by this
+    amount before painting.
+    """
 
 
 @overload
@@ -198,7 +237,9 @@ def Field(
     title: str | None = None,
     title_position: FrameTitlePosition | None = None,
     padding: types.PaddingLike | None = None,
+    margin: types.PaddingLike | None = None,
     slide: Sequence[types.Axis] | None = None,
+    class_name: ClassNameLike | None = None,
 ) -> Any: ...
 
 
@@ -225,7 +266,9 @@ def Field(
     title: str | None = None,
     title_position: FrameTitlePosition | None = None,
     padding: types.PaddingLike | None = None,
+    margin: types.PaddingLike | None = None,
     slide: Sequence[types.Axis] | None = None,
+    class_name: ClassNameLike | None = None,
 ) -> _T: ...
 
 
@@ -251,7 +294,9 @@ def Field(
     title: str | None = None,
     title_position: FrameTitlePosition | None = None,
     padding: types.PaddingLike | None = None,
+    margin: types.PaddingLike | None = None,
     slide: Sequence[types.Axis] | None = None,
+    class_name: ClassNameLike | None = None,
 ) -> _T: ...
 
 
@@ -278,7 +323,9 @@ def Field(
     title: str | None = None,
     title_position: FrameTitlePosition | None = None,
     padding: types.PaddingLike | None = None,
+    margin: types.PaddingLike | None = None,
     slide: Sequence[types.Axis] | None = None,
+    class_name: ClassNameLike | None = None,
 ) -> Any: ...
 
 
@@ -304,7 +351,9 @@ def Field(
     title: str | None = None,
     title_position: FrameTitlePosition | None = None,
     padding: types.PaddingLike | None = None,
+    margin: types.PaddingLike | None = None,
     slide: Sequence[types.Axis] | None = None,
+    class_name: ClassNameLike | None = None,
 ) -> GridFieldInfo:
     """Create a new grid field info instance.
 
@@ -341,11 +390,55 @@ def Field(
         title_position: The alignment of the title within the outer frame of this
             field's area.
         padding: The padding to be applied around the content area of this field.
+        margin: The margin to be applied around the outer area of this field.
         slide: The axes along which this field may slide within its parent grid.
+        class_name: Tailwind CSS classes styling this field — a space-separated
+            string or a sequence of class tokens. Classes are lowered into the
+            standard field attributes (see ``xnano.beta.tailwind``); an explicit
+            keyword argument always overrides a class-derived value. Classes
+            with no terminal equivalent are ignored by the terminal backend and
+            emitted verbatim by the web backend.
 
     Returns:
-        A new ``GridFieldInfo`` instance with all display/layout metadata.
+        A new ``GridFieldInfo`` instance with all display/layout metadata,
+        including the normalized ``class_name`` tokens.
     """
+    tokens: tuple[str, ...] | None = None
+    if class_name is not None:
+        from xnano.beta.tailwind import (
+            normalize_tailwind_classes,
+            resolve_tailwind_classes,
+        )
+
+        tokens = normalize_tailwind_classes(class_name)
+        resolved = resolve_tailwind_classes(tokens)
+        if color is None:
+            color = resolved.color
+        if background is None:
+            background = resolved.background
+        if border is None:
+            border = resolved.border
+        if border_color is None:
+            border_color = resolved.border_color
+        if border_sides is None:
+            border_sides = resolved.border_sides
+        if padding is None:
+            padding = resolved.padding
+        if margin is None:
+            margin = resolved.margin
+        if gap is None:
+            gap = resolved.gap
+        if width is None:
+            width = resolved.width
+        if height is None:
+            height = resolved.height
+        if modifiers is None and resolved.modifiers:
+            modifiers = resolved.modifiers
+        if align is None:
+            align = resolved.align
+        if direction is None:
+            direction = resolved.direction
+
     return GridFieldInfo(
         default=default,
         default_factory=default_factory,
@@ -367,11 +460,14 @@ def Field(
         title=title,
         title_position=title_position,
         padding=padding,
+        margin=margin,
         slide=_normalize_slide_axes(slide),
+        class_name=tokens,
     )  # type: ignore[return-value]
 
 
 __all__ = (
+    "ClassNameLike",
     "Field",
     "GridFieldInfo",
     "UNSET",

--- a/xnano/grid.py
+++ b/xnano/grid.py
@@ -129,7 +129,14 @@ from xnano.fields import (
     Field,
     _normalize_slide_axes,
 )
-from xnano.types import Area, Border, Direction, Side, PaddingLike
+from xnano.types import (
+    Area,
+    Border,
+    Direction,
+    Padding,
+    PaddingLike,
+    Side,
+)
 
 
 _GRID_RESERVED: frozenset[str] = frozenset(
@@ -144,6 +151,22 @@ _GRID_RESERVED: frozenset[str] = frozenset(
 
 
 _FIELD_MOUSE_KINDS: frozenset[str] = frozenset({"press", "drag", "release"})
+
+
+_GRID_MODIFIER_FLAG_KEYS: tuple[str, ...] = (
+    "bold",
+    "dim",
+    "italic",
+    "underline",
+    "slow_blink",
+    "rapid_blink",
+    "reversed",
+)
+"""Boolean ``grid_set_field`` keys that toggle character modifiers.
+
+``GridFieldInfo`` stores modifiers as a single ``modifiers`` sequence,
+so these flags are translated into it before ``dataclasses.replace``.
+"""
 
 
 _GRID_FIELD_CONFIG_KEYS: frozenset[str] = frozenset(
@@ -164,6 +187,9 @@ _GRID_FIELD_CONFIG_KEYS: frozenset[str] = frozenset(
         "title",
         "title_position",
         "padding",
+        "margin",
+        "modifiers",
+        "class_name",
         "bold",
         "dim",
         "italic",
@@ -304,15 +330,106 @@ def _grid_frame_size_for_field(
                     size += 1
 
     if field.padding is not None:
-        from xnano.types import Padding
-
         padding = Padding.parse(field.padding)
         if direction == "vertical":
             size += padding.vertical
         else:
             size += padding.horizontal
 
+    if field.margin is not None:
+        margin = Padding.parse(field.margin)
+        if direction == "vertical":
+            size += margin.vertical
+        else:
+            size += margin.horizontal
+
     return size
+
+
+def _apply_field_modifier_flags(
+    field_config: dict[str, Any],
+    current_modifiers: Sequence[str] | None,
+) -> dict[str, Any]:
+    """Translate boolean modifier flags into a ``modifiers`` sequence.
+
+    ``grid_set_field(bold=True)`` toggles the ``"bold"`` modifier on
+    top of the config's ``modifiers`` (when given) or the field's
+    current modifiers; ``bold=False`` removes it. The flag keys are
+    consumed so ``dataclasses.replace`` only sees real
+    ``GridFieldInfo`` attributes.
+    """
+    translated = dict(field_config)
+    base = translated.get("modifiers")
+    if base is None:
+        base = current_modifiers or ()
+    modifiers = list(base)
+    for key in _GRID_MODIFIER_FLAG_KEYS:
+        if key not in translated:
+            continue
+        enabled = bool(translated.pop(key))
+        if enabled and key not in modifiers:
+            modifiers.append(key)
+        elif not enabled and key in modifiers:
+            modifiers.remove(key)
+    translated["modifiers"] = tuple(modifiers)
+    return translated
+
+
+def _expand_field_class_name_config(
+    field_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Expand a ``class_name`` config entry into derived field attributes.
+
+    Lowers the Tailwind classes through ``xnano.beta.tailwind`` (a lazy
+    import, so the stable path never pays for it) and fills in every
+    derived attribute the caller did not pass explicitly — explicit
+    keys always win, matching ``xnano.fields.Field``.
+    """
+    from xnano.beta.tailwind import (
+        normalize_tailwind_classes,
+        resolve_tailwind_classes,
+    )
+
+    tokens = normalize_tailwind_classes(field_config["class_name"])
+    resolved = resolve_tailwind_classes(tokens)
+    expanded = dict(field_config)
+    expanded["class_name"] = tokens
+    derived_keys = (
+        "color",
+        "background",
+        "border",
+        "border_color",
+        "border_sides",
+        "padding",
+        "margin",
+        "gap",
+        "width",
+        "height",
+        "align",
+        "direction",
+    )
+    for key in derived_keys:
+        value = getattr(resolved, key)
+        if value is not None and key not in field_config:
+            expanded[key] = value
+    if resolved.modifiers and "modifiers" not in field_config:
+        expanded["modifiers"] = resolved.modifiers
+    return expanded
+
+
+def _grid_inset_area_for_margin(
+    area: Area,
+    margin: Padding,
+) -> Area:
+    """Shrink ``area`` by ``margin`` on each side, clamped to >= 0 size."""
+    width = max(0, area.width - margin.horizontal)
+    height = max(0, area.height - margin.vertical)
+    return Area(
+        x=area.x + min(margin.left, area.width),
+        y=area.y + min(margin.top, area.height),
+        width=width,
+        height=height,
+    )
 
 
 def _grid_min_size_for_field(
@@ -1137,6 +1254,13 @@ class Grid(metaclass=_GridMeta):
             )
 
         if field_config:
+            if "class_name" in field_config:
+                field_config = _expand_field_class_name_config(field_config)
+            if any(key in field_config for key in _GRID_MODIFIER_FLAG_KEYS):
+                field_config = _apply_field_modifier_flags(
+                    field_config,
+                    self._grid_field_info(name).modifiers,
+                )
             if "slide" in field_config:
                 field_config = {
                     **field_config,
@@ -1316,6 +1440,10 @@ class Grid(metaclass=_GridMeta):
                 slide_axes,
                 self._grid_field_position(field_name),
             )
+            if field.margin is not None:
+                paint_area = _grid_inset_area_for_margin(
+                    paint_area, Padding.parse(field.margin)
+                )
             if collect_mouse_geometry and self._grid_field_needs_hit(
                 field_name, field
             ):


### PR DESCRIPTION
## Summary

Adds first-class Tailwind CSS utility-class support to grid fields, working in **both** the terminal and web renderers:

```python
from xnano import Grid, Field

class App(Grid):
    header: str = Field(
        default="Dashboard",
        class_name="m-1 p-2 border rounded-lg bg-slate-900 text-slate-100 font-bold shadow-lg",
    )
```

`class_name` accepts a space-separated string or a sequence of `TailwindClass` Literal tokens (~1,525 classes with autocomplete/static checking).

## How it works

- **`xnano/beta/tailwind.py`** — `resolve_tailwind_classes()` lowers tokens into xnano vocabulary (`Color` bindings, `Padding`, `Sizing`, borders, modifiers) through a plugin registry: one `AbstractTailwindClassGroup` handler per utility group (color, spacing, border, typography, sizing, flex). New groups plug in via `register_tailwind_class_group()`. Unmatched/web-only tokens (`shadow-lg`, `hover:*`) go to `passthrough_classes` — ignored on terminal, emitted verbatim on web. The Literal blocks are generated by the checked-in `scripts/generate_tailwind_literal.py`; the runtime class set derives from the Literal via `typing.get_args`, so they cannot drift.
- **`xnano/fields.py`** — `Field()` gains `class_name` and `margin`; classes lower once at call time into normal `GridFieldInfo` attributes, so the terminal pipeline needed almost nothing. Explicit kwargs always beat class-derived values. The tailwind module imports lazily, so the stable path pays nothing.
- **Terminal margin** (new layout concept) — margin counts in constraint sizing and insets the paint area before framing, using an aspect-corrected unit-to-cell scale (`p-4` → 1 row / 2 cols).
- **Web controller** — raw classes are emitted verbatim on the field wrapper; derived inline styles are suppressed when a class already covers them, and kwarg overrides win via inline CSS. Also works at runtime through `grid_set_field(name, class_name=...)`.

## Bug fix

`grid_set_field`'s boolean modifier keys (`bold`, `italic`, …) previously crashed `dataclasses.replace` (no such `GridFieldInfo` attributes). They now translate into the `modifiers` tuple: `True` adds, `False` removes.

## Testing

- `uv run pytest tests/beta` — 351 passed (293 new), including a Literal↔runtime drift guard over every lowerable class, terminal render equivalence between `class_name` and explicit kwargs, and all web suppression paths
- `uv run pytest` — 927 passed, 6 skipped (no regressions)
- `uv run prek run --all-files` and `uv run ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)