### PR TITLE
test: update suite for module layout and BaseGrid

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,9 +8,9 @@ from xnano.fields import Field, UNSET
 
 if TYPE_CHECKING:
     from xnano.components.abstract import AbstractComponent
-    from xnano.core.nodes.terminal import AbstractTerminalNode
-    from xnano.grid import Grid
-    from xnano.terminal import Terminal
+    from xnano.tui.nodes import AbstractTerminalNode
+    from xnano.grid import BaseGrid
+    from xnano.tui import Terminal
 
 
 def invalid_field(default: Any) -> Any:
@@ -125,7 +125,7 @@ def key_binding(*names: str) -> FakeKeyboard:
 
 
 def open_offscreen_app(
-    grid: "Grid",
+    grid: "BaseGrid",
     *,
     cols: int = 48,
     rows: int = 14,
@@ -135,7 +135,7 @@ def open_offscreen_app(
 
     Caller should call :func:`close_offscreen_app` when finished.
     """
-    from xnano.terminal import Terminal
+    from xnano.tui import Terminal
 
     terminal = Terminal.offscreen(cols=cols, rows=rows, state=state)
     terminal.attach_grid(grid)
@@ -145,7 +145,7 @@ def open_offscreen_app(
 
 def close_offscreen_app(terminal: "Terminal[Any]") -> None:
     """Reset the active-terminal context var for an offscreen session."""
-    import xnano.terminal as terminal_mod
+    import xnano.tui as terminal_mod
 
     token = getattr(terminal, "_terminal_token", None)
     if token is not None:
@@ -155,7 +155,7 @@ def close_offscreen_app(terminal: "Terminal[Any]") -> None:
     terminal._session = None
 
 
-def paint(terminal: "Terminal[Any]", grid: "Grid") -> str:
+def paint(terminal: "Terminal[Any]", grid: "BaseGrid") -> str:
     """Re-render ``grid`` and return the offscreen buffer text."""
     terminal._render_frame(grid)
     return terminal.get_output()
@@ -164,7 +164,7 @@ def paint(terminal: "Terminal[Any]", grid: "Grid") -> str:
 def dispatch_key(terminal: "Terminal[Any]", keyboard: FakeKeyboard) -> None:
     """Run the full keyboard dispatch path for ``keyboard``."""
     from xnano.context import Context
-    from xnano.core.dispatch import dispatch_hooks
+    from xnano._dispatch import dispatch_hooks
 
     event = FakeEvent(keyboard=keyboard)
     ctx = Context(
@@ -202,8 +202,8 @@ def render_node_to_text(
     """
     from xnano_core.core import CoreSession
 
-    from xnano.core.controllers.terminal import TerminalController
-    from xnano.types import Area
+    from xnano.core.controllers.tui import TerminalController
+    from xnano._types import Area
 
     core = CoreSession.offscreen(width=width, height=height)
     session = TerminalController(
@@ -237,7 +237,7 @@ def render_component_to_text(
         component yields no node (e.g. ``visible=False``).
     """
     from xnano.components.abstract import ComponentRenderContext
-    from xnano.types import Area
+    from xnano._types import Area
 
     area = Area(x=0, y=0, width=width, height=height)
     ctx = ComponentRenderContext(area=area)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,106 @@
+"""Tests for xnano.actions — matching, synthesis, and host.perform."""
+
+from __future__ import annotations
+
+from xnano.core.actions import Action
+from xnano.events import Event, KeyboardEventData, on, on_keyboard
+from xnano.fields import Field
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
+
+
+def test_keyboard_action_matches_synthetic_event() -> None:
+    action = Action.keyboard("ctrl+s")
+    event = Event.from_data(KeyboardEventData.from_binding("ctrl+s"))
+    assert action.matches(event)
+    assert not Action.keyboard("ctrl+a").matches(event)
+
+
+def test_keyboard_action_empty_bindings_match_any() -> None:
+    action = Action.keyboard()
+    event = Event.from_data(KeyboardEventData.from_binding("x"))
+    assert action.matches(event)
+
+
+def test_action_to_event_is_real_event() -> None:
+    event = Action.keyboard("enter").to_event()
+    assert event.is_keyboard_event()
+    assert event.keyboard_event is not None
+    assert event.keyboard_event.matches("enter")
+
+
+def test_perform_runs_keyboard_hook() -> None:
+    class App(BaseGrid):
+        n: int = Field(default=0, state=True)
+
+        @on_keyboard("x")
+        def bump(self, ctx) -> None:
+            self.n += 1
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    terminal.perform(Action.keyboard("x"))
+    assert app.n == 1
+
+
+def test_on_decorator_with_shared_action() -> None:
+    SAVE = Action.keyboard("ctrl+s")
+
+    class App(BaseGrid):
+        saved: bool = Field(default=False, state=True)
+
+        @on(SAVE)
+        def save(self, ctx) -> None:
+            self.saved = True
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    terminal.perform(SAVE)
+    assert app.saved is True
+
+
+def test_perform_loop_guard() -> None:
+    from xnano.core.exceptions import HookError
+
+    class App(BaseGrid):
+        n: int = Field(default=0, state=True)
+
+        @on_keyboard("a")
+        def loop(self, ctx) -> None:
+            self.n += 1
+            # Re-entrant perform of the same key — must queue, then depth-guard.
+            if self.n < 100:
+                ctx.host.perform(Action.keyboard("a"))
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    try:
+        terminal.perform(Action.keyboard("a"))
+    except HookError:
+        assert app.n >= 32
+    else:
+        # Queue drains without stack overflow; depth guard may or may not
+        # trip depending on whether each perform re-enters the same drain.
+        assert app.n >= 1
+
+
+def test_ctx_actions_facade() -> None:
+    class App(BaseGrid):
+        n: int = Field(default=0, state=True)
+
+        @on_keyboard("z")
+        def bump(self, ctx) -> None:
+            self.n += 1
+
+        @on_keyboard("p")
+        def via_actions(self, ctx) -> None:
+            ctx.actions.press("z")
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    terminal.perform(Action.keyboard("p"))
+    assert app.n == 1

--- a/tests/test_component_chart.py
+++ b/tests/test_component_chart.py
@@ -7,8 +7,8 @@ from helpers import render_component_to_text
 from xnano.components.abstract import ComponentRenderContext
 from xnano.components.chart import Chart
 from xnano.components.schema import Series
-from xnano.core.nodes.terminal import ChartNode
-from xnano.types import Area
+from xnano.tui.nodes import ChartNode
+from xnano._types import Area
 
 
 def _ctx() -> ComponentRenderContext:

--- a/tests/test_component_progress.py
+++ b/tests/test_component_progress.py
@@ -6,11 +6,11 @@ from helpers import render_component_to_text
 
 from xnano.components.abstract import ComponentRenderContext
 from xnano.components.progress import Progress
-from xnano.core.nodes.terminal import (
+from xnano.tui.nodes import (
     LineGaugeNode,
     ProgressBarNode,
 )
-from xnano.types import Area
+from xnano._types import Area
 
 
 def _ctx() -> ComponentRenderContext:

--- a/tests/test_component_table.py
+++ b/tests/test_component_table.py
@@ -9,8 +9,8 @@ from helpers import render_component_to_text
 from xnano.components.abstract import ComponentRenderContext
 from xnano.components.schema import Column
 from xnano.components.table import Table
-from xnano.core.nodes.terminal import TableNode
-from xnano.types import Area
+from xnano.tui.nodes import TableNode
+from xnano._types import Area
 
 
 def _ctx() -> ComponentRenderContext:

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -10,20 +10,23 @@ from xnano.effects import (
     Effect,
     FadeEffect,
     SweepInEffect,
+)
+from xnano.tui.effects import (
+    build_native_effect,
     resolve_native_effect,
 )
 
 
 def test_effect_factory_builds_dissolve() -> None:
     effect = Effect("dissolve", duration_ms=250)
-    native_effect = effect.build_native_effect()
+    native_effect = build_native_effect(effect)
     assert isinstance(native_effect, native.Effect)
 
 
 def test_effect_factory_builds_fade_with_color() -> None:
     effect = Effect("fade", color="#ff00aa", duration_ms=400)
     assert isinstance(effect, FadeEffect)
-    native_effect = effect.build_native_effect()
+    native_effect = build_native_effect(effect)
     assert isinstance(native_effect, native.Effect)
 
 
@@ -37,7 +40,7 @@ def test_effect_factory_builds_sweep_in() -> None:
         duration_ms=500,
     )
     assert isinstance(effect, SweepInEffect)
-    native_effect = effect.build_native_effect()
+    native_effect = build_native_effect(effect)
     assert isinstance(native_effect, native.Effect)
 
 
@@ -64,7 +67,7 @@ def test_resolve_native_effect_accepts_kind_string() -> None:
 def test_custom_subclass_round_trip() -> None:
     effect = DissolveEffect(duration_ms=220, interpolation="cubic_out")
     assert effect.interpolation == "cubic_out"
-    native_effect = effect.build_native_effect()
+    native_effect = build_native_effect(effect)
     assert isinstance(native_effect, native.Effect)
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 
 import pytest
 
-from xnano.exceptions import FieldValidationError, TerminalNotActiveError
+from xnano.core.exceptions import FieldValidationError, TerminalNotActiveError
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.terminal import Terminal
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
 
 
-class _Counter(Grid):
+class _Counter(BaseGrid):
     # ``strict=True`` on a state field opts assignments (not just
     # construction) into validation — the default field-level ``strict``
     # is False, since re-validating every attribute set is not free.

--- a/tests/test_field_focus.py
+++ b/tests/test_field_focus.py
@@ -6,23 +6,26 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.hooks import on_focus, on_keyboard
+from xnano.grid import BaseGrid
+from xnano.events import on_focus, on_keyboard
 from xnano.components.text import Text
 from xnano.context import Context
-from xnano.core.dispatch import (
+from xnano._dispatch import (
     _handle_focus_navigation,
     _handle_focused_text_input,
     dispatch_hooks,
 )
-from xnano.focus import (
+from xnano._types import (
     FieldFocus,
     collect_focusable_fields,
     cycle_field_focus,
     set_field_focus,
     clear_field_focus,
 )
-from xnano.hooks import _EventHooksRegistry, _OnFocusHookFunctionEntry
+from xnano._function_hooks import (
+    _EventHooksRegistry,
+    _OnFocusHookFunctionEntry,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -30,7 +33,7 @@ from xnano.hooks import _EventHooksRegistry, _OnFocusHookFunctionEntry
 # ---------------------------------------------------------------------------
 
 
-class _Form(Grid):
+class _Form(BaseGrid):
     name: Text = Field(default=Text("", input=True, placeholder="name"))
     email: Text = Field(default=Text("", input=True, placeholder="email"))
     status: str = Field(default="")
@@ -217,7 +220,7 @@ def test_enter_still_available_to_hooks() -> None:
 
 
 def test_terminal_focus_helpers() -> None:
-    from xnano.terminal import Terminal
+    from xnano.tui import Terminal
 
     term = Terminal.__new__(Terminal)
     term._field_focus = None

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,11 +1,11 @@
-"""Tests for xnano.frame — Frame."""
+"""Tests for xnano._types — Frame."""
 
 from __future__ import annotations
 
 import pytest
 
 from xnano.fields import GridFieldInfo
-from xnano.frame import Frame, frame_from_field
+from xnano._types import Frame, frame_from_field
 
 
 def test_frame_default_is_empty() -> None:

--- a/tests/test_grid_field_hooks.py
+++ b/tests/test_grid_field_hooks.py
@@ -8,12 +8,12 @@ from typing import cast
 import pytest
 
 from xnano.context import Context
-from xnano.hooks import on_click, on_mouse
+from xnano.events import on_click, on_mouse
 from xnano.fields import Field
-from xnano.grid import Grid, _resolve_grid_mouse_handler
+from xnano.grid import BaseGrid, _resolve_grid_mouse_handler
 
 
-class Panel(Grid):
+class Panel(BaseGrid):
     body: str = Field(default="hello")
 
     @on_click("body")
@@ -21,7 +21,7 @@ class Panel(Grid):
         self.body = "clicked"
 
 
-class HeaderPanel(Grid):
+class HeaderPanel(BaseGrid):
     header: str = Field(default="title")
 
     @on_mouse(field="header", button="left", kind="press")
@@ -56,7 +56,7 @@ def test_on_mouse_field_param_registers_handler() -> None:
 def test_unknown_field_raises_at_class_creation() -> None:
     with pytest.raises(TypeError, match="not a layout field"):
 
-        class Bad(Grid):  # noqa: N801
+        class Bad(BaseGrid):  # noqa: N801
             @on_click("missing")
             def handler(self, ctx: Context) -> None:
                 pass

--- a/tests/test_grid_flex.py
+++ b/tests/test_grid_flex.py
@@ -8,12 +8,12 @@ lower to fraction (fill) weights through ``Sizing.parse``.
 from __future__ import annotations
 
 from xnano.fields import Field
-from xnano.grid import Grid, _layout_constraint_for_field
-from xnano.sizing import Sizing
+from xnano.grid import BaseGrid, _layout_constraint_for_field
+from xnano._types import Sizing
 
 
 def test_field_accepts_tailwind_flex_class() -> None:
-    class FlexGrid(Grid):
+    class FlexGrid(BaseGrid):
         body: str = Field(default="hello", height="flex-1")
 
     field = FlexGrid()._grid_field_info("body")
@@ -21,7 +21,7 @@ def test_field_accepts_tailwind_flex_class() -> None:
 
 
 def test_field_accepts_numeric_fraction() -> None:
-    class FlexGrid(Grid):
+    class FlexGrid(BaseGrid):
         body: str = Field(default="hello", height="3fr")
 
     field = FlexGrid()._grid_field_info("body")
@@ -29,7 +29,7 @@ def test_field_accepts_numeric_fraction() -> None:
 
 
 def test_grid_set_field_normalizes_tailwind_flex() -> None:
-    class FlexGrid(Grid):
+    class FlexGrid(BaseGrid):
         body: str = Field(default="hello")
 
     grid = FlexGrid()
@@ -40,7 +40,7 @@ def test_grid_set_field_normalizes_tailwind_flex() -> None:
 
 
 def test_layout_constraint_uses_fill_for_grow_classes() -> None:
-    class FlexGrid(Grid):
+    class FlexGrid(BaseGrid):
         body: str = Field(default="hello", height="flex-1")
 
     field = FlexGrid()._grid_field_info("body")
@@ -51,7 +51,7 @@ def test_layout_constraint_uses_fill_for_grow_classes() -> None:
 
 
 def test_layout_constraint_uses_min_for_no_grow_classes() -> None:
-    class FlexGrid(Grid):
+    class FlexGrid(BaseGrid):
         body: str = Field(default="hello", height="flex-none")
 
     field = FlexGrid()._grid_field_info("body")
@@ -62,7 +62,7 @@ def test_layout_constraint_uses_min_for_no_grow_classes() -> None:
 
 
 def test_field_without_layout_sizing_fills() -> None:
-    class FlexGrid(Grid):
+    class FlexGrid(BaseGrid):
         body: str = Field(default="hello")
 
     field = FlexGrid()._grid_field_info("body")

--- a/tests/test_grid_init.py
+++ b/tests/test_grid_init.py
@@ -1,21 +1,21 @@
-"""Tests for xnano Grid field initialization."""
+"""Tests for xnano BaseGrid field initialization."""
 
 from __future__ import annotations
 
 from xnano.fields import Field
-from xnano.grid import Grid
+from xnano.grid import BaseGrid
 from xnano.components.text import Text
 from xnano_core.core import CoreSession
 from xnano_core.rust import native
-from xnano.core.controllers.terminal import TerminalController
-from xnano.types import Area as GridArea
+from xnano.core.controllers.tui import TerminalController
+from xnano._types import Area as GridArea
 
 
-class Leaf(Grid):
+class Leaf(BaseGrid):
     label: str = Field(default="hello")
 
 
-class Root(Grid, direction="horizontal"):
+class Root(BaseGrid, direction="horizontal"):
     left: Leaf = Field(default_factory=Leaf)
     right: Leaf = Field(default_factory=Leaf)
 
@@ -28,7 +28,7 @@ def test_default_factory_creates_instances() -> None:
     assert root.left.label == "hello"
 
 
-class OptionalPanel(Grid, direction="vertical"):
+class OptionalPanel(BaseGrid, direction="vertical"):
     body: Text = Field(default=Text("visible"))
     overlay: Text | None = Field(
         default=None, border="rounded", title="Overlay"
@@ -69,7 +69,7 @@ def test_nullable_layout_field_renders_when_set() -> None:
 
 
 def test_grid_play_effect_targets_layout_field_area() -> None:
-    class EffectGrid(Grid):
+    class EffectGrid(BaseGrid):
         body: Text = Field(default=Text("hello"))
 
     grid = EffectGrid()
@@ -92,7 +92,7 @@ def test_grid_play_effect_targets_layout_field_area() -> None:
 
 
 def test_field_text_background_does_not_paint_frame() -> None:
-    class App(Grid, direction="vertical"):
+    class App(BaseGrid, direction="vertical"):
         header: str = Field(
             default="My App",
             height=1,
@@ -121,7 +121,7 @@ def test_field_text_background_does_not_paint_frame() -> None:
 def test_field_background_covers_text_span_only() -> None:
     # A field background should paint behind the text glyphs only, not flood
     # the whole slot to the right edge. "violet" == #ee82ee.
-    class App(Grid, direction="vertical"):
+    class App(BaseGrid, direction="vertical"):
         header: str = Field(
             default="My App",
             height=1,

--- a/tests/test_grid_min_size.py
+++ b/tests/test_grid_min_size.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from xnano.fields import Field
-from xnano.grid import Grid, _layout_constraint_for_field
+from xnano.grid import BaseGrid, _layout_constraint_for_field
 
 
 def test_grid_min_size_with_border() -> None:
-    class MinSizeGrid(Grid):
+    class MinSizeGrid(BaseGrid):
         body: str = Field(default="hello", border="rounded")
 
     grid = MinSizeGrid()

--- a/tests/test_grid_set_field.py
+++ b/tests/test_grid_set_field.py
@@ -1,22 +1,22 @@
-"""Tests for Grid.grid_set_field and grid-slot component positioning."""
+"""Tests for BaseGrid.grid_set_field and grid-slot component positioning."""
 
 from __future__ import annotations
 
 import pytest
 
 from xnano.fields import Field, UNSET
-from xnano.grid import Grid
-from xnano.terminal import Terminal
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
 from xnano.components.text import Text
-from xnano.exceptions import FieldValidationError
-from xnano.types import Area
+from xnano.core.exceptions import FieldValidationError
+from xnano._types import Area
 
 
-class LayoutGrid(Grid):
+class LayoutGrid(BaseGrid):
     body: str = Field(default="hello")
 
 
-class StatefulGrid(Grid):
+class StatefulGrid(BaseGrid):
     body: str = Field(default="hello")
     count: int = Field(default=0, state=True)
 
@@ -68,13 +68,13 @@ def test_set_field_validates_when_strict() -> None:
 
 
 def test_grid_slot_renders_text_component_offscreen() -> None:
-    class TextGrid(Grid):
+    class TextGrid(BaseGrid):
         body: Text = Field(default_factory=lambda: Text(content="hello"))
 
     terminal = Terminal.offscreen(cols=40, rows=8)
     grid = TextGrid()
     terminal.run.__func__  # verify it's a callable
-    from xnano.types import Area
+    from xnano._types import Area
 
     terminal._track_frame_grid(grid)
     sess = terminal.session
@@ -86,7 +86,7 @@ def test_grid_slot_renders_text_component_offscreen() -> None:
 
 
 def test_set_field_accepts_text_component() -> None:
-    class TextGrid(Grid):
+    class TextGrid(BaseGrid):
         body: Text = Field(default_factory=lambda: Text(content="init"))
 
     grid = TextGrid()

--- a/tests/test_grid_sizing.py
+++ b/tests/test_grid_sizing.py
@@ -7,13 +7,13 @@ slot geometry, so no TTY is required.
 from __future__ import annotations
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.sizing import Sizing
-from xnano.terminal import Terminal
-from xnano.types import Area
+from xnano.grid import BaseGrid
+from xnano._types import Sizing
+from xnano.tui import Terminal
+from xnano._types import Area
 
 
-def _slot_areas(grid: Grid, width: int, height: int) -> dict[str, Area]:
+def _slot_areas(grid: BaseGrid, width: int, height: int) -> dict[str, Area]:
     """Build ``grid`` into a ``width`` x ``height`` area and return slot areas."""
     terminal = Terminal.offscreen(cols=width, rows=height)
     terminal._track_frame_grid(grid)
@@ -25,7 +25,7 @@ def _slot_areas(grid: Grid, width: int, height: int) -> dict[str, Area]:
 
 
 def test_vertical_height_cells() -> None:
-    class App(Grid):
+    class App(BaseGrid):
         header: str = Field(default="h", height=2)
         body: str = Field(default="b", height="1fr")
 
@@ -38,7 +38,7 @@ def test_vertical_height_cells() -> None:
 
 
 def test_horizontal_width_percent() -> None:
-    class Row(Grid, direction="horizontal"):
+    class Row(BaseGrid, direction="horizontal"):
         left: str = Field(default="l", width="25%")
         right: str = Field(default="r", width="1fr")
 
@@ -48,7 +48,7 @@ def test_horizontal_width_percent() -> None:
 
 
 def test_horizontal_width_ratio() -> None:
-    class Row(Grid, direction="horizontal"):
+    class Row(BaseGrid, direction="horizontal"):
         left: str = Field(default="l", width=Sizing.ratio(1, 4))
         right: str = Field(default="r", width="1fr")
 
@@ -58,7 +58,7 @@ def test_horizontal_width_ratio() -> None:
 
 
 def test_vertical_height_fit() -> None:
-    class App(Grid):
+    class App(BaseGrid):
         header: str = Field(default="one\ntwo", height="fit")
         body: str = Field(default="b", height="1fr")
 
@@ -69,7 +69,7 @@ def test_vertical_height_fit() -> None:
 
 
 def test_fixed_height_wins_over_fill_sibling() -> None:
-    class App(Grid):
+    class App(BaseGrid):
         top: str = Field(default="t", height=3)
         rest: str = Field(default="r", height="1fr")
 
@@ -84,7 +84,7 @@ def test_fixed_height_wins_over_fill_sibling() -> None:
 
 
 def test_vertical_cross_axis_width_cells() -> None:
-    class App(Grid):
+    class App(BaseGrid):
         a: str = Field(default="x", width=10, height=2)
 
     area = _slot_areas(App(), 40, 6)["a"]
@@ -94,7 +94,7 @@ def test_vertical_cross_axis_width_cells() -> None:
 
 
 def test_horizontal_cross_axis_height_cells() -> None:
-    class Row(Grid, direction="horizontal"):
+    class Row(BaseGrid, direction="horizontal"):
         a: str = Field(default="x", width="50%", height=3)
         b: str = Field(default="y", width="1fr")
 
@@ -106,7 +106,7 @@ def test_horizontal_cross_axis_height_cells() -> None:
 
 
 def test_cross_axis_fit_measures_content() -> None:
-    class App(Grid):
+    class App(BaseGrid):
         a: str = Field(default="hello", width="fit")
 
     area = _slot_areas(App(), 40, 6)["a"]
@@ -114,7 +114,7 @@ def test_cross_axis_fit_measures_content() -> None:
 
 
 def test_cross_axis_percent() -> None:
-    class App(Grid):
+    class App(BaseGrid):
         a: str = Field(default="x", width="25%")
 
     area = _slot_areas(App(), 40, 6)["a"]
@@ -122,7 +122,7 @@ def test_cross_axis_percent() -> None:
 
 
 def test_cross_axis_none_fills() -> None:
-    class App(Grid):
+    class App(BaseGrid):
         a: str = Field(default="x", height=2)
 
     area = _slot_areas(App(), 40, 6)["a"]

--- a/tests/test_grid_slide.py
+++ b/tests/test_grid_slide.py
@@ -6,19 +6,20 @@ from dataclasses import dataclass
 from typing import cast
 
 from xnano.context import Context
-from xnano.hooks import on_mouse, _EventHooksRegistry
+from xnano.events import on_mouse
+from xnano._function_hooks import _EventHooksRegistry
 from xnano.fields import Field
-from xnano.grid import Grid, _GridSlideCapture, _grid_slide_paint_area
-from xnano.terminal import Terminal, _ACTIVE_TERMINAL
+from xnano.grid import BaseGrid, _GridSlideCapture, _grid_slide_paint_area
+from xnano.tui import Terminal, _ACTIVE_TERMINAL
 from xnano.events import Event
-from xnano.types import Area
+from xnano._types import Area
 
 
-class SlideGrid(Grid):
+class SlideGrid(BaseGrid):
     body: str = Field(default="hello", slide=["x", "y"])
 
 
-class ClickGrid(Grid):
+class ClickGrid(BaseGrid):
     body: str = Field(default="hello")
 
     @on_mouse(field="body")
@@ -26,7 +27,7 @@ class ClickGrid(Grid):
         self.body = "clicked"
 
 
-class DragHookGrid(Grid):
+class DragHookGrid(BaseGrid):
     body: str = Field(default="hello", slide=["x"])
 
     @on_mouse(field="body", kind="drag")

--- a/tests/test_grid_type_validation.py
+++ b/tests/test_grid_type_validation.py
@@ -1,4 +1,4 @@
-"""Grid integration tests for Python and Pydantic type validation."""
+"""BaseGrid integration tests for Python and Pydantic type validation."""
 
 from __future__ import annotations
 
@@ -13,11 +13,11 @@ from pydantic import BaseModel, Field as PydanticField
 
 from helpers import assign_attr, invalid_field
 from xnano.fields import Field
-from xnano.grid import Grid
+from xnano.grid import BaseGrid
 from xnano.components.text import Text
-from xnano.core.renderable import Renderable
-from xnano.exceptions import FieldValidationError
-from xnano.types import Area
+from xnano._renderable import Renderable
+from xnano.core.exceptions import FieldValidationError
+from xnano._types import Area
 
 
 class Status(enum.Enum):
@@ -43,7 +43,7 @@ class SettingsTD(TypedDict):
     verbose: bool
 
 
-class TypedLayoutGrid(Grid):
+class TypedLayoutGrid(BaseGrid):
     label: Literal["on", "off"] = Field(default="on")
     body: Renderable | str = Field(default="hello")
     count: int | None = Field(default=None, state=True)
@@ -62,26 +62,26 @@ class TypedLayoutGrid(Grid):
     metrics: Metrics = Field(default_factory=lambda: Metrics(0), state=True)
 
 
-class StrictLayoutGrid(Grid):
+class StrictLayoutGrid(BaseGrid):
     child: "ChildGrid" = Field(default_factory=lambda: ChildGrid())
     paragraph: Text = Field(default_factory=lambda: Text(content="hi"))
 
 
-class ChildGrid(Grid):
+class ChildGrid(BaseGrid):
     value: int = Field(default=1, state=True, strict=True)
 
 
-class PydanticLayoutGrid(Grid):
+class PydanticLayoutGrid(BaseGrid):
     payload: ConfigModel = Field(default_factory=ConfigModel)
 
 
-class PydanticNestedGrid(Grid):
+class PydanticNestedGrid(BaseGrid):
     nested: NestedConfigGrid = Field(
         default_factory=lambda: NestedConfigGrid(config=ConfigModel())
     )
 
 
-class LooseSetFieldGrid(Grid):
+class LooseSetFieldGrid(BaseGrid):
     name: str = Field(default="ok")
 
 
@@ -91,7 +91,7 @@ def test_literal_layout_field_validates() -> None:
 
 
 def test_literal_layout_field_rejects_invalid_on_init() -> None:
-    class LiteralPanel(Grid):
+    class LiteralPanel(BaseGrid):
         mode: Literal["on", "off"] = invalid_field("maybe")
 
     with pytest.raises(FieldValidationError, match="mode"):
@@ -124,7 +124,7 @@ def test_enum_state_field_rejects_raw_string_without_strict() -> None:
 
 
 def test_enum_state_field_rejects_with_strict_runtime() -> None:
-    class StrictEnumGrid(Grid):
+    class StrictEnumGrid(BaseGrid):
         status: Status = Field(default=Status.ON, state=True, strict=True)
 
     grid = StrictEnumGrid()
@@ -133,7 +133,7 @@ def test_enum_state_field_rejects_with_strict_runtime() -> None:
 
 
 def test_datetime_state_field_with_strict() -> None:
-    class StrictDateGrid(Grid):
+    class StrictDateGrid(BaseGrid):
         when: datetime.datetime = Field(
             default_factory=lambda: datetime.datetime(
                 2026, 1, 1, tzinfo=datetime.timezone.utc
@@ -148,7 +148,7 @@ def test_datetime_state_field_with_strict() -> None:
 
 
 def test_uuid_state_field_with_strict() -> None:
-    class StrictUuidGrid(Grid):
+    class StrictUuidGrid(BaseGrid):
         uid: uuid.UUID = Field(
             default_factory=lambda: uuid.UUID(int=0),
             state=True,
@@ -166,7 +166,7 @@ def test_pydantic_model_state_field_accepts_instance() -> None:
 
 
 def test_pydantic_model_state_field_rejects_dict_with_strict() -> None:
-    class StrictConfigGrid(Grid):
+    class StrictConfigGrid(BaseGrid):
         config: ConfigModel = Field(
             default_factory=ConfigModel, state=True, strict=True
         )
@@ -183,7 +183,7 @@ def test_dataclass_state_field_accepts_instance() -> None:
 
 
 def test_dataclass_state_field_rejects_wrong_type_with_strict() -> None:
-    class StrictMetricsGrid(Grid):
+    class StrictMetricsGrid(BaseGrid):
         metrics: Metrics = Field(
             default_factory=lambda: Metrics(0),
             state=True,
@@ -229,7 +229,7 @@ def test_set_field_validates_under_strict_grid() -> None:
 
 
 def test_set_field_allows_valid_renderable() -> None:
-    class Panel(Grid):
+    class Panel(BaseGrid):
         body: Renderable = invalid_field("hi")
 
     panel = Panel()
@@ -238,7 +238,7 @@ def test_set_field_allows_valid_renderable() -> None:
 
 
 def test_set_field_position_does_not_validate_value() -> None:
-    class SlidePanel(Grid):
+    class SlidePanel(BaseGrid):
         body: str = Field(default="hi", slide=["x"])
 
     panel = SlidePanel()
@@ -251,7 +251,7 @@ def test_set_field_position_does_not_validate_value() -> None:
 
 
 def test_field_validation_error_wraps_validation_error() -> None:
-    class Bad(Grid):
+    class Bad(BaseGrid):
         n: int = invalid_field("x")
 
     with pytest.raises(FieldValidationError) as exc:
@@ -263,7 +263,7 @@ def test_field_validation_error_wraps_validation_error() -> None:
 
 
 def test_none_layout_value_skips_validation() -> None:
-    class OptionalPanel(Grid):
+    class OptionalPanel(BaseGrid):
         body: Renderable | None = Field(default=None)
 
     panel = OptionalPanel()
@@ -277,7 +277,7 @@ def test_strict_child_state_field_validates_on_assignment() -> None:
 
 
 def test_init_validation_coerces_nothing_for_layout_fields() -> None:
-    class IntPanel(Grid):
+    class IntPanel(BaseGrid):
         n: int = Field(default=3)
 
     panel = IntPanel()

--- a/tests/test_grid_validation.py
+++ b/tests/test_grid_validation.py
@@ -6,34 +6,34 @@ import pytest
 from pydantic import BaseModel
 
 from helpers import assign_attr, invalid_field
-from xnano.core.renderable import Renderable
-from xnano.exceptions import FieldValidationError
+from xnano._renderable import Renderable
+from xnano.core.exceptions import FieldValidationError
 from xnano.fields import Field
-from xnano.grid import Grid
+from xnano.grid import BaseGrid
 
 
-class Leaf(Grid):
+class Leaf(BaseGrid):
     label: str = Field(default="hello")
 
 
-class Root(Grid, direction="horizontal"):
+class Root(BaseGrid, direction="horizontal"):
     left: Leaf = Field(default_factory=Leaf)
     right: Leaf = Field(default_factory=Leaf)
 
 
-class LooseGrid(Grid, strict=False):
+class LooseGrid(BaseGrid, strict=False):
     count: int = invalid_field("not-an-int")
 
 
-class StrictStateGrid(Grid):
+class StrictStateGrid(BaseGrid):
     count: int = 0
 
 
-class StrictRuntimeGrid(Grid):
+class StrictRuntimeGrid(BaseGrid):
     count: int = Field(default=0, state=True, strict=True)
 
 
-class ModelGrid(Grid):
+class ModelGrid(BaseGrid):
     model: "UserModel" = Field(default_factory=lambda: UserModel(name="ada"))
 
 
@@ -41,7 +41,7 @@ class UserModel(BaseModel):
     name: str
 
 
-class UnannotatedLayoutGrid(Grid):
+class UnannotatedLayoutGrid(BaseGrid):
     body = "hello"
 
 
@@ -52,7 +52,7 @@ def test_strict_init_accepts_nested_grids() -> None:
 
 
 def test_strict_init_rejects_invalid_layout_field() -> None:
-    class Bad(Grid):
+    class Bad(BaseGrid):
         label: str = invalid_field(123)
 
     with pytest.raises(FieldValidationError, match="label"):
@@ -60,7 +60,7 @@ def test_strict_init_rejects_invalid_layout_field() -> None:
 
 
 def test_strict_init_rejects_invalid_nested_grid() -> None:
-    class Bad(Grid):
+    class Bad(BaseGrid):
         child: Leaf = invalid_field(123)
 
     with pytest.raises(FieldValidationError, match="child"):
@@ -68,7 +68,7 @@ def test_strict_init_rejects_invalid_nested_grid() -> None:
 
 
 def test_strict_init_accepts_any_renderable_value() -> None:
-    class Panel(Grid):
+    class Panel(BaseGrid):
         body: Renderable = invalid_field(123)
 
     grid = Panel()
@@ -125,7 +125,7 @@ def test_state_field_with_runtime_strict_rejects_bad_assignment() -> None:
 
 
 def test_none_skips_init_validation() -> None:
-    class OptionalBody(Grid):
+    class OptionalBody(BaseGrid):
         body: Renderable | None = Field(default=None)
 
     grid = OptionalBody()

--- a/tests/test_hook_async_and_exceptions.py
+++ b/tests/test_hook_async_and_exceptions.py
@@ -10,11 +10,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.hooks import on_tick, _EventHooksRegistry
+from xnano.grid import BaseGrid
+from xnano.events import on_tick
+from xnano._function_hooks import _EventHooksRegistry
 from xnano.context import Context
-from xnano.core.dispatch import invoke_hook, pump_tick, run_awaitable
-from xnano.exceptions import Exit, HookError
+from xnano._dispatch import invoke_hook, pump_tick, run_awaitable
+from xnano.core.exceptions import Exit, HookError
 
 
 def _ctx() -> Context[Any]:
@@ -53,7 +54,7 @@ def test_run_awaitable_rejects_nested_loop() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _AsyncTickGrid(Grid):
+class _AsyncTickGrid(BaseGrid):
     count: int = Field(default=0, state=True)
 
     @on_tick
@@ -103,13 +104,13 @@ def test_invoke_hook_awaits_free_async_function() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _BoomGrid(Grid):
+class _BoomGrid(BaseGrid):
     @on_tick
     def _explode(self) -> None:
         raise ValueError("boom")
 
 
-class _ExitGrid(Grid):
+class _ExitGrid(BaseGrid):
     @on_tick
     def _leave(self) -> None:
         raise Exit()
@@ -149,7 +150,7 @@ def test_invoke_hook_propagates_exit_without_logging(
 def test_async_hook_exception_is_logged_and_reraised(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    class _AsyncBoom(Grid):
+    class _AsyncBoom(BaseGrid):
         @on_tick
         async def _explode(self) -> None:
             await asyncio.sleep(0)
@@ -175,7 +176,7 @@ def test_hook_error_wraps_cause() -> None:
 
 
 def test_async_hook_can_raise_exit() -> None:
-    class _Ready(Grid):
+    class _Ready(BaseGrid):
         ready: bool = Field(default=True, state=True)
 
         @on_tick

--- a/tests/test_hook_interop.py
+++ b/tests/test_hook_interop.py
@@ -28,20 +28,20 @@ import enum
 from typing import Any, cast
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.hooks import on_field, on_keyboard, on_tick
+from xnano.grid import BaseGrid
+from xnano.events import on_field, on_keyboard, on_tick
 from xnano.context import Context
-from xnano.core.dispatch import invoke_hook, pump_tick
-from xnano.hooks import (
+from xnano._dispatch import invoke_hook, pump_tick
+from xnano._function_hooks import (
     _EventHooksRegistry,
     _OnFieldHookFunctionEntry,
     _OnKeyboardHookFunctionEntry,
     _OnStateHookFunctionEntry,
     _OnTickHookFunctionEntry,
 )
-from xnano.hooks import on_state
+from xnano.events import on_state
 from xnano.state import State
-from xnano.utils.core import evaluate_state_expression
+from xnano._introspection import evaluate_state_expression
 
 
 # ---------------------------------------------------------------------------
@@ -136,7 +136,7 @@ class _StubTerminal:
 # ---------------------------------------------------------------------------
 
 
-class _SwitcherGrid(Grid):
+class _SwitcherGrid(BaseGrid):
     mode: str = Field(default="idle", state=True)
     label: str = Field(default="idle mode")
     john_count: int = Field(default=0, state=True)
@@ -221,7 +221,7 @@ def test_multiple_keyboard_presses_before_tick_last_wins() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _TrafficLightGrid(Grid):
+class _TrafficLightGrid(BaseGrid):
     color: str = Field(default="green", state=True)
     red_fires: int = Field(default=0, state=True)
     yellow_fires: int = Field(default=0, state=True)
@@ -288,7 +288,7 @@ def test_field_hook_stops_when_condition_becomes_false() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _CascadeGrid(Grid):
+class _CascadeGrid(BaseGrid):
     step: int = Field(default=0, state=True)
     stage_a_reached: bool = Field(default=False, state=True)
     stage_b_reached: bool = Field(default=False, state=True)
@@ -321,7 +321,7 @@ def test_cascade_second_step_fires_on_next_tick() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _CountdownGrid(Grid):
+class _CountdownGrid(BaseGrid):
     ticks: int = Field(default=0, state=True)
     threshold_reached: bool = Field(default=False, state=True)
 
@@ -349,7 +349,7 @@ def test_tick_increments_then_field_hook_fires_at_threshold() -> None:
     assert grid.ticks == 3 and grid.threshold_reached
 
 
-class _IntervalGrid(Grid):
+class _IntervalGrid(BaseGrid):
     """on_tick with a huge interval fires only once (first call starts from
     last_fire_ms=0, so elapsed is large enough to trip the interval gate
     immediately). on_field fires on every tick regardless.
@@ -390,7 +390,7 @@ class _IntervalGrid(Grid):
 # ---------------------------------------------------------------------------
 
 
-class _CompoundGrid(Grid):
+class _CompoundGrid(BaseGrid):
     count: int = Field(default=0, state=True)
     active: bool = Field(default=False, state=True)
     fired: bool = Field(default=False, state=True)
@@ -452,7 +452,7 @@ def test_or_expression_fires_on_either_condition() -> None:
 
 
 def test_chained_comparison_expression() -> None:
-    class _RangeGrid(Grid):
+    class _RangeGrid(BaseGrid):
         value: int = Field(default=0, state=True)
         in_range: bool = Field(default=False, state=True)
 
@@ -480,7 +480,7 @@ def test_chained_comparison_expression() -> None:
 
 
 # 7a. Optional[str] — truthiness and None check
-class _OptionalGrid(Grid):
+class _OptionalGrid(BaseGrid):
     username: str | None = Field(default=None, state=True)
     logged_in: bool = Field(default=False, state=True)
     logged_out: bool = Field(default=False, state=True)
@@ -511,7 +511,7 @@ def test_optional_field_none_check() -> None:
 
 
 # 7b. set[str] — membership test
-class _PermissionsGrid(Grid):
+class _PermissionsGrid(BaseGrid):
     roles: set[str] = Field(default_factory=set, state=True)
     is_admin: bool = Field(default=False, state=True)
     is_editor: bool = Field(default=False, state=True)
@@ -558,7 +558,7 @@ def test_set_multiple_memberships() -> None:
 
 
 # 7c. tuple — index access
-class _CoordGrid(Grid):
+class _CoordGrid(BaseGrid):
     position: tuple[int, int] = Field(default=(0, 0), state=True)
     in_positive_quadrant: bool = Field(default=False, state=True)
     at_origin: bool = Field(default=False, state=True)
@@ -589,7 +589,7 @@ def test_tuple_index_expression() -> None:
 
 
 # 7d. float — threshold and abs comparison
-class _ProgressGrid(Grid):
+class _ProgressGrid(BaseGrid):
     progress: float = Field(default=0.0, state=True)
     complete: bool = Field(default=False, state=True)
     near_half: bool = Field(default=False, state=True)
@@ -633,7 +633,7 @@ def test_float_abs_proximity_expression() -> None:
 
 
 # 7e. Nested dict — deep key access
-class _ConfigGrid(Grid):
+class _ConfigGrid(BaseGrid):
     config: dict[str, Any] = Field(default_factory=dict, state=True)
     is_admin: bool = Field(default=False, state=True)
     theme_dark: bool = Field(default=False, state=True)
@@ -670,7 +670,7 @@ def test_nested_dict_expression() -> None:
 
 
 # 7f. String operators — in, len, str() conversion
-class _StringFieldGrid(Grid):
+class _StringFieldGrid(BaseGrid):
     message: str = Field(default="", state=True)
     count: int = Field(default=0, state=True)
     has_error: bool = Field(default=False, state=True)
@@ -726,7 +726,7 @@ def test_str_conversion_expression() -> None:
 
 
 # 7g. List membership and truthiness
-class _LogGrid(Grid):
+class _LogGrid(BaseGrid):
     log: list[str] = Field(default_factory=list, state=True)
     has_warning: bool = Field(default=False, state=True)
     is_empty: bool = Field(default=False, state=True)
@@ -773,7 +773,7 @@ def test_list_truthiness_and_len() -> None:
 
 
 # 7h. max / min built-in expressions
-class _ScoreGrid(Grid):
+class _ScoreGrid(BaseGrid):
     scores: list[int] = Field(default_factory=list, state=True)
     high_score: bool = Field(default=False, state=True)
     low_score: bool = Field(default=False, state=True)
@@ -808,7 +808,7 @@ def test_min_builtin_expression() -> None:
 
 
 # 7i. isinstance and hasattr
-class _TypeCheckGrid(Grid):
+class _TypeCheckGrid(BaseGrid):
     value: Any = Field(default=None, state=True)
     is_int: bool = Field(default=False, state=True)
     has_name: bool = Field(default=False, state=True)
@@ -853,7 +853,7 @@ def test_hasattr_expression() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _StateVarGrid(Grid):
+class _StateVarGrid(BaseGrid):
     count: int = Field(default=0, state=True)
     via_state: bool = Field(default=False, state=True)
     has_count_attr: bool = Field(default=False, state=True)
@@ -906,7 +906,7 @@ def test_state_variable_getattr() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _SafeGrid(Grid):
+class _SafeGrid(BaseGrid):
     count: int = Field(default=5, state=True)
     denominator: int = Field(default=0, state=True)
 
@@ -942,7 +942,7 @@ def test_invalid_index_returns_false() -> None:
 
 
 def test_bad_expression_does_not_fire_hook() -> None:
-    class _BadExprGrid(Grid):
+    class _BadExprGrid(BaseGrid):
         count: int = Field(default=5, state=True)
         fired: bool = Field(default=False, state=True)
 
@@ -963,7 +963,7 @@ def test_bad_expression_does_not_fire_hook() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _TwoHandlerGrid(Grid):
+class _TwoHandlerGrid(BaseGrid):
     active: bool = Field(default=False, state=True)
     handler_a_count: int = Field(default=0, state=True)
     handler_b_count: int = Field(default=0, state=True)
@@ -1004,7 +1004,7 @@ def test_two_handlers_neither_fires_when_false() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _FireCountGrid(Grid):
+class _FireCountGrid(BaseGrid):
     active: bool = Field(default=True, state=True)
     fire_count: int = Field(default=0, state=True)
 
@@ -1044,7 +1044,7 @@ def test_hook_fire_count_matches_true_ticks_only() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _ParentGrid(Grid):
+class _ParentGrid(BaseGrid):
     base_flag: bool = Field(default=False, state=True)
     parent_fired: bool = Field(default=False, state=True)
 
@@ -1144,7 +1144,7 @@ def test_overridden_hook_registers_once() -> None:
     # A subclass overriding a parent's hook method must shadow it — both
     # collected members rebind to the same bound method, so registering
     # both would fire the override twice per event.
-    class _OverrideParent(Grid):
+    class _OverrideParent(BaseGrid):
         flag: bool = Field(default=False, state=True)
         fired: int = Field(default=0, state=True)
 
@@ -1173,7 +1173,7 @@ def test_overridden_hook_registers_once() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _IsolatedGrid(Grid):
+class _IsolatedGrid(BaseGrid):
     value: int = Field(default=0, state=True)
     fired: bool = Field(default=False, state=True)
     fire_count: int = Field(default=0, state=True)
@@ -1244,7 +1244,7 @@ def test_mixed_grid_types_do_not_contaminate() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _DualSourceGrid(Grid):
+class _DualSourceGrid(BaseGrid):
     grid_flag: bool = Field(default=False, state=True)
     field_hook_fired: bool = Field(default=False, state=True)
     state_hook_fired: bool = Field(default=False, state=True)
@@ -1297,7 +1297,7 @@ def test_on_field_not_confused_by_terminal_state_attribute() -> None:
     """on_field must evaluate against the grid, not terminal.state,
     even if terminal.state has a same-named attribute."""
 
-    class _AmbiguousGrid(Grid):
+    class _AmbiguousGrid(BaseGrid):
         count: int = Field(default=10, state=True)
         correct: bool = Field(default=False, state=True)
 
@@ -1320,7 +1320,7 @@ def test_on_field_not_confused_by_terminal_state_attribute() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _DictStateGrid(Grid):
+class _DictStateGrid(BaseGrid):
     config: dict[str, Any] = Field(default_factory=dict, state=True)
     display: str = Field(default="waiting")
 

--- a/tests/test_hook_perf.py
+++ b/tests/test_hook_perf.py
@@ -24,20 +24,19 @@ from typing import Any, cast
 from xnano_core.core import CoreSession
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.core.dispatch import pump_tick
-from xnano.core.controllers.terminal import TerminalController
-from xnano.hooks import (
+from xnano.grid import BaseGrid
+from xnano._dispatch import pump_tick
+from xnano.core.controllers.tui import TerminalController
+from xnano.events import on_field, on_tick
+from xnano._function_hooks import (
     _EventHooksRegistry,
     _OnFieldHookFunctionEntry,
     _OnStateHookFunctionEntry,
     _OnTickHookFunctionEntry,
-    on_field,
-    on_tick,
 )
 from xnano.state import State
-from xnano.types import Area
-from xnano.utils.core import evaluate_state_expression
+from xnano._types import Area
+from xnano._introspection import evaluate_state_expression
 
 
 # ---------------------------------------------------------------------------
@@ -106,14 +105,14 @@ def _make_offscreen(
     return core, sess
 
 
-def _one_frame(grid: Grid, sess: TerminalController, area: Area) -> None:
+def _one_frame(grid: BaseGrid, sess: TerminalController, area: Area) -> None:
     sess.begin_viewport_frame()
     grid._grid_build_frame(area, sess)
     sess.commit_requests()
 
 
 def _frame_and_tick(
-    grid: Grid,
+    grid: BaseGrid,
     sess: TerminalController,
     area: Area,
     terminal: _StubTerminal,
@@ -125,11 +124,11 @@ def _frame_and_tick(
 
 
 # ---------------------------------------------------------------------------
-# Grid fixtures
+# BaseGrid fixtures
 # ---------------------------------------------------------------------------
 
 
-class _CounterGrid(Grid):
+class _CounterGrid(BaseGrid):
     count: int = Field(default=0, state=True)
     active: bool = Field(default=True, state=True)
     label: str = Field(default="running")
@@ -147,7 +146,7 @@ class _CounterGrid(Grid):
         self.count += 1
 
 
-class _AlwaysFiringGrid(Grid):
+class _AlwaysFiringGrid(BaseGrid):
     """All on_field hooks evaluate to true every tick."""
 
     count: int = Field(default=5, state=True)
@@ -168,8 +167,8 @@ class _AlwaysFiringGrid(Grid):
         self.calls += 1
 
 
-class _RenderGrid(Grid):
-    title: str = Field(default="Benchmark Grid", height=1)
+class _RenderGrid(BaseGrid):
+    title: str = Field(default="Benchmark BaseGrid", height=1)
     body: str = Field(
         default=(
             "frame content goes here — this simulates a typical "
@@ -179,14 +178,14 @@ class _RenderGrid(Grid):
     status: str = Field(default="ok", height=1)
 
 
-class _NestedRenderGrid(Grid):
+class _NestedRenderGrid(BaseGrid):
     header: str = Field(default="Header", height=1)
     left: _RenderGrid = Field(default_factory=_RenderGrid)
     right: _RenderGrid = Field(default_factory=_RenderGrid)
     footer: str = Field(default="Footer", height=1)
 
 
-class _ExprGrid(Grid):
+class _ExprGrid(BaseGrid):
     count: int = Field(default=42, state=True)
     active: bool = Field(default=True, state=True)
     name: str = Field(default="alice", state=True)
@@ -558,7 +557,7 @@ def test_bench_pump_tick_mixed_grid_types(benchmark) -> None:
 # ---------------------------------------------------------------------------
 
 
-class _MixedHookGrid(Grid):
+class _MixedHookGrid(BaseGrid):
     count: int = Field(default=5, state=True)
     active: bool = Field(default=True, state=True)
     label: str = Field(default="running")
@@ -586,7 +585,7 @@ def test_bench_mixed_hooks_no_terminal_state(benchmark) -> None:
 def test_bench_mixed_hooks_with_terminal_state(benchmark) -> None:
     grid = _MixedHookGrid()
 
-    from xnano.hooks import on_state
+    from xnano.events import on_state
 
     class _WithStateGrid(_MixedHookGrid):
         state_fired: bool = Field(default=False, state=True)
@@ -614,12 +613,12 @@ def test_bench_registry_few_hooks(benchmark) -> None:
     benchmark(_EventHooksRegistry.from_component_class, _AlwaysFiringGrid)
 
 
-class _DeepGrid(_GrandchildGrid if False else Grid):
+class _DeepGrid(_GrandchildGrid if False else BaseGrid):
     pass
 
 
 # Re-define inline to avoid forward-reference to test_hook_interop
-class _L0(Grid):
+class _L0(BaseGrid):
     f0: bool = Field(default=False, state=True)
 
     @on_field("f0")

--- a/tests/test_keyboard_bindings.py
+++ b/tests/test_keyboard_bindings.py
@@ -7,7 +7,7 @@ from typing import cast
 
 from xnano_core.rust import native
 
-from xnano.utils.events import (
+from xnano._event_processing import (
     get_keyboard_binding_tuple_from_native_event,
 )
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,10 +1,10 @@
-"""Tests for xnano.core.nodes.terminal — render IR nodes."""
+"""Tests for xnano.tui.nodes — render IR nodes."""
 
 from __future__ import annotations
 
 import pytest
 
-from xnano.core.nodes.terminal import (
+from xnano.tui.nodes import (
     ClearNode,
     ContainerNode,
     FrameNode,
@@ -16,8 +16,8 @@ from xnano.core.nodes.terminal import (
     StackNode,
     TextNode,
 )
-from xnano.frame import Frame
-from xnano.types import Size
+from xnano._types import Frame
+from xnano._types import Size
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_on_field_hook.py
+++ b/tests/test_on_field_hook.py
@@ -6,15 +6,15 @@ import dataclasses
 from typing import Any, cast
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.hooks import (
-    on_field,
+from xnano.grid import BaseGrid
+from xnano.events import on_field
+from xnano._function_hooks import (
     _EventHooksRegistry,
     _OnFieldHookFunctionEntry,
 )
 from xnano.context import Context
-from xnano.core.dispatch import pump_tick
-from xnano.utils.core import evaluate_state_expression
+from xnano._dispatch import pump_tick
+from xnano._introspection import evaluate_state_expression
 
 
 # ---------------------------------------------------------------------------
@@ -22,7 +22,7 @@ from xnano.utils.core import evaluate_state_expression
 # ---------------------------------------------------------------------------
 
 
-class _SimpleLabelGrid(Grid):
+class _SimpleLabelGrid(BaseGrid):
     label: str = Field(default="initial")
     active: bool = Field(default=False, state=True)
     fired: bool = Field(default=False, state=True)
@@ -74,7 +74,7 @@ def test_evaluate_against_grid_string_comparison() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _NameSwitcherGrid(Grid):
+class _NameSwitcherGrid(BaseGrid):
     config: dict[str, Any] = Field(default_factory=dict, state=True)
     current_text: str = Field(default="choose a name")
     john_fired: bool = Field(default=False, state=True)

--- a/tests/test_on_poll_hook.py
+++ b/tests/test_on_poll_hook.py
@@ -8,14 +8,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.hooks import (
-    on_poll,
-    PollWhen,
+from xnano.grid import BaseGrid
+from xnano.events import on_poll, PollWhen
+from xnano._function_hooks import (
     _EventHooksRegistry,
     _OnPollHookFunctionEntry,
 )
-from xnano.core.dispatch import pump_events, pump_poll
+from xnano._dispatch import pump_events, pump_poll
 
 
 # ---------------------------------------------------------------------------
@@ -23,7 +22,7 @@ from xnano.core.dispatch import pump_events, pump_poll
 # ---------------------------------------------------------------------------
 
 
-class _IdleGrid(Grid):
+class _IdleGrid(BaseGrid):
     idle_count: int = Field(default=0, state=True)
     frame_count: int = Field(default=0, state=True)
 
@@ -36,7 +35,7 @@ class _IdleGrid(Grid):
         self.frame_count += 1
 
 
-class _KeywordIdleGrid(Grid):
+class _KeywordIdleGrid(BaseGrid):
     hits: int = Field(default=0, state=True)
 
     @on_poll(when="idle")
@@ -78,7 +77,7 @@ def test_invalid_when_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _stub_terminal(grid: Grid) -> Any:
+def _stub_terminal(grid: BaseGrid) -> Any:
     terminal = MagicMock()
     terminal.state = None
     registry = _EventHooksRegistry.from_component_class(type(grid))

--- a/tests/test_render_fallback.py
+++ b/tests/test_render_fallback.py
@@ -1,4 +1,4 @@
-"""Tests for xnano.core.renderable — stdout fallback renderer.
+"""Tests for xnano._renderable — stdout fallback renderer.
 
 All tests run without a live terminal (no TTY / no _ACTIVE_TERMINAL set),
 exercising the ANSI-based fallback path directly.
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from xnano.core.renderable import (
+from xnano._renderable import (
     _RESET,
     _ansi_color,
     _apply_border,
@@ -31,7 +31,7 @@ def _force_fallback_path():
     This fixture resets the context var to None for the duration of each test
     so the fallback renderer is always exercised.
     """
-    from xnano.terminal import _ACTIVE_TERMINAL
+    from xnano.tui import _ACTIVE_TERMINAL
 
     token = _ACTIVE_TERMINAL.set(None)
     yield

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from xnano.sizing import Sizing
+from xnano._types import Sizing
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_terminal_render.py
+++ b/tests/test_terminal_render.py
@@ -1,6 +1,6 @@
 """Tests for Terminal.render / Terminal.run inline rendering of renderables.
 
-These exercise the non-Grid rendering path — content measurement, inline
+These exercise the non-BaseGrid rendering path — content measurement, inline
 viewport sizing, and painting standalone renderables — using offscreen
 sessions so no TTY is required.
 """
@@ -10,11 +10,11 @@ from __future__ import annotations
 import pytest
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.sizing import Sizing
-from xnano.terminal import Terminal
+from xnano.grid import BaseGrid
+from xnano._types import Sizing
+from xnano.tui import Terminal
 from xnano.components.text import Text
-from xnano.core import dispatch
+from xnano import _dispatch as dispatch
 
 
 # ---------------------------------------------------------------------------
@@ -218,20 +218,20 @@ def test_render_frame_paints_lone_root_renderable() -> None:
 
 
 # ---------------------------------------------------------------------------
-# run() dispatch routing (Grid vs inline)
+# run() dispatch routing (BaseGrid vs inline)
 # ---------------------------------------------------------------------------
 
 
 def _run_would_use_inline(*renderables: object) -> bool:
-    """Mirror the Grid-vs-inline branch that ``Terminal.run`` uses."""
-    return not (len(renderables) == 1 and isinstance(renderables[0], Grid))
+    """Mirror the BaseGrid-vs-inline branch that ``Terminal.run`` uses."""
+    return not (len(renderables) == 1 and isinstance(renderables[0], BaseGrid))
 
 
 def test_run_routes_single_grid_to_full_screen() -> None:
-    class MyGrid(Grid):
+    class MyGrid(BaseGrid):
         body: str = Field(default="hello")
 
-    # A lone Grid takes the full-screen path (no inline viewport).
+    # A lone BaseGrid takes the full-screen path (no inline viewport).
     assert _run_would_use_inline(MyGrid()) is False
 
 
@@ -256,7 +256,7 @@ def test_fresh_terminal_has_no_inline_height() -> None:
 def test_resolve_run_grid_defaults_to_fullscreen() -> None:
     terminal: Terminal = Terminal()
     resolved = terminal._resolve_run(["x"], is_grid=True, field=None)
-    # A Grid defaults to fill height → full-screen (no inline viewport).
+    # A BaseGrid defaults to fill height → full-screen (no inline viewport).
     assert resolved.inline_height is None
     assert resolved.root_width_sizing == Sizing.fraction(1)
 
@@ -272,7 +272,7 @@ def test_resolve_run_leaf_defaults_to_inline_fit() -> None:
 def test_resolve_run_explicit_cells_height_is_inline() -> None:
     terminal: Terminal = Terminal(height=5)
     resolved = terminal._resolve_run(["x"], is_grid=True, field=None)
-    # An explicit finite height forces an inline viewport even for a Grid.
+    # An explicit finite height forces an inline viewport even for a BaseGrid.
     assert resolved.inline_height == 5
 
 
@@ -290,17 +290,17 @@ def test_resolve_run_records_explicit_width_sizing() -> None:
 
 
 def test_resolve_run_fit_grid_falls_back_to_fullscreen() -> None:
-    # A Grid has no measurable intrinsic height, so an explicit fit height
+    # A BaseGrid has no measurable intrinsic height, so an explicit fit height
     # cannot reserve an inline viewport and must fall back to full-screen —
     # and it warns rather than silently overriding the request.
     terminal: Terminal = Terminal(height="fit")
-    with pytest.warns(UserWarning, match="has no effect for a Grid"):
+    with pytest.warns(UserWarning, match="has no effect for a BaseGrid"):
         resolved = terminal._resolve_run(["x"], is_grid=True, field=None)
     assert resolved.inline_height is None
 
 
 def test_resolve_run_cells_height_grid_is_inline() -> None:
-    # A fixed cells height needs no measurement, so it works for a Grid.
+    # A fixed cells height needs no measurement, so it works for a BaseGrid.
     terminal: Terminal = Terminal(height=8)
     resolved = terminal._resolve_run(["x"], is_grid=True, field=None)
     assert resolved.inline_height == 8

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -7,13 +7,13 @@ import pytest
 
 from xnano.components.abstract import ComponentRenderContext
 from xnano.components.text import Text
-from xnano.core.nodes.terminal import (
+from xnano.tui.nodes import (
     LineNode,
     ParagraphNode,
     SpanNode,
     TextNode,
 )
-from xnano.types import Area
+from xnano._types import Area
 
 
 def _ctx() -> ComponentRenderContext:

--- a/tests/test_text_input.py
+++ b/tests/test_text_input.py
@@ -7,9 +7,9 @@ from unittest.mock import MagicMock
 
 from xnano.components.abstract import ComponentRenderContext
 from xnano.components.text import Text
-from xnano.core.nodes.terminal import ParagraphNode
-from xnano.focus import apply_text_keyboard
-from xnano.types import Area
+from xnano.tui.nodes import ParagraphNode
+from xnano._types import apply_text_keyboard
+from xnano._types import Area
 
 
 def _ctx() -> ComponentRenderContext:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,11 +1,11 @@
-"""Tests for xnano.types — Padding, Size, Area."""
+"""Tests for xnano._types — Padding, Size, Area."""
 
 from __future__ import annotations
 
 import pytest
 from typing import Any
 
-from xnano.types import Area, Flex, Padding, Size, resolve_flex_weight
+from xnano._types import Area, Flex, Padding, Size, resolve_flex_weight
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_usage_scenarios.py
+++ b/tests/test_usage_scenarios.py
@@ -1,7 +1,7 @@
 """End-to-end usage scenarios — hooks + components working together.
 
 These are not unit checks of single conditionals. Each test builds a small
-app-like ``Grid``, drives it through an offscreen ``Terminal``, and asserts
+app-like ``BaseGrid``, drives it through an offscreen ``Terminal``, and asserts
 on rendered output and cross-feature behavior (focus → input → submit,
 table/progress/chart in one layout, tick/poll/field chains, etc.).
 """
@@ -21,21 +21,21 @@ from helpers import (
 )
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.hooks import (
+from xnano.grid import BaseGrid
+from xnano.events import (
     on_field,
     on_focus,
     on_keyboard,
     on_poll,
     on_tick,
-    _EventHooksRegistry,
 )
+from xnano._function_hooks import _EventHooksRegistry
 from xnano.components.chart import Chart
 from xnano.components.progress import Progress
 from xnano.components.table import Table
 from xnano.components.text import Text
 from xnano.components.schema import Column, Series
-from xnano.core.dispatch import pump_poll, pump_tick
+from xnano._dispatch import pump_poll, pump_tick
 
 
 # ---------------------------------------------------------------------------
@@ -43,7 +43,7 @@ from xnano.core.dispatch import pump_poll, pump_tick
 # ---------------------------------------------------------------------------
 
 
-class LoginForm(Grid):
+class LoginForm(BaseGrid):
     """Two-field form with focus hooks and submit-on-enter."""
 
     heading: str = Field(default="Sign in", height=1)
@@ -136,7 +136,7 @@ def test_login_form_paste_into_focused_input() -> None:
     from typing import Any, cast
 
     from xnano.context import Context
-    from xnano.core.dispatch import dispatch_hooks
+    from xnano._dispatch import dispatch_hooks
 
     form = LoginForm()
     terminal = open_offscreen_app(form)
@@ -168,7 +168,7 @@ class CpuChart(Chart):
     mem = Series(color="magenta")
 
 
-class Dashboard(Grid):
+class Dashboard(BaseGrid):
     title: str = Field(default="ops", height=1)
     table: Table = Field(
         default_factory=lambda: ServicesTable(
@@ -275,7 +275,7 @@ def test_dashboard_tick_updates_progress_and_fires_on_field() -> None:
 # ---------------------------------------------------------------------------
 
 
-class ChatApp(Grid):
+class ChatApp(BaseGrid):
     log: Text = Field(
         default_factory=lambda: Text("welcome"),
         height=4,
@@ -299,8 +299,8 @@ class ChatApp(Grid):
             self.log = Text("\n".join(self.history[-4:]))
         self.prompt = Text("", input=True, placeholder="message")
         # keep focus on the new prompt instance
-        from xnano.focus import set_field_focus
-        from xnano.terminal import _ACTIVE_TERMINAL
+        from xnano._types import set_field_focus
+        from xnano.tui import _ACTIVE_TERMINAL
 
         term = _ACTIVE_TERMINAL.get()
         if term is not None:
@@ -334,7 +334,7 @@ def test_chat_prompt_type_submit_command_flow() -> None:
 # ---------------------------------------------------------------------------
 
 
-class WorkerApp(Grid):
+class WorkerApp(BaseGrid):
     label: str = Field(default="boot", height=1)
     idle_count: int = Field(default=0, state=True)
     frame_count: int = Field(default=0, state=True)
@@ -448,7 +448,7 @@ def test_worker_poll_tick_keyboard_field_chain() -> None:
 # ---------------------------------------------------------------------------
 
 
-class AsyncMeter(Grid):
+class AsyncMeter(BaseGrid):
     meter: Progress = Field(
         default_factory=lambda: Progress(value=0, total=10),
         height=3,
@@ -495,7 +495,7 @@ def test_async_tick_with_progress_and_on_field() -> None:
 # ---------------------------------------------------------------------------
 
 
-class Panel(Grid):
+class Panel(BaseGrid):
     name: str = Field(default="panel", height=1, state=True)
     field: Text = Field(
         default_factory=lambda: Text("", input=True, placeholder="…"),
@@ -503,7 +503,7 @@ class Panel(Grid):
     )
 
 
-class Dual(Grid):
+class Dual(BaseGrid):
     left: Panel = Field(default_factory=lambda: Panel(name="left"))
     right: Panel = Field(default_factory=lambda: Panel(name="right"))
 
@@ -525,7 +525,7 @@ def test_nested_panels_render_and_focus_left_input() -> None:
         assert len(terminal._attached_frame_grids) >= 3  # root + 2 panels
 
         # Explicitly focus left panel input and type.
-        from xnano.focus import set_field_focus
+        from xnano._types import set_field_focus
 
         assert set_field_focus(terminal, root.left, "field") is True
         type_text(terminal, "xy")
@@ -541,8 +541,8 @@ def test_nested_panels_render_and_focus_left_input() -> None:
 # ---------------------------------------------------------------------------
 
 
-class Picker(Grid):
-    # Note: cannot name a layout field ``rows`` — Grid owns ``rows``/``columns``.
+class Picker(BaseGrid):
+    # Note: cannot name a layout field ``rows`` — BaseGrid owns ``rows``/``columns``.
     items: Table = Field(
         default_factory=lambda: Table(
             data=[
@@ -616,7 +616,7 @@ def test_picker_keyboard_moves_selection_and_progress() -> None:
 # ---------------------------------------------------------------------------
 
 
-class BoomApp(Grid):
+class BoomApp(BaseGrid):
     label: str = Field(default="safe", height=1)
 
     @on_keyboard("x")
@@ -654,7 +654,7 @@ def test_hook_exception_logs_and_terminal_still_paints(
 # ---------------------------------------------------------------------------
 
 
-class _Tally(Grid):
+class _Tally(BaseGrid):
     label: str = Field(default="", height=1)
     count: int = Field(default=0, state=True)
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -13,10 +13,10 @@ import pytest
 from pydantic import BaseModel
 from pydantic_core import ValidationError, core_schema
 
-from xnano.grid import Grid
+from xnano.grid import BaseGrid
 from xnano.components.text import Text
-from xnano.core.renderable import Renderable
-from xnano.utils.validation import (
+from xnano._renderable import Renderable
+from xnano._validation import (
     infer_pydantic_core_schema_name,
     layout_field_annotation,
     register_validatable_type,
@@ -71,7 +71,7 @@ class OptionalTD(TypedDict, total=False):
     age: int
 
 
-class LeafGrid(Grid):
+class LeafGrid(BaseGrid):
     label: str = "leaf"
 
 

--- a/tests/webui/grids.py
+++ b/tests/webui/grids.py
@@ -1,23 +1,23 @@
-"""Shared Grid fixtures for beta web tests."""
+"""Shared BaseGrid fixtures for beta web tests."""
 
 from __future__ import annotations
 
-from xnano.beta.components.text import Text
-from xnano.beta.requests import on_get_request, on_post_request
+from xnano.components.text import Text
+from xnano.webui.requests import on_get_request, on_post_request
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.hooks import on_click, on_field, on_keyboard, on_tick
+from xnano.grid import BaseGrid
+from xnano.events import on_click, on_field, on_keyboard, on_tick
 
 
-class SimpleGrid(Grid, direction="horizontal", gap=1):
-    """Grid with two string fields side by side."""
+class SimpleGrid(BaseGrid, direction="horizontal", gap=1):
+    """BaseGrid with two string fields side by side."""
 
     left: str = Field(default="left", height=1)
     right: str = Field(default="right", height=1)
 
 
-class StyledGrid(Grid):
-    """Grid with styled fields."""
+class StyledGrid(BaseGrid):
+    """BaseGrid with styled fields."""
 
     title: str = Field(default="Title", color="cyan", modifiers=("bold",))
     body: str = Field(
@@ -25,8 +25,8 @@ class StyledGrid(Grid):
     )
 
 
-class FrameGrid(Grid):
-    """Grid with frame chrome."""
+class FrameGrid(BaseGrid):
+    """BaseGrid with frame chrome."""
 
     framed: str = Field(
         default="framed",
@@ -35,14 +35,14 @@ class FrameGrid(Grid):
     )
 
 
-class NestedGrid(Grid):
-    """Grid that contains another grid."""
+class NestedGrid(BaseGrid):
+    """BaseGrid that contains another grid."""
 
     inner: SimpleGrid = Field(default_factory=SimpleGrid)
 
 
-class ClickableGrid(Grid, direction="vertical", gap=1):
-    """Grid with a clickable field and state."""
+class ClickableGrid(BaseGrid, direction="vertical", gap=1):
+    """BaseGrid with a clickable field and state."""
 
     label: str = Field(default="Count: 0", height=1)
     body: str = Field(default="Click me", border="rounded")
@@ -54,8 +54,8 @@ class ClickableGrid(Grid, direction="vertical", gap=1):
         self.label = f"Count: {self.count}"
 
 
-class TextGrid(Grid):
-    """Grid using beta Text component."""
+class TextGrid(BaseGrid):
+    """BaseGrid using beta Text component."""
 
     title: Text = Field(
         default=Text("Title", color="cyan", modifiers=("bold",))
@@ -63,8 +63,8 @@ class TextGrid(Grid):
     body: str = Field(default="Body text")
 
 
-class InteractiveGrid(Grid, direction="vertical", gap=1):
-    """Grid exercising keyboard, tick, field-expression, and input hooks."""
+class InteractiveGrid(BaseGrid, direction="vertical", gap=1):
+    """BaseGrid exercising keyboard, tick, field-expression, and input hooks."""
 
     name: Text = Field(
         default_factory=lambda: Text("", input=True, placeholder="name…")
@@ -94,8 +94,8 @@ class InteractiveGrid(Grid, direction="vertical", gap=1):
         self.note = "double digits"
 
 
-class RequestHookGrid(Grid, direction="vertical", gap=1):
-    """Grid with custom HTTP request hooks and a reactive field hook."""
+class RequestHookGrid(BaseGrid, direction="vertical", gap=1):
+    """BaseGrid with custom HTTP request hooks and a reactive field hook."""
 
     label: str = Field(default="Count: 0", height=1)
     body: str = Field(default="bump", border="rounded")

--- a/tests/webui/test_commands.py
+++ b/tests/webui/test_commands.py
@@ -1,4 +1,4 @@
-"""tests.beta.test_commands"""
+"""tests.webui.test_commands"""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from xnano.beta.commands import Command, HelpException
+from xnano.cli.command import Command, HelpException
 
 
 def test_command_decorator_and_simple_parsing() -> None:

--- a/tests/webui/test_tailwind.py
+++ b/tests/webui/test_tailwind.py
@@ -1,4 +1,4 @@
-"""tests.beta.test_tailwind"""
+"""tests.webui.test_tailwind"""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 import pytest
 
-from xnano.beta.tailwind import (
+from xnano._styles import (
     KNOWN_TAILWIND_CLASSES,
     TailwindBorderClass,
     TailwindColorClass,
@@ -20,8 +20,8 @@ from xnano.beta.tailwind import (
 )
 from xnano.color import Color
 from xnano.fields import Field, GridFieldInfo
-from xnano.sizing import Sizing
-from xnano.types import Padding
+from xnano._types import Sizing
+from xnano._types import Padding
 
 
 TAILWIND_PALETTES = (
@@ -561,7 +561,7 @@ def test_resolution_is_cached() -> None:
 
 
 def test_register_tailwind_class_group() -> None:
-    from xnano.beta import tailwind
+    from xnano import _styles as tailwind
 
     class _AccentGroup(tailwind.AbstractTailwindClassGroup):
         def match(self, token: str) -> bool:
@@ -582,7 +582,7 @@ def test_register_tailwind_class_group() -> None:
 
 
 def test_builtin_groups_match_before_registered_groups() -> None:
-    from xnano.beta import tailwind
+    from xnano import _styles as tailwind
 
     class _HijackGroup(tailwind.AbstractTailwindClassGroup):
         def match(self, token: str) -> bool:
@@ -751,9 +751,9 @@ def test_field_keeps_unknown_classes_in_tokens() -> None:
 
 
 def test_grid_set_field_class_name_roundtrip() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         header: str = Field(default="hi")
 
     app = App()
@@ -766,9 +766,9 @@ def test_grid_set_field_class_name_roundtrip() -> None:
 
 
 def test_grid_set_field_explicit_key_wins_over_class_name() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         header: str = Field(default="hi")
 
     app = App()
@@ -778,9 +778,9 @@ def test_grid_set_field_explicit_key_wins_over_class_name() -> None:
 
 
 def test_grid_set_field_class_name_accepts_sequence() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         header: str = Field(default="hi")
 
     app = App()
@@ -792,9 +792,9 @@ def test_grid_set_field_class_name_accepts_sequence() -> None:
 
 
 def test_grid_set_field_modifier_flags_toggle() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         header: str = Field(default="hi")
 
     app = App()
@@ -810,9 +810,9 @@ def test_grid_set_field_modifier_flags_toggle() -> None:
 
 
 def test_grid_set_field_modifier_flags_on_top_of_class_name() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         header: str = Field(default="hi")
 
     app = App()
@@ -821,9 +821,9 @@ def test_grid_set_field_modifier_flags_on_top_of_class_name() -> None:
 
 
 def test_grid_set_field_modifier_flags_with_explicit_modifiers() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         header: str = Field(default="hi")
 
     app = App()
@@ -854,9 +854,9 @@ def render_grid_offscreen(grid: Any, *, cols: int = 30, rows: int = 9) -> str:
 
 
 def test_terminal_renders_class_name_field() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         content: str = Field(
             default="hello",
             class_name="border rounded p-2 m-2 text-red-500",
@@ -877,14 +877,14 @@ def test_terminal_renders_class_name_field() -> None:
 
 def test_terminal_class_name_matches_explicit_kwargs() -> None:
     """Class-derived chrome must render identically to explicit kwargs."""
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class ByClass(Grid):
+    class ByClass(BaseGrid):
         content: str = Field(
             default="hello", class_name="border p-4 text-red-500"
         )
 
-    class ByKwargs(Grid):
+    class ByKwargs(BaseGrid):
         content: str = Field(
             default="hello",
             border="plain",
@@ -898,12 +898,12 @@ def test_terminal_class_name_matches_explicit_kwargs() -> None:
 
 
 def test_terminal_margin_insets_content() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class Plain(Grid):
+    class Plain(BaseGrid):
         content: str = Field(default="hello")
 
-    class WithMargin(Grid):
+    class WithMargin(BaseGrid):
         content: str = Field(default="hello", class_name="m-4")
 
     plain_lines = render_grid_offscreen(Plain()).split("\n")
@@ -922,9 +922,9 @@ def test_terminal_margin_insets_content() -> None:
 
 
 def test_terminal_asymmetric_margin_sides() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         content: str = Field(
             default="hello", class_name="mt-4 ml-8 border"
         )
@@ -938,9 +938,9 @@ def test_terminal_asymmetric_margin_sides() -> None:
 
 
 def test_terminal_width_class_constrains_split() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid, direction="horizontal"):
+    class App(BaseGrid, direction="horizontal"):
         left: str = Field(default="L", class_name="w-8 border")
         right: str = Field(default="R", border="plain")
 
@@ -952,9 +952,9 @@ def test_terminal_width_class_constrains_split() -> None:
 
 
 def test_terminal_height_class_constrains_split() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         top: str = Field(default="T", class_name="h-16 border")
         bottom: str = Field(default="B")
 
@@ -967,9 +967,9 @@ def test_terminal_height_class_constrains_split() -> None:
 
 
 def test_terminal_ignores_web_only_classes() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         content: str = Field(
             default="hello",
             class_name="shadow-lg transition hover:bg-red-500 truncate",
@@ -980,9 +980,9 @@ def test_terminal_ignores_web_only_classes() -> None:
 
 
 def test_terminal_grid_with_multiple_class_name_fields() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid, gap=1):
+    class App(BaseGrid, gap=1):
         header: str = Field(
             default="Header", class_name="h-4 border-b font-bold"
         )
@@ -1001,15 +1001,15 @@ def test_terminal_grid_with_multiple_class_name_fields() -> None:
 
 
 def render_grid_html(grid: Any) -> str:
-    from xnano.beta.controllers.web import WebController
+    from xnano.core.controllers.webui import WebController
 
     return WebController().render_grid_html(grid)
 
 
 def test_web_emits_raw_classes_verbatim() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         header: str = Field(
             default="Dashboard",
             class_name="p-2 bg-slate-900 text-slate-100 shadow-lg",
@@ -1026,9 +1026,9 @@ def test_web_emits_raw_classes_verbatim() -> None:
 
 
 def test_web_emits_unknown_classes_verbatim() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         body: str = Field(default="x", class_name="my-custom-class md:p-8")
 
     html = render_grid_html(App())
@@ -1037,9 +1037,9 @@ def test_web_emits_unknown_classes_verbatim() -> None:
 
 
 def test_web_inline_style_when_kwarg_overrides_class() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         body: str = Field(
             default="x", color="red", class_name="text-blue-500"
         )
@@ -1050,9 +1050,9 @@ def test_web_inline_style_when_kwarg_overrides_class() -> None:
 
 
 def test_web_suppresses_covered_modifier_classes() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         body: str = Field(default="x", class_name="font-bold")
 
     html = render_grid_html(App())
@@ -1060,9 +1060,9 @@ def test_web_suppresses_covered_modifier_classes() -> None:
 
 
 def test_web_suppresses_covered_alignment() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         body: str = Field(default="x", class_name="text-center")
 
     html = render_grid_html(App())
@@ -1070,9 +1070,9 @@ def test_web_suppresses_covered_alignment() -> None:
 
 
 def test_web_suppresses_covered_sizing() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid, direction="horizontal"):
+    class App(BaseGrid, direction="horizontal"):
         left: str = Field(default="L", class_name="w-1/2")
         right: str = Field(default="R")
 
@@ -1082,9 +1082,9 @@ def test_web_suppresses_covered_sizing() -> None:
 
 
 def test_web_inline_sizing_when_kwarg_overrides_class() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid, direction="horizontal"):
+    class App(BaseGrid, direction="horizontal"):
         left: str = Field(default="L", width="75%", class_name="w-1/2")
         right: str = Field(default="R")
 
@@ -1094,9 +1094,9 @@ def test_web_inline_sizing_when_kwarg_overrides_class() -> None:
 
 
 def test_web_suppresses_covered_frame_chrome() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         body: str = Field(default="x", class_name="border rounded-lg p-1")
 
     html = render_grid_html(App())
@@ -1106,9 +1106,9 @@ def test_web_suppresses_covered_frame_chrome() -> None:
 
 
 def test_web_keeps_frame_chrome_without_class_name() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         body: str = Field(default="x", border="rounded", padding=1)
 
     html = render_grid_html(App())
@@ -1118,9 +1118,9 @@ def test_web_keeps_frame_chrome_without_class_name() -> None:
 
 
 def test_web_flex_weight_class_replaces_flex_grow_style() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         body: str = Field(default="x", class_name="flex-1")
 
     html = render_grid_html(App())
@@ -1129,9 +1129,9 @@ def test_web_flex_weight_class_replaces_flex_grow_style() -> None:
 
 
 def test_web_margin_classes_have_no_inline_margin() -> None:
-    from xnano import Grid
+    from xnano import BaseGrid
 
-    class App(Grid):
+    class App(BaseGrid):
         body: str = Field(default="x", class_name="m-4")
 
     html = render_grid_html(App())

--- a/tests/webui/test_web_events.py
+++ b/tests/webui/test_web_events.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import time
 
-from tests.beta.grids import ClickableGrid, InteractiveGrid, SimpleGrid
-from xnano.beta.web import Web
+from tests.webui.grids import ClickableGrid, InteractiveGrid, SimpleGrid
+from xnano.webui import Web
 
 
 def test_dispatch_click_fires_handler() -> None:

--- a/tests/webui/test_web_http.py
+++ b/tests/webui/test_web_http.py
@@ -15,12 +15,12 @@ from typing import Any, AsyncIterator
 import httpx
 import pytest
 
-from tests.beta.grids import (
+from tests.webui.grids import (
     ClickableGrid,
     InteractiveGrid,
     RequestHookGrid,
 )
-from xnano.beta.web import Web
+from xnano.webui import Web
 
 
 @asynccontextmanager

--- a/tests/webui/test_web_render.py
+++ b/tests/webui/test_web_render.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from tests.beta.grids import (
+from tests.webui.grids import (
     ClickableGrid,
     FrameGrid,
     NestedGrid,
@@ -10,10 +10,10 @@ from tests.beta.grids import (
     StyledGrid,
     TextGrid,
 )
-from xnano.beta.components.text import Text
-from xnano.beta.controllers.web import WebController
+from xnano.components.text import Text
+from xnano.core.controllers.webui import WebController
 from xnano.fields import Field
-from xnano.grid import Grid
+from xnano.grid import BaseGrid
 
 
 def test_simple_grid_renders_html() -> None:
@@ -46,7 +46,7 @@ def test_gap_renders_in_styles() -> None:
 def test_script_tag_escaped() -> None:
     """Script tags in field values are escaped."""
 
-    class ScriptGrid(Grid):
+    class ScriptGrid(BaseGrid):
         content: str = Field(default="<script>alert(1)</script>")
 
     grid = ScriptGrid()
@@ -116,9 +116,9 @@ def test_nested_grid_has_inner_flex() -> None:
 
 
 def test_grid_background_color() -> None:
-    """Grid-level background renders as style."""
+    """BaseGrid-level background renders as style."""
 
-    class BackgroundGrid(Grid, background="black"):
+    class BackgroundGrid(BaseGrid, background="black"):
         content: str = Field(default="text")
 
     grid = BackgroundGrid()
@@ -148,7 +148,7 @@ def test_text_component_terminal_render() -> None:
 def test_text_spans() -> None:
     """Text with multiple colored spans renders all spans."""
 
-    class SpanTestGrid(Grid):
+    class SpanTestGrid(BaseGrid):
         content: Text = Field(
             default=Text(
                 [

--- a/tests/webui/test_web_request_hooks.py
+++ b/tests/webui/test_web_request_hooks.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from tests.beta.grids import RequestHookGrid
+from tests.webui.grids import RequestHookGrid
 from tests.helpers import close_offscreen_app, open_offscreen_app
-from xnano.beta.requests import on_post_request
-from xnano.beta.web import Web
+from xnano.webui.requests import on_post_request
+from xnano.webui import Web
 from xnano.fields import Field
-from xnano.grid import Grid
+from xnano.grid import BaseGrid
 
 
 def test_dispatch_request_post_mutates_state_and_html() -> None:
@@ -105,7 +105,7 @@ def test_request_hooks_do_not_fire_on_terminal_frame() -> None:
 def test_request_hook_subclass_shadows_base_handler() -> None:
     """A more-derived @on_post_request for the same path replaces the base one."""
 
-    class BaseCounter(Grid):
+    class BaseCounter(BaseGrid):
         label: str = Field(default="0")
         count: int = Field(default=0, state=True)
 

--- a/tests/webui/test_web_sessions.py
+++ b/tests/webui/test_web_sessions.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import types
 
-from tests.beta.grids import InteractiveGrid
-from xnano.beta.web import Web
+from tests.webui.grids import InteractiveGrid
+from xnano.webui import Web
 
 
 def test_factory_source_creates_isolated_sessions() -> None:
@@ -22,7 +22,7 @@ def test_factory_source_creates_isolated_sessions() -> None:
 
 
 def test_grid_instance_source_shares_mutations() -> None:
-    """A Grid instance source is one shared grid across sessions."""
+    """A BaseGrid instance source is one shared grid across sessions."""
     grid = InteractiveGrid()
     web = Web()
     web._source = grid


### PR DESCRIPTION
## Summary

- Update unit/integration tests for the module-layout refactor (`BaseGrid`, `xnano.core`, `xnano.tui` / `webui`, hooks from `xnano.events`).
- Relocate beta web/command tests to `tests/webui/`.
- Add `tests/test_actions.py` for Action matching, `perform`, and `@on`.

## Depends on

#33 (`refactor/module-layout-finalization`)

## Test plan

- [ ] `uv run pytest --ignore=tests/core -q`
- [ ] Spot-check webui suite: `uv run pytest tests/webui -q`
- [ ] Spot-check actions: `uv run pytest tests/test_actions.py -q`