### PR TITLE
chore: retarget examples and scripts to the new package layout

### DIFF
--- a/examples/agent_chat.py
+++ b/examples/agent_chat.py
@@ -13,12 +13,12 @@ import time
 from typing import Iterable, Iterator, Literal, TypeAlias
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.terminal import Terminal
-from xnano.hooks import on_keyboard, on_mouse, on_tick
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
+from xnano.events import on_keyboard, on_mouse, on_tick
 from xnano.components.text import Text
 from xnano.color import tailwind_color
-from xnano.types import CharacterModifier
+from xnano._types import CharacterModifier
 
 ToolKind: TypeAlias = Literal["read", "bash", "edit", "grep"]
 """Supported tool-call kinds shown in the transcript."""
@@ -355,7 +355,7 @@ def _render_autocomplete(
     return Text(parts)
 
 
-class AgentChat(Grid, direction="vertical", gap=0):
+class AgentChat(BaseGrid, direction="vertical", gap=0):
     """Agent CLI with transcript, slash commands, and simulated tool calls."""
 
     header: str = Field(
@@ -426,7 +426,7 @@ class AgentChat(Grid, direction="vertical", gap=0):
 
         ``source`` is consumed eagerly into state — a plain list, a
         generator, or a real streaming API's token iterator all work, since
-        a ``Grid`` state field must hold a concrete value rather than a
+        a ``BaseGrid`` state field must hold a concrete value rather than a
         live iterator.
         """
         self.messages = [*self.messages, {"type": "agent", "text": ""}]

--- a/examples/dashboard.py
+++ b/examples/dashboard.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 import random
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.terminal import Terminal
-from xnano.hooks import on_keyboard, on_tick
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
+from xnano.events import on_keyboard, on_tick
 from xnano.components.sparkline import Sparkline
 from xnano.components.text import Text
 from xnano.color import tailwind_color
@@ -136,7 +136,7 @@ def _build_table(processes: list, selected: int) -> Text:
     return Text(lines)
 
 
-class GaugesPanel(Grid, direction="vertical", gap=1):
+class GaugesPanel(BaseGrid, direction="vertical", gap=1):
     mem: Text = Field(
         default=Text(""),
         height=3,
@@ -153,7 +153,7 @@ class GaugesPanel(Grid, direction="vertical", gap=1):
     )
 
 
-class LeftPanel(Grid, direction="vertical"):
+class LeftPanel(BaseGrid, direction="vertical"):
     cpu: Sparkline = Field(
         default_factory=Sparkline,
         border="rounded",
@@ -163,7 +163,7 @@ class LeftPanel(Grid, direction="vertical"):
     gauges: GaugesPanel = Field(default_factory=GaugesPanel, height=9)
 
 
-class MainContent(Grid, direction="horizontal", gap=1):
+class MainContent(BaseGrid, direction="horizontal", gap=1):
     left: LeftPanel = Field(default_factory=LeftPanel, width="40%")
     right: Text = Field(
         default=Text(""),
@@ -173,7 +173,7 @@ class MainContent(Grid, direction="horizontal", gap=1):
     )
 
 
-class Dashboard(Grid, direction="vertical"):
+class Dashboard(BaseGrid, direction="vertical"):
     header: str = Field(
         default="   SUPER COOL VERY IMPORTANT DASHBOARD   ",
         height=1,

--- a/examples/effects_demo.py
+++ b/examples/effects_demo.py
@@ -9,9 +9,9 @@ import math
 import time
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.terminal import Terminal
-from xnano.hooks import on_keyboard, on_tick
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
+from xnano.events import on_keyboard, on_tick
 from xnano.components.text import Text
 from xnano.color import tailwind_color
 from xnano.effects import AbstractEffect, Effect
@@ -92,7 +92,7 @@ def _build_canvas_effect(key: str) -> AbstractEffect:
     )
 
 
-class EffectsDemo(Grid, direction="vertical"):
+class EffectsDemo(BaseGrid, direction="vertical"):
     header: str = Field(
         default="  TACHYONFX VISUAL EFFECTS ANIMATION DEMO  ",
         height=1,

--- a/examples/feed.py
+++ b/examples/feed.py
@@ -15,9 +15,9 @@ import random
 import time
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.terminal import Terminal
-from xnano.hooks import on_keyboard, on_tick
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
+from xnano.events import on_keyboard, on_tick
 from xnano.components.sparkline import Sparkline
 from xnano.components.text import Text
 from xnano.components.abstract import (
@@ -181,7 +181,7 @@ class ServiceGraph(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import (
+        from xnano.tui.nodes import (
             CanvasLine,
             CanvasNode,
             CanvasPrint,
@@ -248,7 +248,7 @@ class ServiceTable(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import (
+        from xnano.tui.nodes import (
             SpanNode,
             TableCellItem,
             TableNode,
@@ -330,7 +330,7 @@ class ErrorGauge(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import LineGaugeNode
+        from xnano.tui.nodes import LineGaugeNode
 
         if self.ratio < 0.02:
             filled = tailwind_color("emerald", 500)
@@ -357,7 +357,7 @@ class EndpointChart(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import (
+        from xnano.tui.nodes import (
             BarChartNode,
             BarGroupItem,
             BarItem,
@@ -392,7 +392,7 @@ class EventLog(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import (
+        from xnano.tui.nodes import (
             SpanNode,
             TableCellItem,
             TableNode,
@@ -481,7 +481,7 @@ class EventLog(AbstractComponent):
 # ── Layout ────────────────────────────────────────────────────────────────────
 
 
-class SparkRow(Grid, direction="horizontal", gap=1):
+class SparkRow(BaseGrid, direction="horizontal", gap=1):
     s_api: Sparkline = Field(
         default_factory=Sparkline,
         border="plain",
@@ -508,7 +508,7 @@ class SparkRow(Grid, direction="horizontal", gap=1):
     )
 
 
-class GaugeStack(Grid, direction="vertical", gap=0):
+class GaugeStack(BaseGrid, direction="vertical", gap=0):
     g0: ErrorGauge = Field(
         default_factory=ErrorGauge,
         height=3,
@@ -535,7 +535,7 @@ class GaugeStack(Grid, direction="vertical", gap=0):
     )
 
 
-class RightPanel(Grid, direction="vertical", gap=1):
+class RightPanel(BaseGrid, direction="vertical", gap=1):
     table: ServiceTable = Field(
         default_factory=ServiceTable,
         border="rounded",
@@ -558,7 +558,7 @@ class RightPanel(Grid, direction="vertical", gap=1):
     )
 
 
-class GraphPanel(Grid, direction="vertical", gap=1):
+class GraphPanel(BaseGrid, direction="vertical", gap=1):
     svc_label: Text = Field(default=Text(""), height=1)
     main_graph: ServiceGraph = Field(
         default_factory=ServiceGraph,
@@ -582,12 +582,12 @@ class GraphPanel(Grid, direction="vertical", gap=1):
     )
 
 
-class MainArea(Grid, direction="horizontal", gap=1):
+class MainArea(BaseGrid, direction="horizontal", gap=1):
     graphs: GraphPanel = Field(default_factory=GraphPanel, width="62%")
     right: RightPanel = Field(default_factory=RightPanel)
 
 
-class ApiMonitor(Grid, direction="vertical"):
+class ApiMonitor(BaseGrid, direction="vertical"):
     header: str = Field(
         default="  API HEALTH MONITOR",
         height=1,

--- a/examples/kanban.py
+++ b/examples/kanban.py
@@ -17,9 +17,9 @@ import time
 from typing import Literal, cast
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.terminal import Terminal
-from xnano.hooks import on_keyboard, on_tick
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
+from xnano.events import on_keyboard, on_tick
 from xnano.components.text import Text
 from xnano.components.abstract import (
     AbstractComponent,
@@ -168,7 +168,7 @@ class BoardTabs(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import LineNode, SpanNode, TabsNode
+        from xnano.tui.nodes import LineNode, SpanNode, TabsNode
 
         titles: list[str | LineNode | SpanNode] = [
             SpanNode(
@@ -198,7 +198,7 @@ class TaskList(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import (
+        from xnano.tui.nodes import (
             SpanNode,
             TableCellItem,
             TableNode,
@@ -265,7 +265,7 @@ class ActivityFeed(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import (
+        from xnano.tui.nodes import (
             SpanNode,
             TableCellItem,
             TableNode,
@@ -311,7 +311,7 @@ class VelocityChart(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import (
+        from xnano.tui.nodes import (
             CanvasLine,
             CanvasNode,
             CanvasPrint,
@@ -384,7 +384,7 @@ class PriorityBreakdown(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import (
+        from xnano.tui.nodes import (
             BarChartNode,
             BarGroupItem,
             BarItem,
@@ -426,7 +426,7 @@ class SprintGauge(AbstractComponent):
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
     def get_terminal_node(self, ctx: ComponentRenderContext):  # type: ignore[override]
-        from xnano.core.nodes.terminal import LineGaugeNode
+        from xnano.tui.nodes import LineGaugeNode
 
         return LineGaugeNode(
             progress=self.progress,
@@ -440,7 +440,7 @@ class SprintGauge(AbstractComponent):
 # ── Layout ────────────────────────────────────────────────────────────────────
 
 
-class SprintStats(Grid, direction="vertical", gap=0):
+class SprintStats(BaseGrid, direction="vertical", gap=0):
     completion: SprintGauge = Field(
         default_factory=SprintGauge,
         height=3,
@@ -461,7 +461,7 @@ class SprintStats(Grid, direction="vertical", gap=0):
     )
 
 
-class LeftPane(Grid, direction="vertical", gap=1):
+class LeftPane(BaseGrid, direction="vertical", gap=1):
     col_tabs: BoardTabs = Field(
         default_factory=BoardTabs,
         height=3,
@@ -482,7 +482,7 @@ class LeftPane(Grid, direction="vertical", gap=1):
     )
 
 
-class RightPane(Grid, direction="vertical", gap=1):
+class RightPane(BaseGrid, direction="vertical", gap=1):
     velocity: VelocityChart = Field(
         default_factory=VelocityChart,
         border="rounded",
@@ -505,12 +505,12 @@ class RightPane(Grid, direction="vertical", gap=1):
     )
 
 
-class MainArea(Grid, direction="horizontal", gap=1):
+class MainArea(BaseGrid, direction="horizontal", gap=1):
     left: LeftPane = Field(default_factory=LeftPane, width="45%")
     right: RightPane = Field(default_factory=RightPane)
 
 
-class KanbanApp(Grid, direction="vertical"):
+class KanbanApp(BaseGrid, direction="vertical"):
     header: str = Field(
         default="  BOARD",
         height=1,

--- a/examples/tabs_nav.py
+++ b/examples/tabs_nav.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 import time
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.terminal import Terminal
-from xnano.hooks import on_keyboard, on_tick
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
+from xnano.events import on_keyboard, on_tick
 from xnano.components.text import Text
 from xnano.color import tailwind_color
 
@@ -134,7 +134,7 @@ def _logs_screen(elapsed: float) -> str:
     return "\n".join(_LOGS)
 
 
-class TabNav(Grid, direction="vertical"):
+class TabNav(BaseGrid, direction="vertical"):
     tab_bar: Text = Field(
         default=Text(""),
         height=3,

--- a/examples/web_counter.py
+++ b/examples/web_counter.py
@@ -1,6 +1,6 @@
 """xnano web counter example.
 
-Demonstrates the same Grid working on both terminal and web interfaces:
+Demonstrates the same BaseGrid working on both terminal and web interfaces:
 click the box (or press the up arrow) to count, type into the name
 input, and watch the tick counter advance once per second.
 
@@ -14,13 +14,13 @@ from __future__ import annotations
 
 import sys
 
-from xnano.grid import Grid
+from xnano.grid import BaseGrid
 from xnano.fields import Field
-from xnano.hooks import on_click, on_keyboard, on_tick
-from xnano.beta.components.text import Text
+from xnano.events import on_click, on_keyboard, on_tick
+from xnano.components.text import Text
 
 
-class Counter(Grid, direction="vertical", gap=1):
+class Counter(BaseGrid, direction="vertical", gap=1):
     """A counter with click, keyboard, tick, and text-input hooks."""
 
     title: Text = Field(
@@ -67,13 +67,13 @@ def main() -> None:
     use_web = "--web" in sys.argv
 
     if use_web:
-        from xnano.beta.web import Web
+        from xnano.webui import Web
 
         # Pass the class itself for a fresh grid per browser session;
         # pass an instance (``Counter()``) to share one across visitors.
         Web(title="xnano web counter").run(Counter)
     else:
-        from xnano.terminal import Terminal
+        from xnano.tui import Terminal
 
         with Terminal() as terminal:
             terminal.run(Counter())

--- a/scripts/generate_component_demos.py
+++ b/scripts/generate_component_demos.py
@@ -26,7 +26,7 @@ generate_concept_demos.OUTPUT_DIR = (
 def _demo_code(imports: str, expression: str, width: int, height: int) -> str:
     return f"""import time
 {imports}
-from xnano.terminal import Terminal
+from xnano.tui import Terminal
 
 Terminal(width={width}, height={height}).render({expression})
 time.sleep(3)

--- a/scripts/generate_concept_demos.py
+++ b/scripts/generate_concept_demos.py
@@ -104,7 +104,7 @@ DEMOS: tuple[Demo, ...] = (
         name="render_text",
         code=_code("""
             import time
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
             from xnano.components.text import Text
 
             Terminal().render(
@@ -125,7 +125,7 @@ DEMOS: tuple[Demo, ...] = (
         name="render_multiple",
         code=_code("""
             import time
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
             from xnano.components.text import Text
 
             Terminal().render(
@@ -147,7 +147,7 @@ DEMOS: tuple[Demo, ...] = (
         name="styled_text",
         code=_code("""
             import time
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
             from xnano.components.text import Text
 
             message = Text([
@@ -172,11 +172,11 @@ DEMOS: tuple[Demo, ...] = (
         name="hello_render",
         code=_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_keyboard
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_keyboard
 
-            class Hello(Grid, direction="vertical", gap=1):
+            class Hello(BaseGrid, direction="vertical", gap=1):
                 line1: str = Field(
                     default="Hello from xnano!",
                     color="violet",
@@ -202,11 +202,11 @@ DEMOS: tuple[Demo, ...] = (
         name="hello_grid",
         code=_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_keyboard
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_keyboard
 
-            class Hello(Grid, direction="vertical"):
+            class Hello(BaseGrid, direction="vertical"):
                 message: str = Field(default="Press q to quit.", height=1)
 
                 @on_keyboard("q")
@@ -223,11 +223,11 @@ DEMOS: tuple[Demo, ...] = (
         name="terminal_render",
         code=_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_keyboard
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_keyboard
 
-            class Output(Grid, direction="vertical", gap=1):
+            class Output(BaseGrid, direction="vertical", gap=1):
                 line1: str = Field(
                     default="Build complete.",
                     color="emerald-400",
@@ -251,15 +251,15 @@ DEMOS: tuple[Demo, ...] = (
         code=_code("""
             from dataclasses import dataclass
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_keyboard
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_keyboard
 
             @dataclass
             class AppState:
                 theme: str = "dark"
 
-            class App(Grid, direction="vertical", gap=1):
+            class App(BaseGrid, direction="vertical", gap=1):
                 header: str = Field(
                     default="",
                     height=1,
@@ -302,11 +302,11 @@ DEMOS: tuple[Demo, ...] = (
         name="grid_basic",
         code=_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_keyboard
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_keyboard
 
-            class App(Grid, direction="vertical"):
+            class App(BaseGrid, direction="vertical"):
                 header: str = Field(
                     default="My App",
                     height=1,
@@ -330,11 +330,11 @@ DEMOS: tuple[Demo, ...] = (
         name="grid_nested",
         code=_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_keyboard
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_keyboard
 
-            class Sidebar(Grid, direction="vertical"):
+            class Sidebar(BaseGrid, direction="vertical"):
                 nav: str = Field(
                     default="  — Home\\n  — About\\n  — Settings",
                     border="rounded",
@@ -342,7 +342,7 @@ DEMOS: tuple[Demo, ...] = (
                 )
                 status: str = Field(default="  Ready", height=1, color="slate-500")
 
-            class App(Grid, direction="horizontal", gap=1):
+            class App(BaseGrid, direction="horizontal", gap=1):
                 sidebar: Sidebar = Field(default_factory=Sidebar, width="25%")
                 main: str = Field(
                     default="Main content area.",
@@ -366,11 +366,11 @@ DEMOS: tuple[Demo, ...] = (
         name="grid_render_method",
         code=_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_keyboard
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_keyboard
 
-            class App(Grid, direction="vertical", gap=1):
+            class App(BaseGrid, direction="vertical", gap=1):
                 header: str = Field(
                     default="",
                     height=1,
@@ -405,11 +405,11 @@ DEMOS: tuple[Demo, ...] = (
         name="sizing_mix",
         code=_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_keyboard
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_keyboard
 
-            class App(Grid, direction="vertical", gap=1):
+            class App(BaseGrid, direction="vertical", gap=1):
                 header: str = Field(
                     default="  fixed: height=1",
                     height=1,
@@ -449,11 +449,11 @@ DEMOS: tuple[Demo, ...] = (
         name="hooks_keyboard",
         code=_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_keyboard
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_keyboard
 
-            class Counter(Grid, direction="vertical", gap=1):
+            class Counter(BaseGrid, direction="vertical", gap=1):
                 label: str = Field(
                     default="Count: 0",
                     height=1,
@@ -500,11 +500,11 @@ DEMOS: tuple[Demo, ...] = (
         code=_code("""
             import time
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_keyboard, on_tick
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_keyboard, on_tick
 
-            class Clock(Grid, direction="vertical", gap=1):
+            class Clock(BaseGrid, direction="vertical", gap=1):
                 display: str = Field(
                     default="",
                     height=3,
@@ -533,11 +533,11 @@ DEMOS: tuple[Demo, ...] = (
         code=_code("""
             import os
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.terminal import Terminal
-            from xnano.hooks import on_click, on_keyboard
+            from xnano.grid import BaseGrid
+            from xnano.tui import Terminal
+            from xnano.events import on_click, on_keyboard
 
-            class App(Grid, direction="vertical", gap=1):
+            class App(BaseGrid, direction="vertical", gap=1):
                 button: str = Field(
                     default="  [ Click me ]  ",
                     height=3,

--- a/scripts/generate_readme_demos.py
+++ b/scripts/generate_readme_demos.py
@@ -72,14 +72,14 @@ DEMOS: tuple[Demo, ...] = (
     Demo(
         name="hello_world",
         code=dedent("""\
-            from xnano.grid import Grid
+            from xnano.grid import BaseGrid
             from xnano.fields import Field
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
             from xnano.context import Context
             from xnano.color import tailwind_color
-            from xnano.hooks import on_tick, on_keyboard
+            from xnano.events import on_tick, on_keyboard
 
-            class App(Grid):
+            class App(BaseGrid):
                 message: str = Field(default="Hello, world!", color=tailwind_color("sky", 500))
                 current_color: str = Field(default="sky", state=True)
 
@@ -113,20 +113,20 @@ DEMOS: tuple[Demo, ...] = (
         name="layout_nesting",
         launch_delay="1.5s",
         code=dedent("""\
-            from xnano.grid import Grid
+            from xnano.grid import BaseGrid
             from xnano.fields import Field
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
             from xnano.context import Context
-            from xnano.hooks import on_keyboard
+            from xnano.events import on_keyboard
 
-            class SidebarTitle(Grid, align="center"):
+            class SidebarTitle(BaseGrid, align="center"):
                 title: str = Field("This is a title.", align="center")
 
-            class Sidebar(Grid, direction="vertical"):
+            class Sidebar(BaseGrid, direction="vertical"):
                 title: SidebarTitle = Field(default_factory=SidebarTitle, height="10%")
                 nav: str = Field(default="- Home", height="1fr")
 
-            class App(Grid, direction="horizontal", gap=1):
+            class App(BaseGrid, direction="horizontal", gap=1):
                 sidebar: Sidebar = Field(default_factory=Sidebar, width="25%")
                 content: str = Field(default="Main area", width="1fr", border="rounded")
 
@@ -143,13 +143,13 @@ DEMOS: tuple[Demo, ...] = (
         name="keyboard_events",
         launch_delay="1.5s",
         code=dedent("""\
-            from xnano.grid import Grid
+            from xnano.grid import BaseGrid
             from xnano.fields import Field
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
             from xnano.context import Context
-            from xnano.hooks import on_keyboard
+            from xnano.events import on_keyboard
 
-            class Counter(Grid, direction="vertical", gap=1):
+            class Counter(BaseGrid, direction="vertical", gap=1):
                 label: str = Field(default="Count: 0", height=1)
                 hint: str = Field(default="Press up/down · q to quit", height=1)
                 count: int = Field(default=0, state=True)
@@ -187,14 +187,14 @@ DEMOS: tuple[Demo, ...] = (
         code=dedent("""\
             import os
 
-            from xnano.grid import Grid
+            from xnano.grid import BaseGrid
             from xnano.fields import Field
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
             from xnano.context import Context
-            from xnano.hooks import on_click, on_keyboard
+            from xnano.events import on_click, on_keyboard
 
 
-            class App(Grid, direction="vertical", gap=1):
+            class App(BaseGrid, direction="vertical", gap=1):
                 button: str = Field(default="[ Click me ]", height=3, border="rounded")
                 status: str = Field(default="Waiting...", height="1fr")
 
@@ -230,13 +230,13 @@ DEMOS: tuple[Demo, ...] = (
         launch_delay="1.5s",
         code=dedent("""\
             import time
-            from xnano.grid import Grid
+            from xnano.grid import BaseGrid
             from xnano.fields import Field
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
             from xnano.context import Context
-            from xnano.hooks import on_tick, on_keyboard
+            from xnano.events import on_tick, on_keyboard
 
-            class Clock(Grid, direction="vertical"):
+            class Clock(BaseGrid, direction="vertical"):
                 time_display: str = Field(default="", height=3, border="rounded")
 
                 def __post_init__(self) -> None:
@@ -260,17 +260,17 @@ DEMOS: tuple[Demo, ...] = (
         launch_delay="1.5s",
         code=dedent("""\
             from dataclasses import dataclass
-            from xnano.grid import Grid
+            from xnano.grid import BaseGrid
             from xnano.fields import Field
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
             from xnano.context import Context
-            from xnano.hooks import on_keyboard
+            from xnano.events import on_keyboard
 
             @dataclass
             class AppState:
                 username: str = "guest"
 
-            class App(Grid, direction="vertical", gap=1):
+            class App(BaseGrid, direction="vertical", gap=1):
                 header: str = Field(default="", height=1)
                 body: str = Field(default="Press q to quit", height="1fr")
 
@@ -292,14 +292,14 @@ DEMOS: tuple[Demo, ...] = (
         launch_delay="1.5s",
         code=dedent("""\
             import dataclasses
-            from xnano.grid import Grid
+            from xnano.grid import BaseGrid
             from xnano.fields import Field
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
             from xnano.context import Context
             from xnano.color import tailwind_color, pydantic_color
-            from xnano.hooks import on_keyboard
+            from xnano.events import on_keyboard
             from xnano.components.abstract import AbstractComponent, ComponentRenderContext
-            from xnano.core.nodes.terminal import ParagraphNode, AbstractTerminalNode
+            from xnano.tui.nodes import ParagraphNode, AbstractTerminalNode
 
 
             @dataclasses.dataclass
@@ -311,7 +311,7 @@ DEMOS: tuple[Demo, ...] = (
                     return ParagraphNode(text=self.label, color=self.color)
 
 
-            class StatusBoard(Grid, direction="vertical", gap=1):
+            class StatusBoard(BaseGrid, direction="vertical", gap=1):
                 ok: Badge = Field(default_factory=lambda: Badge(label="● OK", color=tailwind_color("emerald", 500)), height=1)
                 warn: Badge = Field(default_factory=lambda: Badge(label="● Warning", color="yellow"), height=1)
                 err: Badge = Field(default_factory=lambda: Badge(label="● Error", color=pydantic_color("palevioletred")), height=1)

--- a/scripts/generate_terminal_demos.py
+++ b/scripts/generate_terminal_demos.py
@@ -57,7 +57,7 @@ DEMOS = (
         get_code("""
             import time
             from xnano.components.text import Text
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
 
             Terminal().render(
                 Text("Build complete", color="emerald-400"),
@@ -73,11 +73,11 @@ DEMOS = (
         "run-interface",
         get_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.hooks import on_keyboard
-            from xnano.terminal import Terminal
+            from xnano.grid import BaseGrid
+            from xnano.events import on_keyboard
+            from xnano.tui import Terminal
 
-            class App(Grid):
+            class App(BaseGrid):
                 message: str = Field(default="Press q to leave")
 
                 @on_keyboard("q")
@@ -94,7 +94,7 @@ DEMOS = (
         "sized-inline",
         get_code("""
             import time
-            from xnano.terminal import Terminal
+            from xnano.tui import Terminal
 
             Terminal(width=36, height=3).render(
                 "A compact result",
@@ -110,11 +110,11 @@ DEMOS = (
         "context-session",
         get_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.hooks import on_keyboard
-            from xnano.terminal import Terminal
+            from xnano.grid import BaseGrid
+            from xnano.events import on_keyboard
+            from xnano.tui import Terminal
 
-            class App(Grid):
+            class App(BaseGrid):
                 message: str = Field(default="Tasks · press q to leave")
 
                 @on_keyboard("q")
@@ -132,11 +132,11 @@ DEMOS = (
         "device-options",
         get_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.hooks import on_keyboard
-            from xnano.terminal import Terminal
+            from xnano.grid import BaseGrid
+            from xnano.events import on_keyboard
+            from xnano.tui import Terminal
 
-            class App(Grid):
+            class App(BaseGrid):
                 message: str = Field(default="Device modes are active · press q")
 
                 @on_keyboard("q")
@@ -160,11 +160,11 @@ DEMOS = (
         "device-live-title",
         get_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.hooks import on_keyboard
-            from xnano.terminal import Terminal
+            from xnano.grid import BaseGrid
+            from xnano.events import on_keyboard
+            from xnano.tui import Terminal
 
-            class App(Grid):
+            class App(BaseGrid):
                 message: str = Field(default="Press t to update the window title")
 
                 @on_keyboard("t")
@@ -187,11 +187,11 @@ DEMOS = (
         "device-clear-line",
         get_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.hooks import on_keyboard
-            from xnano.terminal import Terminal
+            from xnano.grid import BaseGrid
+            from xnano.events import on_keyboard
+            from xnano.tui import Terminal
 
-            class App(Grid):
+            class App(BaseGrid):
                 message: str = Field(default="Press c to clear the current line")
 
                 @on_keyboard("c")
@@ -214,11 +214,11 @@ DEMOS = (
         "cursor-style",
         get_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.hooks import on_keyboard
-            from xnano.terminal import Terminal
+            from xnano.grid import BaseGrid
+            from xnano.events import on_keyboard
+            from xnano.tui import Terminal
 
-            class App(Grid):
+            class App(BaseGrid):
                 message: str = Field(default="Press i for a steady bar cursor")
 
                 @on_keyboard("i")
@@ -241,11 +241,11 @@ DEMOS = (
         "cursor-position",
         get_code("""
             from xnano.fields import Field
-            from xnano.grid import Grid
-            from xnano.hooks import on_keyboard
-            from xnano.terminal import Terminal
+            from xnano.grid import BaseGrid
+            from xnano.events import on_keyboard
+            from xnano.tui import Terminal
 
-            class App(Grid):
+            class App(BaseGrid):
                 message: str = Field(default="Press p to preview a cursor move")
 
                 @on_keyboard("p")

--- a/scripts/generate_xnano_demos.py
+++ b/scripts/generate_xnano_demos.py
@@ -197,15 +197,15 @@ def optimize(gif: pathlib.Path) -> None:
 def run_example(name: str) -> None:
     """Launch one feature-tour stage for VHS to record."""
     if name == "title":
-        from xnano.core.demo.title import TitleSplash
-        from xnano.terminal import Terminal
+        from xnano._demo import TitleSplash
+        from xnano.tui import Terminal
 
         Terminal(title="xnano · title", tick_interval=16).run(TitleSplash())
         return
 
     if name == "panels":
-        from xnano.core.demo.panels import XnanoDemo
-        from xnano.terminal import Terminal
+        from xnano._demo import XnanoDemo
+        from xnano.tui import Terminal
 
         Terminal(title="xnano · feature tour", tick_interval=16).run(
             XnanoDemo()

--- a/scripts/run_xnano_spec.py
+++ b/scripts/run_xnano_spec.py
@@ -120,9 +120,9 @@ def save_block(block: SpecBlock, new_body: list[str]) -> None:
 # ---------------------------------------------------------------------------
 
 from xnano.fields import Field
-from xnano.grid import Grid
-from xnano.terminal import Terminal
-from xnano.hooks import on_keyboard
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
+from xnano.events import on_keyboard
 from xnano.components.text import Text
 from xnano.color import tailwind_color
 
@@ -203,7 +203,7 @@ def _render_detail(
     return Text(parts)
 
 
-class SpecApp(Grid, direction="horizontal", gap=1, background="black"):
+class SpecApp(BaseGrid, direction="horizontal", gap=1, background="black"):
     left: Text = Field(
         default=Text(""),
         width="30%",
@@ -281,7 +281,7 @@ class SpecApp(Grid, direction="horizontal", gap=1, background="black"):
 
         if not self.edit_mode:
             if char == "q":
-                from xnano.exceptions import Exit
+                from xnano.core.exceptions import Exit
 
                 raise Exit
             elif char == "j" and self.blocks:


### PR DESCRIPTION
## Summary

- Update examples (`dashboard`, `kanban`, `feed`, dual-mode web counter, …) for `BaseGrid`, `xnano.events` hooks, and `xnano.tui` / `xnano.webui` imports.
- Update demo/VHS generators and `run_xnano_spec` for the same layout.

## Depends on

#33 (`refactor/module-layout-finalization`)

## Test plan

- [ ] Import/run a couple of examples after #33 is available locally
- [ ] Dry-run a demo generator if desired: `uv run python scripts/generate_xnano_demos.py --dry-run`