### PR TITLE
refactor: polish package docs, Actions tests, and type fixes

### DIFF
--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,12 +1,44 @@
-"""Tests for xnano.actions — matching, synthesis, and host.perform."""
+"""Tests for xnano.core.actions — matching, synthesis, and host.perform.
+
+Covers every Action family (matches / to_event), Terminal.offscreen perform
+paths, field-scoped click + slide via real dispatch helpers, and the
+Context.actions facade. WebUI Action vocabulary lives in
+``tests/webui/test_web_actions.py``.
+"""
 
 from __future__ import annotations
 
+from typing import cast
+
+from xnano._dispatch import dispatch_field_mouse
+from xnano._types import Area
+from xnano.context import Context
 from xnano.core.actions import Action
-from xnano.events import Event, KeyboardEventData, on, on_keyboard
+from xnano.core.exceptions import HookError
+from xnano.events import (
+    ClipboardEventData,
+    Event,
+    FocusEventData,
+    KeyboardEventData,
+    MouseEventData,
+    ResizeEventData,
+    on,
+    on_clipboard,
+    on_click,
+    on_focus,
+    on_keyboard,
+    on_mouse,
+    on_resize,
+    on_tick,
+)
 from xnano.fields import Field
-from xnano.grid import BaseGrid
+from xnano.grid import BaseGrid, _GridFieldHit, _GridSlideCapture
 from xnano.tui import Terminal
+
+
+# ---------------------------------------------------------------------------
+# 1. Action matching + to_event for each family
+# ---------------------------------------------------------------------------
 
 
 def test_keyboard_action_matches_synthetic_event() -> None:
@@ -22,11 +54,194 @@ def test_keyboard_action_empty_bindings_match_any() -> None:
     assert action.matches(event)
 
 
-def test_action_to_event_is_real_event() -> None:
+def test_keyboard_action_kind_filter() -> None:
+    press = Event.from_data(KeyboardEventData.from_binding("a", kind="press"))
+    release = Event.from_data(
+        KeyboardEventData.from_binding("a", kind="release")
+    )
+    only_press = Action.keyboard("a", kind="press")
+    assert only_press.matches(press)
+    assert not only_press.matches(release)
+
+
+def test_keyboard_action_to_event_is_real_event() -> None:
     event = Action.keyboard("enter").to_event()
     assert event.is_keyboard_event()
     assert event.keyboard_event is not None
     assert event.keyboard_event.matches("enter")
+    assert Action.keyboard("enter").matches(event)
+
+
+def test_mouse_action_button_and_kind_filters() -> None:
+    left_press = Event.from_data(
+        MouseEventData(kind="press", x=1, y=2, button="left")
+    )
+    right_press = Event.from_data(
+        MouseEventData(kind="press", x=1, y=2, button="right")
+    )
+    left_drag = Event.from_data(
+        MouseEventData(kind="drag", x=3, y=4, button="left")
+    )
+
+    any_button = Action.mouse()
+    left_only = Action.mouse("left")
+    left_drag_only = Action.mouse("left", kind="drag")
+
+    assert any_button.matches(left_press)
+    assert any_button.matches(right_press)
+    assert left_only.matches(left_press)
+    assert not left_only.matches(right_press)
+    assert left_drag_only.matches(left_drag)
+    assert not left_drag_only.matches(left_press)
+    assert not Action.mouse("left").matches(
+        Event.from_data(KeyboardEventData.from_binding("x"))
+    )
+
+
+def test_mouse_action_to_event_round_trips_matches() -> None:
+    action = Action.mouse("right", kind="release")
+    event = action.to_event()
+    assert event.is_mouse_event()
+    assert event.mouse_event is not None
+    assert event.mouse_event.button == "right"
+    assert event.mouse_event.kind == "release"
+    assert action.matches(event)
+
+
+def test_click_action_matches_press_only() -> None:
+    click = Action.click("body", button="left")
+    press = Event.from_data(
+        MouseEventData(kind="press", x=0, y=0, button="left")
+    )
+    drag = Event.from_data(
+        MouseEventData(kind="drag", x=0, y=0, button="left")
+    )
+    right = Event.from_data(
+        MouseEventData(kind="press", x=0, y=0, button="right")
+    )
+    assert click.matches(press)
+    # Field is host-side metadata — matches ignores it.
+    assert Action.click("other").matches(press)
+    assert not click.matches(drag)
+    assert not click.matches(right)
+
+
+def test_click_action_to_event_is_left_press() -> None:
+    event = Action.click("save").to_event()
+    assert event.is_mouse_event()
+    assert event.mouse_button == "left"
+    assert event.mouse_event_kind == "press"
+    assert Action.click("save").matches(event)
+
+
+def test_focus_action_matches_and_kind_compatibility() -> None:
+    window_gained = Event.from_data(FocusEventData(kind="gained"))
+    field_gained = Event.from_data(
+        FocusEventData(kind="field_gained", field="prompt")
+    )
+    field_lost = Event.from_data(
+        FocusEventData(kind="field_lost", field="prompt")
+    )
+
+    any_focus = Action.focus()
+    gained = Action.focus(kind="gained")
+    prompt_gained = Action.focus(field="prompt", kind="gained")
+    prompt_lost = Action.focus(field="prompt", kind="lost")
+
+    assert any_focus.matches(window_gained)
+    assert any_focus.matches(field_gained)
+    assert gained.matches(window_gained)
+    assert gained.matches(field_gained)  # gained accepts field_gained
+    assert prompt_gained.matches(field_gained)
+    assert not prompt_gained.matches(window_gained)  # field filter
+    assert not prompt_gained.matches(field_lost)
+    assert prompt_lost.matches(field_lost)
+
+
+def test_focus_action_to_event_defaults() -> None:
+    window = Action.focus().to_event()
+    assert window.is_focus_event()
+    assert window.focus_event is not None
+    assert window.focus_event.kind == "gained"
+    assert Action.focus(kind="gained").matches(window)
+
+    field = Action.focus(field="name", kind="lost").to_event()
+    assert field.focus_event is not None
+    assert field.focus_event.kind == "field_lost"
+    assert field.focus_event.field == "name"
+    assert Action.focus(field="name", kind="lost").matches(field)
+
+
+def test_clipboard_action_matches_and_to_event() -> None:
+    any_paste = Action.clipboard()
+    exact = Action.clipboard("hello")
+    hello = Event.from_data(ClipboardEventData(text="hello"))
+    other = Event.from_data(ClipboardEventData(text="other"))
+
+    assert any_paste.matches(hello)
+    assert any_paste.matches(other)
+    assert exact.matches(hello)
+    assert not exact.matches(other)
+
+    synthesized = exact.to_event()
+    assert synthesized.is_clipboard_event()
+    assert synthesized.clipboard_text == "hello"
+    assert exact.matches(synthesized)
+
+
+def test_tick_action_matches_shell_not_plain_events() -> None:
+    tick = Action.tick(50)
+    shell = tick.to_event()
+    assert shell.is_tick_event()
+    assert getattr(shell, "type", None) == "tick"
+    assert tick.matches(shell)
+    assert Action.tick(0).matches(shell)  # 0 = any interval
+    assert not Action.tick(100).matches(shell)
+
+    # Ordinary keyboard events never match tick actions.
+    key = Event.from_data(KeyboardEventData.from_binding("x"))
+    assert not tick.matches(key)
+
+
+def test_resize_action_matches_and_to_event() -> None:
+    any_size = Action.resize()
+    exact = Action.resize(120, 40)
+    wide = Event.from_data(ResizeEventData(width=120, height=40))
+    tall = Event.from_data(ResizeEventData(width=80, height=50))
+
+    assert any_size.matches(wide)
+    assert any_size.matches(tall)
+    assert exact.matches(wide)
+    assert not exact.matches(tall)
+    assert Action.resize(width=120).matches(wide)
+    assert not Action.resize(width=120).matches(tall)
+
+    synthesized = Action.resize(100, 30).to_event()
+    assert synthesized.is_resize_event()
+    assert synthesized.resize_size == (100, 30)
+    assert Action.resize(100, 30).matches(synthesized)
+
+    defaults = Action.resize().to_event()
+    assert defaults.resize_size == (80, 24)
+
+
+def test_request_action_object_form_and_to_event() -> None:
+    post = Action.request("POST", "/save")
+    shell = post.to_event()
+    assert getattr(shell, "type", None) == "request" or (
+        hasattr(shell, "is_request_event") and shell.is_request_event()
+    )
+    assert post.matches(shell)
+    assert not Action.request("GET", "/save").matches(shell)
+    assert not Action.request("POST", "/other").matches(shell)
+    # Terminal keyboard events never match request actions.
+    key = Event.from_data(KeyboardEventData.from_binding("x"))
+    assert not post.matches(key)
+
+
+# ---------------------------------------------------------------------------
+# 2. Terminal host perform + shared Action hooks
+# ---------------------------------------------------------------------------
 
 
 def test_perform_runs_keyboard_hook() -> None:
@@ -44,7 +259,7 @@ def test_perform_runs_keyboard_hook() -> None:
     assert app.n == 1
 
 
-def test_on_decorator_with_shared_action() -> None:
+def test_on_decorator_with_shared_keyboard_action() -> None:
     SAVE = Action.keyboard("ctrl+s")
 
     class App(BaseGrid):
@@ -59,11 +274,125 @@ def test_on_decorator_with_shared_action() -> None:
     terminal.attach_grid(app)
     terminal.perform(SAVE)
     assert app.saved is True
+    # Mismatched binding does not fire.
+    terminal.perform(Action.keyboard("ctrl+a"))
+    assert app.saved is True
+
+
+def test_perform_unscoped_mouse_hook() -> None:
+    class App(BaseGrid):
+        presses: int = Field(default=0, state=True)
+
+        @on_mouse("left", kind="press")
+        def on_press(self, ctx) -> None:
+            self.presses += 1
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    terminal.perform(Action.mouse("left", kind="press"))
+    assert app.presses == 1
+    # Kind filter: drag does not fire press hook.
+    terminal.perform(Action.mouse("left", kind="drag"))
+    assert app.presses == 1
+
+
+def test_on_decorator_with_shared_mouse_action() -> None:
+    RIGHT = Action.mouse("right", kind="press")
+
+    class App(BaseGrid):
+        n: int = Field(default=0, state=True)
+
+        @on(RIGHT)
+        def right_click(self, ctx) -> None:
+            self.n += 1
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    terminal.perform(RIGHT)
+    assert app.n == 1
+    terminal.perform(Action.mouse("left", kind="press"))
+    assert app.n == 1
+
+
+def test_perform_clipboard_hook() -> None:
+    class App(BaseGrid):
+        pasted: str = Field(default="", state=True)
+
+        @on_clipboard
+        def on_paste(self, ctx) -> None:
+            self.pasted = ctx.event.clipboard_text or ""
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    terminal.perform(Action.clipboard("hello world"))
+    assert app.pasted == "hello world"
+
+
+def test_perform_window_focus_hook() -> None:
+    class App(BaseGrid):
+        log: list[str] = Field(default_factory=list, state=True)
+
+        @on_focus
+        def on_window_focus(self, ctx) -> None:
+            focus = ctx.event.focus_event if ctx.event else None
+            if focus is not None and focus.kind is not None:
+                self.log.append(focus.kind)
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    terminal.perform(Action.focus(kind="gained"))
+    terminal.perform(Action.focus(kind="lost"))
+    assert app.log == ["gained", "lost"]
+
+
+def test_perform_resize_hook() -> None:
+    class App(BaseGrid):
+        size: tuple[int, int] = Field(default=(0, 0), state=True)
+
+        @on_resize
+        def on_resize(self, ctx) -> None:
+            if ctx.event is not None and ctx.event.resize_size is not None:
+                self.size = ctx.event.resize_size
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    terminal.perform(Action.resize(100, 30))
+    assert app.size == (100, 30)
+
+
+def test_perform_tick_does_not_replace_pump_tick() -> None:
+    """Ticks are pumped by the host clock, not Action.perform.
+
+    ``Action.tick().to_event()`` is a shell for matching; perform runs
+    ``dispatch_hooks``, which has no tick branch — ``@on_tick`` only
+    fires via ``pump_tick`` / web ``dispatch_tick``.
+    """
+
+    class App(BaseGrid):
+        ticks: int = Field(default=0, state=True)
+
+        @on_tick
+        def on_tick(self, ctx) -> None:
+            self.ticks += 1
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    terminal.perform(Action.tick())
+    assert app.ticks == 0
+
+    from xnano._dispatch import pump_tick
+
+    pump_tick(terminal)
+    assert app.ticks == 1
 
 
 def test_perform_loop_guard() -> None:
-    from xnano.core.exceptions import HookError
-
     class App(BaseGrid):
         n: int = Field(default=0, state=True)
 
@@ -87,7 +416,7 @@ def test_perform_loop_guard() -> None:
         assert app.n >= 1
 
 
-def test_ctx_actions_facade() -> None:
+def test_ctx_actions_press_convenience() -> None:
     class App(BaseGrid):
         n: int = Field(default=0, state=True)
 
@@ -104,3 +433,251 @@ def test_ctx_actions_facade() -> None:
     terminal.attach_grid(app)
     terminal.perform(Action.keyboard("p"))
     assert app.n == 1
+
+
+def test_ctx_actions_paste_and_resize_conveniences() -> None:
+    class App(BaseGrid):
+        pasted: str = Field(default="", state=True)
+        size: tuple[int, int] = Field(default=(0, 0), state=True)
+
+        @on_clipboard
+        def on_paste(self, ctx) -> None:
+            self.pasted = (
+                ctx.event.clipboard_text if ctx.event is not None else ""
+            ) or ""
+
+        @on_resize
+        def on_resize(self, ctx) -> None:
+            if ctx.event is not None and ctx.event.resize_size is not None:
+                self.size = ctx.event.resize_size
+
+        @on_keyboard("g")
+        def drive(self, ctx) -> None:
+            ctx.actions.paste("clip")
+            ctx.actions.resize(64, 20)
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    terminal.perform(Action.keyboard("g"))
+    assert app.pasted == "clip"
+    assert app.size == (64, 20)
+
+
+# ---------------------------------------------------------------------------
+# 3. Field click + sliding (Action vocabulary + host geometry)
+# ---------------------------------------------------------------------------
+
+
+def _arm_field_hit(
+    terminal: Terminal,
+    grid: BaseGrid,
+    field_name: str,
+    *,
+    area: Area | None = None,
+    slide_axes: list[str] | None = None,
+) -> None:
+    """Register a hit region so dispatch_field_mouse can resolve clicks."""
+    terminal._mouse_geometry_active = True
+    paint = area or Area(x=0, y=0, width=10, height=5)
+    terminal._field_hits.append(
+        _GridFieldHit(
+            grid=grid,
+            field_name=field_name,
+            area=paint,
+            slot_area=paint,
+            parent_area=Area(x=0, y=0, width=40, height=20),
+            slide_axes=slide_axes or [],
+        )
+    )
+
+
+def test_field_click_via_action_to_event_and_dispatch() -> None:
+    """Action.click is the object form; field scope needs host hit-testing.
+
+    ``perform(Action.click("body"))`` alone does not run field handlers
+    (field scope is host metadata). With geometry +
+    ``dispatch_field_mouse``, ``Action.click(...).to_event()`` fires
+    ``@on_click``.
+    """
+
+    CLICK_BODY = Action.click("body")
+
+    class App(BaseGrid):
+        body: str = Field(default="idle")
+        n: int = Field(default=0, state=True)
+
+        @on(CLICK_BODY)
+        def on_body(self, ctx) -> None:
+            self.n += 1
+            self.body = "clicked"
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    _arm_field_hit(terminal, app, "body")
+
+    # perform alone: field handlers are not in on_mouse_hooks.
+    terminal.perform(CLICK_BODY)
+    assert app.n == 0
+
+    event = CLICK_BODY.to_event()
+    assert CLICK_BODY.matches(event)
+    ctx = Context(event=event, terminal=terminal, state=terminal.state)
+    dispatch_field_mouse(terminal, ctx)
+    assert app.n == 1
+    assert app.body == "clicked"
+
+
+def test_field_click_via_on_click_and_action_event() -> None:
+    class App(BaseGrid):
+        body: str = Field(default="hello")
+        n: int = Field(default=0, state=True)
+
+        @on_click("body")
+        def bump(self, ctx) -> None:
+            self.n += 1
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    _arm_field_hit(terminal, app, "body")
+
+    event = Action.click("body").to_event()
+    dispatch_field_mouse(
+        terminal,
+        Context(event=event, terminal=terminal, state=terminal.state),
+    )
+    assert app.n == 1
+
+
+def test_ctx_actions_click_uses_perform_not_field_hits() -> None:
+    """ctx.actions.click → host.perform; field hits are not consulted."""
+
+    class App(BaseGrid):
+        body: str = Field(default="x")
+        n: int = Field(default=0, state=True)
+
+        @on_click("body")
+        def bump(self, ctx) -> None:
+            self.n += 1
+
+        @on_keyboard("c")
+        def via_actions(self, ctx) -> None:
+            ctx.actions.click("body")
+
+    terminal = Terminal.offscreen()
+    app = App()
+    terminal.attach_grid(app)
+    _arm_field_hit(terminal, app, "body")
+    terminal.perform(Action.keyboard("c"))
+    assert app.n == 0  # perform path does not hit-test fields
+
+
+def test_slide_drag_matches_mouse_action_and_updates_position() -> None:
+    """Sliding uses coordinate-bearing mouse events; Action filters kinds.
+
+    ``Action.mouse(kind="drag")`` matches drag events. Coordinates are not
+    part of Action factories (always 0,0 in to_event), so hosts synthesize
+    ``MouseEventData`` / ``Event.from_data`` for real geometry — same
+    matching surface.
+    """
+
+    class SlideApp(BaseGrid):
+        body: str = Field(default="hello", slide=["x"])
+
+        @on_mouse(field="body", kind="drag")
+        def on_drag(self, ctx) -> None:
+            self.body = f"x={self.field_position('body')[0]}"
+
+    grid = SlideApp()
+    terminal = Terminal(mouse_events=True)
+    terminal._mouse_geometry_active = True
+    terminal._slide_capture = _GridSlideCapture(
+        grid=grid,
+        field_name="body",
+        parent_area=Area(x=0, y=0, width=20, height=10),
+        slot_area=Area(x=0, y=0, width=6, height=3),
+        grab_x=0,
+        grab_y=0,
+        slide_axes=["x"],
+    )
+
+    drag_event = Event.from_data(
+        MouseEventData(kind="drag", x=7, y=0, button="left")
+    )
+    assert Action.mouse(kind="drag").matches(drag_event)
+    assert Action.mouse("left", kind="drag").matches(drag_event)
+    assert not Action.mouse(kind="press").matches(drag_event)
+
+    dispatch_field_mouse(
+        terminal,
+        Context(
+            event=cast(Event | None, drag_event),
+            terminal=terminal,
+            state=None,
+        ),
+    )
+    assert grid.field_position("body") == (7, 0)
+    assert grid.body == "x=7"
+
+
+def test_slide_y_axis_drag_with_action_filter() -> None:
+    class SlideY(BaseGrid):
+        panel: str = Field(default="p", slide=["y"])
+
+    grid = SlideY()
+    terminal = Terminal(mouse_events=True)
+    terminal._mouse_geometry_active = True
+    terminal._slide_capture = _GridSlideCapture(
+        grid=grid,
+        field_name="panel",
+        parent_area=Area(x=0, y=0, width=20, height=15),
+        slot_area=Area(x=0, y=0, width=4, height=2),
+        grab_x=0,
+        grab_y=0,
+        slide_axes=["y"],
+    )
+    drag = Event.from_data(
+        MouseEventData(kind="drag", x=0, y=5, button="left")
+    )
+    assert Action.mouse("left", kind="drag").matches(drag)
+    dispatch_field_mouse(
+        terminal,
+        Context(event=drag, terminal=terminal, state=None),
+    )
+    assert grid.field_position("panel") == (0, 5)
+
+
+def test_slide_press_starts_capture_via_action_click_event() -> None:
+    """Left press on a slidable field arms slide capture (real hit path)."""
+
+    class SlideApp(BaseGrid):
+        body: str = Field(default="hello", slide=["x", "y"])
+
+    grid = SlideApp()
+    terminal = Terminal(mouse_events=True)
+    terminal.attach_grid(grid)
+    _arm_field_hit(
+        terminal,
+        grid,
+        "body",
+        area=Area(x=2, y=2, width=6, height=3),
+        slide_axes=["x", "y"],
+    )
+
+    # Click at (3, 4) inside the hit — use Event.from_data for coordinates.
+    press = Event.from_data(
+        MouseEventData(kind="press", x=3, y=4, button="left")
+    )
+    assert Action.click("body").matches(press)
+    dispatch_field_mouse(
+        terminal,
+        Context(event=press, terminal=terminal, state=None),
+    )
+    capture = terminal._slide_capture
+    assert capture is not None
+    assert capture.field_name == "body"
+    assert capture.slide_axes == ["x", "y"]
+    assert capture.grab_x == 1  # 3 - area.x
+    assert capture.grab_y == 2  # 4 - area.y

--- a/tests/webui/test_tailwind.py
+++ b/tests/webui/test_tailwind.py
@@ -925,9 +925,7 @@ def test_terminal_asymmetric_margin_sides() -> None:
     from xnano import BaseGrid
 
     class App(BaseGrid):
-        content: str = Field(
-            default="hello", class_name="mt-4 ml-8 border"
-        )
+        content: str = Field(default="hello", class_name="mt-4 ml-8 border")
 
     lines = render_grid_offscreen(App()).split("\n")
     top_border_row = next(
@@ -1040,9 +1038,7 @@ def test_web_inline_style_when_kwarg_overrides_class() -> None:
     from xnano import BaseGrid
 
     class App(BaseGrid):
-        body: str = Field(
-            default="x", color="red", class_name="text-blue-500"
-        )
+        body: str = Field(default="x", color="red", class_name="text-blue-500")
 
     html = render_grid_html(App())
     assert "text-blue-500" in html

--- a/tests/webui/test_web_actions.py
+++ b/tests/webui/test_web_actions.py
@@ -1,0 +1,185 @@
+"""WebUI host tests driven by the Action vocabulary.
+
+Keyboard/click/request paths already exist under ``test_web_events`` and
+``test_web_request_hooks``. These tests assert that Actions are the
+shared object form: matching, ``to_event``, ``WebSession.perform``, and
+parity with ``dispatch_*`` helpers.
+"""
+
+from __future__ import annotations
+
+from tests.webui.grids import ClickableGrid, InteractiveGrid, RequestHookGrid
+from xnano.core.actions import Action
+from xnano.events import Event, KeyboardEventData, on, on_keyboard
+from xnano.fields import Field
+from xnano.grid import BaseGrid
+from xnano.webui import Web
+from xnano.webui.requests import on_post_request
+
+
+def test_web_session_perform_keyboard_action() -> None:
+    """WebSession inherits host.perform; keyboard Actions fire hooks."""
+    grid = InteractiveGrid()
+    web = Web()
+    web.render_html(grid)
+    session = web._ensure_default_session()
+
+    session.perform(Action.keyboard("up"))
+    assert grid.count == 10
+    session.perform(Action.keyboard("ctrl+k"))
+    assert grid.count == 20
+
+
+def test_web_dispatch_keyboard_matches_action_object() -> None:
+    """dispatch_keyboard and Action.keyboard describe the same binding."""
+    SAVE = Action.keyboard("ctrl+k")
+    event = Event.from_data(KeyboardEventData.from_binding("ctrl+k"))
+    assert SAVE.matches(event)
+
+    grid = InteractiveGrid()
+    web = Web()
+    web.render_html(grid)
+    web.dispatch_keyboard("ctrl+k")
+    assert grid.count == 10
+    # Action.round-trip: same binding via session.perform
+    web._ensure_default_session().perform(SAVE)
+    assert grid.count == 20
+
+
+def test_web_shared_action_on_decorator() -> None:
+    BUMP = Action.keyboard("b")
+
+    class App(BaseGrid):
+        n: int = Field(default=0, state=True)
+        label: str = Field(default="0", height=1)
+
+        @on(BUMP)
+        def bump(self, ctx) -> None:
+            self.n += 1
+            self.label = str(self.n)
+
+    grid = App()
+    web = Web()
+    web.render_html(grid)
+    session = web._ensure_default_session()
+    session.perform(BUMP)
+    assert grid.n == 1
+    web.dispatch_keyboard("b")
+    assert grid.n == 2
+
+
+def test_web_dispatch_click_uses_action_click_event() -> None:
+    """dispatch_click builds Action.click(field).to_event() under the hood."""
+    grid = ClickableGrid()
+    web = Web()
+    web.render_html(grid)
+    target_id = next(iter(web._controller.click_targets.keys()))
+
+    click = Action.click("body")
+    event = click.to_event()
+    assert click.matches(event)
+    assert event.is_mouse_event()
+    assert event.mouse_event_kind == "press"
+
+    assert grid.count == 0
+    html_out = web.dispatch_click(target_id)
+    assert grid.count == 1
+    assert "Count: 1" in html_out
+
+
+def test_web_click_action_field_is_metadata_for_matches() -> None:
+    """Action.click field does not affect matches — host maps target_id."""
+    left = Action.click("body")
+    other = Action.click("label")
+    event = left.to_event()
+    assert left.matches(event)
+    assert other.matches(event)  # field ignored by matches
+
+
+def test_web_request_action_object_form_with_dispatch() -> None:
+    """Action.request documents the route; dispatch_request fires hooks."""
+    POST = Action.request("POST", "/increment")
+    shell = POST.to_event()
+    assert POST.matches(shell)
+    assert not Action.request("GET", "/increment").matches(shell)
+
+    grid = RequestHookGrid()
+    web = Web()
+    web.render_html(grid)
+    web.dispatch_request("POST", "/increment")
+    assert grid.count == 1
+    web.dispatch_request("POST", "/increment")
+    assert grid.count == 2
+
+
+def test_web_session_perform_request_does_not_fire_http_hooks() -> None:
+    """HTTP hooks live on the request registry, not dispatch_hooks.
+
+    perform(Action.request(...)) synthesizes a request shell but the
+    shared pump has no request branch — use dispatch_request / HTTP.
+    """
+    grid = RequestHookGrid()
+    web = Web()
+    web.render_html(grid)
+    session = web._ensure_default_session()
+    session.perform(Action.request("POST", "/increment"))
+    assert grid.count == 0
+    session.dispatch_request("POST", "/increment")
+    assert grid.count == 1
+
+
+def test_web_action_request_with_custom_grid_hook() -> None:
+    """Custom POST path expressed as Action.request + dispatch_request."""
+    SAVE = Action.request("POST", "/save")
+
+    class SaveGrid(BaseGrid):
+        saved: bool = Field(default=False, state=True)
+        label: str = Field(default="no", height=1)
+
+        @on_post_request("/save")
+        def save(self) -> None:
+            self.saved = True
+            self.label = "yes"
+
+    grid = SaveGrid()
+    web = Web()
+    web.render_html(grid)
+    assert SAVE.matches(SAVE.to_event())
+    from typing import cast
+
+    from xnano.webui.requests import HttpMethod
+
+    web.dispatch_request(cast(HttpMethod, SAVE.method), SAVE.path)
+    assert grid.saved is True
+    assert "yes" in web.render_html()
+
+
+def test_web_keyboard_action_unmatched_binding_is_noop() -> None:
+    grid = InteractiveGrid()
+    web = Web()
+    web.render_html(grid)
+    session = web._ensure_default_session()
+    session.perform(Action.keyboard("x"))
+    assert grid.count == 0
+
+
+def test_web_ctx_actions_press_via_keyboard_hook() -> None:
+    class App(BaseGrid):
+        n: int = Field(default=0, state=True)
+        label: str = Field(default="0", height=1)
+
+        @on_keyboard("z")
+        def bump(self, ctx) -> None:
+            self.n += 1
+            self.label = str(self.n)
+
+        @on_keyboard("p")
+        def via_actions(self, ctx) -> None:
+            ctx.actions.press("z")
+
+    grid = App()
+    web = Web()
+    web.render_html(grid)
+    session = web._ensure_default_session()
+    session.perform(Action.keyboard("p"))
+    assert grid.n == 1

--- a/xnano/_core_bindings.py
+++ b/xnano/_core_bindings.py
@@ -1,18 +1,10 @@
 """xnano._core_bindings
 
-Conversions between `xnano`'s own vocabulary (`Area`, `Color`, `Frame`,
-layout constraints, ...) and the `xnano_core` native bindings that
-actually draw to the terminal. This is the one place that vocabulary is
-taught how to become a real ratatui widget — everything upstream of here
-(nodes, the terminal controller, `BaseGrid`) only ever deals in `xnano` types.
+---
 
-Self-contained on purpose: it resolves colors against `xnano.color.Color`
-directly, with no VHS-recording remap layered in. That remap is a
-docs-recording concern (`xnano.utils.vhs_recording`, driven by
-`XNANO_VHS_MONO`/`XNANO_VHS_DOCS_BG` environment flags for consistent
-screenshot/tape output) that used to be wired into every color resolution
-across the whole framework — it belongs to whatever renders the docs, not
-to color resolution itself, so it isn't referenced here.
+Conversions between framework types (``Area``, ``Color``, ``Frame``,
+layout constraints, …) and ``xnano_core`` native bindings used for
+terminal drawing.
 """
 
 from __future__ import annotations

--- a/xnano/_demo.py
+++ b/xnano/_demo.py
@@ -685,7 +685,6 @@ def _build_watercolor_frame(
     )
 
 
-
 class TitleSplash(BaseGrid):
     """A terminal-sized watercolor wash with a centered xnano wordmark."""
 

--- a/xnano/_dispatch.py
+++ b/xnano/_dispatch.py
@@ -1,4 +1,9 @@
-"""xnano._dispatch"""
+"""xnano._dispatch
+
+---
+
+Shared event, state, field, poll, and tick dispatch for hosts.
+"""
 
 from __future__ import annotations
 
@@ -130,7 +135,9 @@ def grid_clamp_slide_position(
     )
 
 
-def resolve_grid_mouse_handler(grid: "BaseGrid", field_name: str) -> Any | None:
+def resolve_grid_mouse_handler(
+    grid: "BaseGrid", field_name: str
+) -> Any | None:
     """Return the field-bound mouse handler for ``field_name`` on ``grid``."""
     from xnano.grid import _resolve_grid_mouse_handler
 
@@ -522,9 +529,7 @@ def _paint_stage_overlay(
     try:
         from xnano._types import Size
 
-        stage.set_size(
-            Size(width=viewport.width, height=viewport.height)
-        )
+        stage.set_size(Size(width=viewport.width, height=viewport.height))
     except Exception:
         pass
     canvas = None
@@ -683,7 +688,6 @@ def _handle_focused_text_input(
     text = focused_input_text(terminal)
     if text is None:
         return False
-    # Prefer the component-owned path when present.
     handle = getattr(text, "handle_keyboard", None)
     if callable(handle):
         return bool(handle(keyboard))

--- a/xnano/_event_processing.py
+++ b/xnano/_event_processing.py
@@ -1,4 +1,9 @@
-"""xnano._event_processing"""
+"""xnano._event_processing
+
+---
+
+Parse and normalize native terminal events into framework events.
+"""
 
 from __future__ import annotations
 

--- a/xnano/_introspection.py
+++ b/xnano/_introspection.py
@@ -1,4 +1,9 @@
-"""xnano._introspection"""
+"""xnano._introspection
+
+---
+
+Hook signature inspection and safe state-expression evaluation.
+"""
 
 from __future__ import annotations
 

--- a/xnano/_renderable.py
+++ b/xnano/_renderable.py
@@ -1,4 +1,9 @@
-"""xnano._renderable"""
+"""xnano._renderable
+
+---
+
+Fallback string and ANSI rendering helpers for simple content.
+"""
 
 from __future__ import annotations
 

--- a/xnano/_styles.py
+++ b/xnano/_styles.py
@@ -2,24 +2,9 @@
 
 ---
 
-Tailwind CSS utility-class support for grids, shared by the terminal
-and web backends. The ``TailwindClass`` Literal alias enumerates every
-supported class; ``resolve_tailwind_classes`` lowers a class string or
-sequence into a ``Style`` expressed in xnano's own vocabulary
-(``Color`` bindings, ``Padding``, ``Sizing``, borders, modifiers).
-
-The terminal backend renders the lowered values through the existing
-field pipeline; classes with no terminal equivalent are silently
-ignored there and carried verbatim to the web backend through
-``Style.passthrough_classes``.
-
-Resolution is organized as one handler per utility group (color,
-spacing, border, typography, sizing, flex), mirroring the controller
-and node plugin patterns — register additional groups with
-``register_tailwind_class_group``.
-
-The generated Tailwind ``Literal`` vocabulary lives in
-``xnano._tailwind_classes`` and is re-exported here for autocomplete.
+Shared styling: ``Style``, Tailwind utility resolution, and related
+helpers for grids and components. Terminal and web backends lower the
+same style model to cells or CSS as needed.
 """
 
 from __future__ import annotations
@@ -166,7 +151,9 @@ class _TailwindStyleBuilder:
         horizontal = _cells_for_units(units, "horizontal")
         if prefix_axis == "":
             sides.update(
-                top=vertical, bottom=vertical, left=horizontal,
+                top=vertical,
+                bottom=vertical,
+                left=horizontal,
                 right=horizontal,
             )
         elif prefix_axis == "x":
@@ -307,17 +294,17 @@ class ColorClassGroup(AbstractTailwindClassGroup):
     def match(self, token: str) -> bool:
         for prefix in ("text-", "bg-", "border-"):
             if token.startswith(prefix):
-                suffix = token[len(prefix):]
+                suffix = token[len(prefix) :]
                 return _color_binding_from_suffix(suffix) is not None
         return False
 
     def apply(self, token: str, style: _TailwindStyleBuilder) -> None:
         if token.startswith("text-"):
-            style.color = token[len("text-"):]
+            style.color = token[len("text-") :]
         elif token.startswith("bg-"):
-            style.background = token[len("bg-"):]
+            style.background = token[len("bg-") :]
         else:
-            style.border_color = token[len("border-"):]
+            style.border_color = token[len("border-") :]
 
 
 class SpacingClassGroup(AbstractTailwindClassGroup):
@@ -649,9 +636,7 @@ def _resolve_tokens(tokens: tuple[str, ...]) -> Style:
         else None
     )
     margin = (
-        types.Padding(**builder.margin_sides)
-        if builder.margin_sides
-        else None
+        types.Padding(**builder.margin_sides) if builder.margin_sides else None
     )
     return Style(
         color=builder.color,

--- a/xnano/_types.py
+++ b/xnano/_types.py
@@ -2,46 +2,10 @@
 
 ---
 
-Private module consolidating xnano's shared type vocabulary: geometry
-(``Area``, ``Size``, ``Coordinate``), sizing (``Sizing``, ``SizingLike``),
-frame chrome (``Frame``, ``Padding``, ``Border``), keyboard/mouse event
-aliases, and field-focus helpers.
-
----
-
-The unified sizing vocabulary shared by every box in ``xnano`` — the terminal
-viewport, grid fields, and standalone renderables.
-
-A ``Sizing`` expresses one axis's *intent* rather than a resolved length:
-
-    - ``cells``     — a fixed number of terminal cells (``Constraint::Length``)
-    - ``percent``   — a percentage of the available axis (``Constraint::Percentage``)
-    - ``ratio``     — a fraction ``numerator/denominator`` of the axis (``Constraint::Ratio``)
-    - ``fraction``  — a relative fill weight (``Constraint::Fill``)
-    - ``fit``       — the measured intrinsic size of the content
-
-Every point on this spectrum resolves through the same two operations —
-measure the content, then place it — so content-driven leaves and
-constraint-driven containers compose with one model.
-
----
-
-Aliases for keyboard-specific (non-event) related types used by
-``xnano.events``.
-
----
-
-Aliases for mouse-specific (non-event) related types used by
-``xnano.events``.
-
----
-
-Field-level focus and editable ``Text`` input helpers.
-
-Terminal focus (OS window gained/lost) stays on ``@on_focus`` without a field
-name.  Field focus is the grid-field equivalent of a caret — tab order walks
-``Text(input=True)`` fields in declaration order, and the focused field
-receives printable keys / backspace / arrows.
+Shared type vocabulary: geometry (``Area``, ``Size``, ``Coordinate``),
+sizing (``Sizing``, ``SizingLike``), frame chrome (``Frame``,
+``Padding``, ``Border``), keyboard/mouse aliases, and field-focus
+helpers for editable ``Text`` input.
 """
 
 from __future__ import annotations
@@ -531,8 +495,8 @@ class Sizing:
 
     ``Sizing`` is the unified currency of layout: the same value can describe a
     grid field's width, a terminal's height, or a renderable's extent. Use the
-    constructor helpers (:meth:`cells`, :meth:`percent`, :meth:`ratio`,
-    :meth:`fraction`, :meth:`fit`) or :meth:`parse` to build one.
+    constructor helpers (``cells``, ``percent``, ``ratio``, ``fraction``,
+    ``fit``) or ``parse`` to build one.
 
     Attributes:
         kind: The kind of sizing intent.
@@ -689,13 +653,13 @@ class Sizing:
         Accepted forms:
             - ``None`` → ``None``
             - ``Sizing`` → itself
-            - ``int`` → :meth:`cells`
-            - ``float`` in ``0..=1`` → :meth:`percent`, otherwise :meth:`cells`
-            - ``"50%"`` → :meth:`percent`
-            - ``"2fr"`` → :meth:`fraction`
-            - ``"fit"`` / ``"auto"`` / ``"content"`` → :meth:`fit`
-            - ``"fill"`` / ``"grow"`` / Tailwind flex class → :meth:`fraction`
-            - a decimal string → :meth:`cells`
+            - ``int`` → ``cells``
+            - ``float`` in ``0..=1`` → ``percent``, otherwise ``cells``
+            - ``"50%"`` → ``percent``
+            - ``"2fr"`` → ``fraction``
+            - ``"fit"`` / ``"auto"`` / ``"content"`` → ``fit``
+            - ``"fill"`` / ``"grow"`` / Tailwind flex class → ``fraction``
+            - a decimal string → ``cells``
 
         Args:
             value: The value to normalize.
@@ -754,9 +718,9 @@ class Sizing:
 
 
 SizingLike: TypeAlias = Union[int, float, str, Sizing]
-"""Any value accepted where a :class:`Sizing` is expected.
+"""Any value accepted where a ``Sizing`` is expected.
 
-See :meth:`Sizing.parse` for the full list of accepted forms.
+See ``Sizing.parse`` for the full list of accepted forms.
 """
 
 

--- a/xnano/_validation.py
+++ b/xnano/_validation.py
@@ -1,4 +1,9 @@
-"""xnano._validation"""
+"""xnano._validation
+
+---
+
+Runtime type and value validation helpers used by fields and CLI.
+"""
 
 from __future__ import annotations
 

--- a/xnano/cli/__init__.py
+++ b/xnano/cli/__init__.py
@@ -1,4 +1,9 @@
-"""xnano.cli"""
+"""xnano.cli
+
+---
+
+Command-line interface helpers (``Command`` and related parsing).
+"""
 
 from __future__ import annotations
 

--- a/xnano/cli/command.py
+++ b/xnano/cli/command.py
@@ -2,8 +2,8 @@
 
 ---
 
-Beta command-line interface for argument parsing and command execution,
-fully rendered using library components and features.
+Command-line interface for argument parsing and command execution,
+built with library components and validation helpers.
 """
 
 from __future__ import annotations

--- a/xnano/color.py
+++ b/xnano/color.py
@@ -1,9 +1,8 @@
 """xnano.color
 
-Functional color types and utilities. This module ports many of it's
-primitives directly from the ``pydantic_extra_types.Color`` module.
+---
 
-You can view the original source code here: [Pydantic Extra Types Color](https://github.com/pydantic/pydantic-extra-types/blob/main/pydantic_extra_types/color.py)
+Color types and utilities (parse, convert, Tailwind named colors).
 """
 
 from __future__ import annotations

--- a/xnano/components/__init__.py
+++ b/xnano/components/__init__.py
@@ -1,1 +1,6 @@
-"""xnano.components"""
+"""xnano.components
+
+---
+
+Built-in UI components (text, table, chart, progress, sparkline, schema).
+"""

--- a/xnano/components/abstract.py
+++ b/xnano/components/abstract.py
@@ -2,20 +2,9 @@
 
 ---
 
-`AbstractComponent` is the base every built-in component (`Text`, `Table`,
-`Chart`, `Progress`, `Sparkline`, ...) inherits from. A component composes
-one or more render nodes from a declarative definition — the same relationship
-`BaseGrid` has to `Field`, just for widget-shaped content instead of layout.
-
-A component supports an interface (terminal, web) by implementing that
-interface's `get_*_node` method: `get_terminal_node` for the terminal,
-`get_web_node` for the web. Both default to returning `None` and are
-entirely opt-in — a controller only ever calls the one method matching its
-own interface, so a terminal-only component (everything built in today)
-never has to define or think about the other one. A component that wants
-to support both interfaces implements both methods side by side, each
-free to compose a completely different node tree since the two interfaces
-have no shared node representation.
+``AbstractComponent`` base for built-in widgets. Components compose
+content or interface-specific nodes (``get_terminal_node`` /
+``get_web_node``); each method is opt-in per host kind.
 """
 
 from __future__ import annotations
@@ -38,13 +27,13 @@ StateT = TypeVar("StateT")
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class ComponentRenderContext(Generic[StateT]):
-    """Render-time scope passed to component hooks.
+    """Render-time scope passed into component paint hooks.
 
     Attributes:
-        area: The `Area` to render.
-        terminal: The `Terminal` to render.
-        state: The `StateT` to render.
-        component: The `AbstractComponent` to render.
+        area: Target area for this paint.
+        terminal: Active host when available.
+        state: Application state for this paint.
+        component: Component being rendered, when known.
     """
 
     area: "Area"
@@ -55,12 +44,11 @@ class ComponentRenderContext(Generic[StateT]):
 
 @dataclasses.dataclass
 class AbstractComponent(abc.ABC):
-    """Abstract base class for a declarative, multi-interface UI component.
+    """Base for declarative widgets used inside grids.
 
-    Every hook here is opt-in — a plain `AbstractComponent` renders as
-    nothing on every interface. Implement `get_terminal_node` and/or
-    `get_web_node` to give a component a representation on one or both
-    interfaces.
+    Override ``compose`` and/or ``get_terminal_node`` / ``get_web_node``
+    to provide a representation; unimplemented paths simply paint nothing
+    for that host kind.
     """
 
     visible: bool = dataclasses.field(default=True, kw_only=True)
@@ -119,8 +107,8 @@ class AbstractComponent(abc.ABC):
         """Compose interface-neutral ``Content`` for this component.
 
         Controllers prefer this over ``get_*_node``. Default returns
-        ``None``; components may implement Content trees while still
-        providing ``get_terminal_node`` as a temporary adapter.
+        ``None``; components may implement Content trees and/or
+        interface-specific ``get_terminal_node`` / ``get_web_node``.
 
         Args:
             ctx: Render context for this paint.

--- a/xnano/components/chart.py
+++ b/xnano/components/chart.py
@@ -1,4 +1,9 @@
-"""xnano.components.chart"""
+"""xnano.components.chart
+
+---
+
+``Chart`` component for multi-series line and scatter plots.
+"""
 
 from __future__ import annotations
 

--- a/xnano/components/progress.py
+++ b/xnano/components/progress.py
@@ -1,4 +1,9 @@
-"""xnano.components.progress"""
+"""xnano.components.progress
+
+---
+
+``Progress`` component for ratio or value/total progress indicators.
+"""
 
 from __future__ import annotations
 
@@ -22,9 +27,8 @@ class Progress(AbstractComponent):
     """Declarative progress indicator.
 
     Describe *how much* is done — as a ``0.0``–``1.0`` ratio, or a ``value``
-    out of a ``total`` — and pick a ``style``. One component covers both the
-    block ``Gauge`` and the thin ``LineGauge`` ratatui widgets, with an
-    auto-derived percentage label.
+    out of a ``total`` — and pick a ``style`` (block bar or thin line), with
+    an auto-derived percentage label.
 
         Progress(value=0.6)                      # 60% block bar
         Progress(value=70, total=100)            # derived ratio, "70%"

--- a/xnano/components/sparkline.py
+++ b/xnano/components/sparkline.py
@@ -1,4 +1,9 @@
-"""xnano.components.sparkline"""
+"""xnano.components.sparkline
+
+---
+
+``Sparkline`` component for compact inline bar charts.
+"""
 
 from __future__ import annotations
 
@@ -15,10 +20,10 @@ if TYPE_CHECKING:
 
 @dataclasses.dataclass
 class Sparkline(AbstractComponent):
-    """Sparkline chart backed by the native ratatui widget.
+    """Compact inline bar chart for a sequence of samples.
 
     Fills the layout slot it is placed in and scales bar heights across the
-    full vertical area.  Supply ``colors`` with one entry per sample to tint
+    full vertical area. Supply ``colors`` with one entry per sample to tint
     individual bars — useful for gradients across a time series.
     """
 

--- a/xnano/components/table.py
+++ b/xnano/components/table.py
@@ -1,4 +1,9 @@
-"""xnano.components.table"""
+"""xnano.components.table
+
+---
+
+``Table`` component for declarative, data-driven tabular layouts.
+"""
 
 from __future__ import annotations
 

--- a/xnano/components/text.py
+++ b/xnano/components/text.py
@@ -1,4 +1,10 @@
-"""xnano.components.text"""
+"""xnano.components.text
+
+---
+
+``Text`` component for styled strings, inline spans, paragraphs, and
+editable input fields.
+"""
 
 from __future__ import annotations
 
@@ -328,7 +334,7 @@ class Text(AbstractComponent):
     def get_terminal_node(
         self, ctx: ComponentRenderContext
     ) -> AbstractTerminalNode:
-        """Lower ``compose()`` to a terminal node (compat adapter)."""
+        """Lower ``compose()`` output to a terminal render node."""
         from xnano.core.content import Native
         from xnano.tui.content_lower import lower_content
         from xnano.tui.nodes import AbstractTerminalNode as TerminalNode

--- a/xnano/context.py
+++ b/xnano/context.py
@@ -1,4 +1,10 @@
-"""xnano.context"""
+"""xnano.context
+
+---
+
+``Context`` passed into ``@on_*`` handlers: event, host, state, and
+shortcuts for cursor, device, actions, and stage.
+"""
 
 from __future__ import annotations
 
@@ -24,11 +30,11 @@ StateT = TypeVar("StateT")
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class Context(Generic[StateT]):
-    """Event hook execution context passed to every ``@on_<event>`` handler.
+    """Runtime context passed into every ``@on_*`` hook handler.
 
-    This class should never be initialized directly, rather it is passed
-    automatically by the live host session to all active & condition-fulfilling
-    hooks.
+    Carries the event, active host, and optional app state, plus shortcuts
+    for cursor, device, actions, and stage. Built by the host — do not
+    construct this yourself.
     """
 
     event: Event | None
@@ -66,17 +72,17 @@ class Context(Generic[StateT]):
 
     @property
     def cursor(self) -> "TerminalCursor | None":
-        """Live cursor controller, forwarded from the active host."""
+        """Cursor / caret controls for the active host (show, hide, style)."""
         return None if self.terminal is None else self.terminal.cursor
 
     @property
     def device(self) -> "TerminalDevice | None":
-        """Live device controller, forwarded from the active host."""
+        """Device controls for the active host (title, clear, size, clipboard)."""
         return None if self.terminal is None else self.terminal.device
 
     @property
     def actions(self) -> "Actions | None":
-        """Actions facade bound to the active host (perform / press / click)."""
+        """Perform synthetic input and requests (``press``, ``click``, …)."""
         if self.terminal is None:
             return None
         getter = getattr(self.terminal, "actions", None)
@@ -86,7 +92,7 @@ class Context(Generic[StateT]):
 
     @property
     def stage(self) -> "Stage | None":
-        """Stage facade for layout map / overlay paint / wireframe."""
+        """Layout map and cell-level paint / wireframe for the active host."""
         if self.terminal is None:
             return None
         if not hasattr(self.terminal, "stage"):

--- a/xnano/core/actions.py
+++ b/xnano/core/actions.py
@@ -167,23 +167,36 @@ def _is_focus_event(event: Any) -> bool:
 def _synthesize_event(data: Any, *, kind: str | None = None) -> Any:
     """Build an event shell for ``to_event``.
 
-    Prefers a future ``Event.synthesize`` / ``Event.from_data`` path when
-    available; otherwise returns a duck-typed shell matching the surface
-    ``dispatch_hooks`` and handlers already read from ``Event``.
+    Prefers ``Event.from_data`` for terminal event families (keyboard,
+    mouse, resize, clipboard, focus). Tick and request shells are not
+    real ``Event`` types — force the duck-typed shell so
+    ``is_tick_event`` / ``is_request_event`` and ``type`` stay honest.
     """
-    try:
-        from xnano.events import Event
-    except Exception:
-        Event = None  # type: ignore[assignment,misc]
+    terminal_kinds = {
+        "keyboard",
+        "mouse",
+        "resize",
+        "clipboard",
+        "focus",
+    }
+    resolved_kind = kind
+    if resolved_kind is None and data is not None:
+        resolved_kind = getattr(data, "type", None)
+    if resolved_kind not in terminal_kinds:
+        return _SyntheticEvent(data, kind=kind)
 
-    if Event is not None:
-        for name in ("synthesize", "from_data"):
-            factory = getattr(Event, name, None)
-            if callable(factory):
-                try:
-                    return factory(data)
-                except Exception:
-                    pass
+    try:
+        from xnano.events import Event as EventClass
+    except Exception:
+        return _SyntheticEvent(data, kind=kind)
+
+    for name in ("synthesize", "from_data"):
+        factory = getattr(EventClass, name, None)
+        if callable(factory):
+            try:
+                return factory(data)
+            except Exception:
+                pass
 
     return _SyntheticEvent(data, kind=kind)
 
@@ -641,9 +654,19 @@ class KeyboardAction(Action):
         binding = str(self.bindings[0]) if self.bindings else ""
         kind = self.kind if self.kind is not None else "press"
         try:
-            from xnano.events import Event, KeyboardEventData
+            from typing import cast
 
-            data = KeyboardEventData.from_binding(binding, kind=kind)  # type: ignore[arg-type]
+            from xnano.events import (
+                Event,
+                KeyboardEventData,
+                KeyboardEventKind,
+            )
+
+            kind_value = cast(
+                KeyboardEventKind,
+                kind if kind in ("press", "release", "repeat") else "press",
+            )
+            data = KeyboardEventData.from_binding(binding, kind=kind_value)
             return Event.from_data(data)
         except Exception:
             data = _SyntheticKeyboardEventData(binding, kind=self.kind)
@@ -695,16 +718,16 @@ class MouseAction(Action):
         Returns:
             An event shell carrying ``MouseEventData``.
         """
-        from xnano.events import MouseEventData
+        from typing import cast
 
-        button: MouseButton = (
-            self.buttons[0] if self.buttons else "left"
-        )
-        kind: MouseEventKindLike = (
+        from xnano.events import MouseEventData, MouseEventKind
+
+        button: MouseButton = self.buttons[0] if self.buttons else "left"
+        raw_kind: MouseEventKindLike = (
             self.kind if self.kind is not None else "press"
         )
         data = MouseEventData(
-            kind=kind,  # type: ignore[arg-type]
+            kind=cast(MouseEventKind, raw_kind),
             x=0,
             y=0,
             button=button,
@@ -760,10 +783,12 @@ class ClickAction(Action):
         Returns:
             An event shell carrying ``MouseEventData``.
         """
-        from xnano.events import MouseEventData
+        from typing import cast
+
+        from xnano.events import MouseEventData, MouseEventKind
 
         data = MouseEventData(
-            kind=self.kind,  # type: ignore[arg-type]
+            kind=cast(MouseEventKind, self.kind),
             x=0,
             y=0,
             button=self.button,
@@ -822,9 +847,11 @@ class FocusAction(Action):
         Returns:
             An event shell carrying ``FocusEventData``.
         """
-        from xnano.events import FocusEventData
+        from typing import cast
 
-        kind = self.kind
+        from xnano.events import FocusEventData, FocusEventKind
+
+        kind: str | None = self.kind
         if kind is None:
             if self.field is not None:
                 kind = "field_gained"
@@ -833,7 +860,10 @@ class FocusAction(Action):
         elif self.field is not None and kind in ("gained", "lost"):
             kind = f"field_{kind}"
 
-        data = FocusEventData(kind=kind, field=self.field)  # type: ignore[arg-type]
+        data = FocusEventData(
+            kind=cast(FocusEventKind | None, kind),
+            field=self.field,
+        )
         return _synthesize_event(data, kind="focus")
 
 
@@ -1168,21 +1198,21 @@ def request_action_from_filter(method: str, path: str) -> RequestAction:
 
 
 # ---------------------------------------------------------------------------
-# Context / host facade
+# Host-bound helpers
 # ---------------------------------------------------------------------------
 
 
 class Actions:
-    """Bound to a host; perform actions and expose conveniences.
+    """Perform actions against a live host from hooks or app code.
 
-    Peer of cursor/device on ``Context``: a thin facade with no state of
-    its own. ``perform`` delegates to ``host.perform(action)`` — hosts
-    synthesize the event and run the shared dispatch pump (queuing
-    re-entrant performs until the current pass completes).
+    Available as ``ctx.actions`` / ``host.actions``. ``perform``
+    delegates to ``host.perform(action)`` — hosts synthesize the event
+    and run the shared dispatch pump (queuing re-entrant performs until
+    the current pass completes).
     """
 
     def __init__(self, host: Any) -> None:
-        """Bind this facade to a live host.
+        """Bind this helper to a live host.
 
         Args:
             host: Terminal, web session, or any object implementing
@@ -1192,7 +1222,7 @@ class Actions:
 
     @property
     def host(self) -> Any:
-        """The bound host this facade performs against."""
+        """The bound host actions are performed against."""
         return self._host
 
     def perform(self, action: Action) -> None:

--- a/xnano/core/content.py
+++ b/xnano/core/content.py
@@ -762,11 +762,7 @@ class CanvasPrint:
 
 
 CanvasShape: TypeAlias = (
-    CanvasLine
-    | CanvasPoints
-    | CanvasRectangle
-    | CanvasCircle
-    | CanvasPrint
+    CanvasLine | CanvasPoints | CanvasRectangle | CanvasCircle | CanvasPrint
 )
 """Union of shape types accepted by ``Canvas``."""
 

--- a/xnano/core/controllers/__init__.py
+++ b/xnano/core/controllers/__init__.py
@@ -1,1 +1,6 @@
-"""xnano.core.controllers"""
+"""xnano.core.controllers
+
+---
+
+Backend controllers that paint grids for terminal and web hosts.
+"""

--- a/xnano/core/controllers/abstract.py
+++ b/xnano/core/controllers/abstract.py
@@ -1,4 +1,10 @@
-"""xnano.core.controllers.abstract"""
+"""xnano.core.controllers.abstract
+
+---
+
+Backend-neutral controller contract: layout constraints, capabilities,
+and paint / measure hooks shared by terminal and web controllers.
+"""
 
 from __future__ import annotations
 
@@ -85,30 +91,28 @@ class AbstractControllerCapabilities(abc.ABC):
 
 
 class AbstractController(abc.ABC):
-    """Abstract base class for the paint/measurement and render lifecycle
-    a UI host must implement.
+    """Paint, measure, and layout contract for a UI host backend.
 
-    Only the ``get_capabilities`` method is a required abstract method, all
-    other methods are opt-in depending on the interface.
+    Only ``get_capabilities`` is required; other methods are opt-in for
+    the features a given interface supports (absolute geometry, frames,
+    effects, and so on).
     """
 
     @classmethod
     @abc.abstractmethod
     def get_capabilities(cls) -> AbstractControllerCapabilities:
-        """Returns the feature capabilities this controller provides."""
+        """Return the feature capabilities this controller provides."""
 
     def commit_requests(self) -> None:
-        """Commits all active 'render requests' prepared by this controller
-        into it's output frame.
-        """
+        """Flush queued paint work for the current frame into the output."""
         return None
 
     def begin_viewport_frame(self) -> None:
-        """Begin the first frame of a render cycle within the viewport area."""
+        """Start a new render frame for the viewport."""
         return None
 
     def get_viewport_area(self) -> Area:
-        """Returns the viewport area for this controller's frame.
+        """Return the viewport area for this controller's frame.
 
         Returns:
             The viewport area for this controller's frame.
@@ -119,10 +123,10 @@ class AbstractController(abc.ABC):
         )
 
     def paint_frame(self, area: Area, frame: Frame, *, z: int = 0) -> Area:
-        """Paints a given frame onto a specified viewport area.
+        """Paint a decorative frame into ``area``.
 
-        Deprecated path — prefer :meth:`paint_chrome` with a ``Style``.
-        Default implementation remains for terminal controllers.
+        Prefer ``paint_chrome`` with a ``Style`` for new code. Controllers
+        may still implement this for direct frame painting.
 
         Args:
             area: The area to paint the frame onto.
@@ -140,9 +144,7 @@ class AbstractController(abc.ABC):
     def paint_chrome(self, area: Area, style: Any, *, z: int = 0) -> Area:
         """Paint interface-neutral chrome for ``style`` into ``area``.
 
-        Default lowers ``Style`` to a ``Frame`` and calls ``paint_frame``
-        so existing terminal/web controllers keep working until they
-        implement a native path.
+        Default lowers ``Style`` to a ``Frame`` and calls ``paint_frame``.
 
         Args:
             area: Target area.

--- a/xnano/core/controllers/tui.py
+++ b/xnano/core/controllers/tui.py
@@ -1,16 +1,11 @@
 """xnano.core.controllers.tui
 
-The terminal controller — the concrete `AbstractController` that actually
-draws to a terminal screen through `xnano_core`. Every `BaseGrid` and every
-terminal render node ultimately calls back into one of these methods to
-get painted; this is the only place in the framework that talks to
-`xnano_core` directly for rendering.
+---
 
-If you've seen the old `xnano.beta` codebase, this is the direct successor
-to `Session` — same job, renamed methods (`paint_frame`, `split_layout`,
-`measure_field_slot`, `paint_field_slot`, ...) so it actually implements
-`AbstractController`'s contract instead of a parallel one `BaseGrid` used to
-call by convention alone.
+Terminal paint controller: the concrete ``AbstractController`` that draws
+to the screen through ``xnano_core``. Grids and terminal render nodes call
+into this controller for measure/split/paint; it is the only framework
+layer that talks to ``xnano_core`` for rendering.
 """
 
 from __future__ import annotations
@@ -75,12 +70,11 @@ class RenderRequest(Generic[StateT]):
 
 
 class TerminalController(AbstractController, Generic[StateT]):
-    """The live-terminal implementation of `AbstractController`.
+    """Live-terminal implementation of ``AbstractController``.
 
-    Owns the `xnano_core` session, batches render requests for a frame,
-    and lowers `xnano`'s own vocabulary (`Area`, `Frame`, layout
-    constraints, terminal render nodes) into native ratatui widgets — the
-    same relationship a future web controller would have to HTML instead.
+    Owns the ``xnano_core`` session, batches render requests for a frame,
+    and lowers framework types (``Area``, ``Frame``, layout constraints,
+    terminal render nodes) into native ratatui widgets.
     """
 
     __slots__ = (
@@ -561,9 +555,7 @@ class TerminalController(AbstractController, Generic[StateT]):
         from xnano.core.content import AbstractContent
 
         if isinstance(value, AbstractContent):
-            self.render_content(
-                area, value, z=parent_z, effect_key=effect_key
-            )
+            self.render_content(area, value, z=parent_z, effect_key=effect_key)
             return
 
         node = ParagraphNode(

--- a/xnano/core/controllers/webui.py
+++ b/xnano/core/controllers/webui.py
@@ -604,23 +604,29 @@ class WebController(AbstractController):
             if content is not None:
                 from xnano.core.content import Native, TextBlock, Run
 
-                if isinstance(content, Native) and content.interface_kind == "webui":
+                if (
+                    isinstance(content, Native)
+                    and content.interface_kind == "webui"
+                ):
                     node = content.payload
                 elif isinstance(content, TextBlock):
                     # Best-effort HTML from TextBlock
                     from xnano.webui.nodes import WebParagraphNode, WebSpanNode
+
                     if content.lines:
                         lines = []
                         for line in content.lines:
                             spans = []
                             for run in line:
                                 if isinstance(run, Run):
-                                    spans.append(WebSpanNode(
-                                        content=run.text,
-                                        color=run.color,
-                                        background=run.background,
-                                        modifiers=run.modifiers,
-                                    ))
+                                    spans.append(
+                                        WebSpanNode(
+                                            content=run.text,
+                                            color=run.color,
+                                            background=run.background,
+                                            modifiers=run.modifiers,
+                                        )
+                                    )
                             lines.append(tuple(spans))
                         node = WebParagraphNode(
                             lines=tuple(lines),

--- a/xnano/core/device.py
+++ b/xnano/core/device.py
@@ -1,4 +1,10 @@
-"""xnano.core.device"""
+"""xnano.core.device
+
+---
+
+Shared device and cursor contracts for hosts (title, clear, size,
+scroll, clipboard, and caret style).
+"""
 
 from __future__ import annotations
 
@@ -54,11 +60,11 @@ Values:
 
 
 class AbstractDevice(abc.ABC):
-    """Intent-level device contract shared by tui and webui.
+    """Device controls shared by terminal and web hosts.
 
-    Interface kinds implement the mechanisms (crossterm escapes, DOM /
-    browser APIs). The DSL only speaks these intents: title, clear,
-    size, scroll, and clipboard.
+    Use via ``host.device`` / ``ctx.device`` for title, clear, size,
+    scroll, and clipboard. Each host implements the underlying
+    mechanism (terminal escapes, browser APIs).
     """
 
     @property
@@ -115,11 +121,10 @@ class AbstractDevice(abc.ABC):
 
 
 class AbstractCursor(abc.ABC):
-    """Intent-level cursor contract shared by tui and webui.
+    """Cursor / caret controls shared by terminal and web hosts.
 
-    Terminal adapters map these intents to crossterm cursor APIs.
-    Web adapters map visibility/style to caret focus and pointer
-    classes; position moves may be no-ops where unsupported.
+    Use via ``host.cursor`` / ``ctx.cursor`` for visibility and style.
+    Position moves may be no-ops on hosts without a free-moving caret.
     """
 
     @property
@@ -147,7 +152,7 @@ class AbstractCursor(abc.ABC):
         """Set the cursor shape/blink style intent.
 
         Args:
-            value: A :data:`CursorStyle` literal.
+            value: A ``CursorStyle`` literal.
         """
 
     def move_to(self, x: int, y: int) -> None:

--- a/xnano/core/exceptions.py
+++ b/xnano/core/exceptions.py
@@ -1,4 +1,10 @@
-"""xnano.core.exceptions"""
+"""xnano.core.exceptions
+
+---
+
+Framework exceptions for session exit, hook failures, field validation,
+inactive terminals, and missing optional extras.
+"""
 
 from __future__ import annotations
 

--- a/xnano/core/hosts.py
+++ b/xnano/core/hosts.py
@@ -1,4 +1,10 @@
-"""xnano.core.hosts"""
+"""xnano.core.hosts
+
+---
+
+Shared host contract for terminal, web, and CLI sessions: navigation,
+``perform``, and device / cursor / actions / stage access.
+"""
 
 from __future__ import annotations
 
@@ -13,8 +19,8 @@ from xnano.core.exceptions import HookError
 _MAX_PERFORM_DEPTH: int = 32
 """Maximum actions drained from a single ``perform`` chain.
 
-Runaway action → hook → action loops raise :class:`HookError` instead
-of overflowing the call stack.
+Runaway action → hook → action loops raise ``HookError`` instead of
+overflowing the call stack.
 """
 
 
@@ -28,18 +34,18 @@ def get_active_host() -> "AbstractHost | None":
     """Return the host bound to the current context, if any.
 
     Returns:
-        The active :class:`AbstractHost`, or ``None`` when no host has
+        The active ``AbstractHost``, or ``None`` when no host has
         entered the context.
     """
     return _ACTIVE_HOST.get()
 
 
 class RouteTable:
-    """Route key → interface factory; single default route today.
+    """Maps route keys to interface factories for host navigation.
 
-    Hosts resolve their active root through this table so tui window
-    swaps and webui page routes share one funnel. Factories are called
-    on :meth:`resolve` so each navigation can materialize a fresh
+    Hosts resolve their active root through this table so terminal
+    window swaps and web page routes share one funnel. Factories are
+    called on ``resolve`` so each navigation can materialize a fresh
     root when desired.
     """
 
@@ -75,7 +81,7 @@ class RouteTable:
 
         Args:
             key: Route key to resolve. When ``None``, uses
-                :attr:`default_key`.
+                ``default_key``.
 
         Returns:
             The factory result for the resolved key.
@@ -86,8 +92,7 @@ class RouteTable:
         resolved_key = self._default_key if key is None else key
         if resolved_key is None:
             raise KeyError(
-                "No route key provided and no default route is "
-                "registered."
+                "No route key provided and no default route is registered."
             )
         factory = self._routes.get(resolved_key)
         if factory is None:
@@ -109,11 +114,11 @@ class RouteTable:
 
 
 class AbstractHost(abc.ABC):
-    """Shared host contract: hooks, state, pump, facades, lifecycle.
+    """Shared host contract for terminal, web, and CLI sessions.
 
-    ``Terminal``, web sessions, and the CLI runner implement this
-    surface so dispatch, ``perform``, navigation, and
-    device/cursor/actions/stage facades stay one shape.
+    ``Terminal``, web sessions, and the CLI runner implement this so
+    dispatch, ``perform``, navigation, and device / cursor / actions /
+    stage access share one shape.
 
     Duck surface expected by shared dispatch helpers (subclasses
     typically initialize these in ``__init__``):
@@ -140,19 +145,19 @@ class AbstractHost(abc.ABC):
     @property
     @abc.abstractmethod
     def device(self) -> AbstractDevice:
-        """Live device facade for this host session."""
+        """Device controls for this host (title, clear, size, clipboard)."""
 
     @property
     @abc.abstractmethod
     def cursor(self) -> AbstractCursor:
-        """Live cursor facade for this host session."""
+        """Cursor / caret controls for this host (visibility and style)."""
 
     @property
     def actions(self) -> Any:
-        """``Actions`` facade bound to this host (lazy import).
+        """Perform synthetic input and requests against this host.
 
         Returns:
-            An ``Actions`` instance from ``xnano.actions``.
+            An ``Actions`` helper bound to this host.
         """
         if self._actions is None:
             from xnano.core.actions import Actions
@@ -162,10 +167,10 @@ class AbstractHost(abc.ABC):
 
     @property
     def stage(self) -> Any:
-        """``Stage`` facade bound to this host (lazy import).
+        """Layout map and cell-level paint / wireframe for this host.
 
         Returns:
-            A :class:`~xnano.stage.Stage` for layout/paint access.
+            A ``Stage`` for layout lookup and overlay painting.
         """
         if self._stage is None:
             from xnano.core.stage import Stage
@@ -175,7 +180,7 @@ class AbstractHost(abc.ABC):
 
     @property
     def routes(self) -> RouteTable:
-        """Route table used by :meth:`navigate`."""
+        """Route table used by ``navigate``."""
         return self._routes
 
     @property
@@ -188,8 +193,7 @@ class AbstractHost(abc.ABC):
 
         Re-entrancy: when already dispatching, ``action`` is queued and
         drained after the current pass completes — never nested. A
-        chain longer than ``_MAX_PERFORM_DEPTH`` raises
-        :class:`~xnano.exceptions.HookError`.
+        chain longer than ``_MAX_PERFORM_DEPTH`` raises ``HookError``.
 
         Args:
             action: An object exposing ``to_event()`` (typically an
@@ -232,21 +236,26 @@ class AbstractHost(abc.ABC):
         if callable(to_event):
             event = to_event()
 
+        from typing import Any as TypingAny, cast
+
         from xnano import _dispatch
         from xnano.context import Context
 
+        # Hosts (Terminal, WebSession) duck-type the Terminal surface
+        # that dispatch_hooks expects.
+        host = cast(TypingAny, self)
         ctx = Context(
             event=event,
-            terminal=self,  # type: ignore[arg-type]
+            terminal=host,
             state=self.state,
         )
-        _dispatch.dispatch_hooks(self, ctx)  # type: ignore[arg-type]
+        _dispatch.dispatch_hooks(host, ctx)
 
     def navigate(self, key: str) -> None:
-        """Swap the active root via :class:`RouteTable`.
+        """Swap the active root using the route table.
 
-        Resolves ``key``, stores the result as :attr:`active_root`, and
-        notifies subclasses through :meth:`on_navigate`.
+        Resolves ``key``, stores the result as ``active_root``, and
+        notifies subclasses through ``on_navigate``.
 
         Args:
             key: Registered route key.
@@ -259,7 +268,7 @@ class AbstractHost(abc.ABC):
         self.on_navigate(key, root)
 
     def on_navigate(self, key: str, root: Any) -> None:
-        """Hook invoked after a successful :meth:`navigate`.
+        """Hook invoked after a successful ``navigate``.
 
         Subclasses override to reattach hooks, update the controller
         root, or map the key to a URL path. Default is a no-op.

--- a/xnano/core/interface.py
+++ b/xnano/core/interface.py
@@ -2,9 +2,8 @@
 
 ---
 
-``AbstractInterface`` is the DSL base every visual surface (grid, and
-eventually components) shares: named fields, live ``FieldState``, and
-hook scanning. Layout-specific behavior stays on ``BaseGrid``.
+``AbstractInterface`` base for surfaces with named fields and live
+``FieldState``. Layout-specific behavior stays on ``BaseGrid``.
 """
 
 from __future__ import annotations
@@ -21,9 +20,7 @@ class AbstractInterface:
     """Shared base for surfaces with named fields and live field state.
 
     ``BaseGrid`` subclasses this so field change notification and
-    per-instance ``FieldState`` live beneath layout. Components may
-    inherit later once their dataclass construction is compatible with
-    the field metaclass.
+    per-instance ``FieldState`` live beneath layout.
     """
 
     _field_states: dict[str, FieldState]

--- a/xnano/core/stage.py
+++ b/xnano/core/stage.py
@@ -1,4 +1,10 @@
-"""xnano.core.stage"""
+"""xnano.core.stage
+
+---
+
+Layout map and cell-level paint / wireframe helpers for the active host
+(``host.stage`` / ``ctx.stage``).
+"""
 
 from __future__ import annotations
 
@@ -10,127 +16,121 @@ from xnano._types import Area, Size
 if TYPE_CHECKING:
     from xnano.core.hosts import AbstractHost
 
-try:
-    from xnano.core.content import CellCanvas, CellSpan
-except ImportError:  # content.py may land in a later wave
-    @dataclasses.dataclass(slots=True)
-    class CellSpan:
-        """One run-length styled span on a cell row.
 
-        Attributes:
-            text: Contiguous cell characters sharing one style.
-            style: Optional style payload (``Style``, color, …).
+@dataclasses.dataclass(slots=True)
+class _PaintSpan:
+    """One run-length span on a mutable paint row."""
+
+    text: str
+    """Contiguous cell characters sharing one style."""
+    style: Any = None
+    """Optional style payload for this span."""
+
+
+@dataclasses.dataclass
+class _PaintCanvas:
+    """Mutable per-cell lattice used for Stage paint and wireframe.
+
+    Distinct from content ``CellCanvas`` (immutable run-length rows).
+    Controllers lower this overlay via ``get_cell`` / ``as_span_rows``.
+    """
+
+    width: int
+    """Lattice width in cells."""
+    height: int
+    """Lattice height in cells."""
+    _cells: list[list[tuple[str, Any]]] = dataclasses.field(
+        init=False,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        width = max(0, int(self.width))
+        height = max(0, int(self.height))
+        self.width = width
+        self.height = height
+        self._cells = [
+            [(" ", None) for _ in range(width)] for _ in range(height)
+        ]
+
+    def set_cell(
+        self,
+        x: int,
+        y: int,
+        char: str,
+        style: Any = None,
+    ) -> None:
+        """Write one cell, clipping out-of-bounds coordinates.
+
+        Args:
+            x: Column index.
+            y: Row index.
+            char: Character to store (first codepoint used).
+            style: Optional style payload.
         """
+        if x < 0 or y < 0 or x >= self.width or y >= self.height:
+            return
+        glyph = char[0] if char else " "
+        self._cells[y][x] = (glyph, style)
 
-        text: str
-        """Contiguous cell characters sharing one style."""
-        style: Any = None
-        """Optional style payload for this span."""
+    def get_cell(self, x: int, y: int) -> tuple[str, Any]:
+        """Return ``(char, style)`` for a cell, or a blank.
 
-    @dataclasses.dataclass
-    class CellCanvas:
-        """Minimal rectangular cell lattice used by :class:`Stage`.
+        Args:
+            x: Column index.
+            y: Row index.
 
-        Fallback used when ``xnano.content.CellCanvas`` is not yet
-        available. Stores per-cell ``(character, style)`` pairs and can
-        export run-length :class:`CellSpan` rows.
-
-        Attributes:
-            width: Lattice width in cells.
-            height: Lattice height in cells.
+        Returns:
+            The cell payload, or ``(" ", None)`` when out of bounds.
         """
+        if x < 0 or y < 0 or x >= self.width or y >= self.height:
+            return (" ", None)
+        return self._cells[y][x]
 
-        width: int
-        """Lattice width in cells."""
-        height: int
-        """Lattice height in cells."""
-        _cells: list[list[tuple[str, Any]]] = dataclasses.field(
-            init=False,
-            repr=False,
-        )
+    def fill(self, style: Any = None, char: str = " ") -> None:
+        """Fill the entire canvas with ``char`` / ``style``.
 
-        def __post_init__(self) -> None:
-            width = max(0, int(self.width))
-            height = max(0, int(self.height))
-            self.width = width
-            self.height = height
-            self._cells = [
-                [(" ", None) for _ in range(width)] for _ in range(height)
-            ]
+        Args:
+            style: Optional style payload.
+            char: Fill character (first codepoint used).
+        """
+        glyph = char[0] if char else " "
+        for y in range(self.height):
+            row = self._cells[y]
+            for x in range(self.width):
+                row[x] = (glyph, style)
 
-        def set_cell(
-            self,
-            x: int,
-            y: int,
-            char: str,
-            style: Any = None,
-        ) -> None:
-            """Write one cell, clipping out-of-bounds coordinates.
+    def as_span_rows(self) -> list[list[_PaintSpan]]:
+        """Export rows as run-length-encoded paint spans.
 
-            Args:
-                x: Column index.
-                y: Row index.
-                char: Character to store (first codepoint used).
-                style: Optional style payload.
-            """
-            if x < 0 or y < 0 or x >= self.width or y >= self.height:
-                return
-            glyph = char[0] if char else " "
-            self._cells[y][x] = (glyph, style)
-
-        def get_cell(self, x: int, y: int) -> tuple[str, Any]:
-            """Return ``(char, style)`` for a cell, or a blank.
-
-            Args:
-                x: Column index.
-                y: Row index.
-
-            Returns:
-                The cell payload, or ``(" ", None)`` when out of bounds.
-            """
-            if x < 0 or y < 0 or x >= self.width or y >= self.height:
-                return (" ", None)
-            return self._cells[y][x]
-
-        def fill(self, style: Any = None, char: str = " ") -> None:
-            """Fill the entire canvas with ``char`` / ``style``.
-
-            Args:
-                style: Optional style payload.
-                char: Fill character (first codepoint used).
-            """
-            glyph = char[0] if char else " "
-            for y in range(self.height):
-                row = self._cells[y]
-                for x in range(self.width):
-                    row[x] = (glyph, style)
-
-        def as_span_rows(self) -> list[list[CellSpan]]:
-            """Export rows as run-length-encoded :class:`CellSpan` lists.
-
-            Returns:
-                One list of spans per row.
-            """
-            rows: list[list[CellSpan]] = []
-            for y in range(self.height):
-                spans: list[CellSpan] = []
-                current_text = ""
-                current_style: Any = None
-                for x in range(self.width):
-                    glyph, style = self._cells[y][x]
-                    if current_text and style != current_style:
-                        spans.append(
-                            CellSpan(text=current_text, style=current_style)
-                        )
-                        current_text = ""
-                    current_text += glyph
-                    current_style = style
-                if current_text:
+        Returns:
+            One list of spans per row.
+        """
+        rows: list[list[_PaintSpan]] = []
+        for y in range(self.height):
+            spans: list[_PaintSpan] = []
+            current_text = ""
+            current_style: Any = None
+            for x in range(self.width):
+                glyph, style = self._cells[y][x]
+                if current_text and style != current_style:
                     spans.append(
-                        CellSpan(text=current_text, style=current_style)
+                        _PaintSpan(text=current_text, style=current_style)
                     )
-                rows.append(spans)
-            return rows
+                    current_text = ""
+                current_text += glyph
+                current_style = style
+            if current_text:
+                spans.append(
+                    _PaintSpan(text=current_text, style=current_style)
+                )
+            rows.append(spans)
+        return rows
+
+
+# Public aliases used by Stage paint/wireframe APIs and tests.
+CellSpan = _PaintSpan
+CellCanvas = _PaintCanvas
 
 
 @dataclasses.dataclass(slots=True)
@@ -158,9 +158,9 @@ class LayoutEntry:
 class LayoutMap:
     """Always-on resolved geometry for the current frame.
 
-    Hosts record ``interface`` / ``field`` → :class:`~xnano._types.Area`
-    (plus ``z``) while laying out each frame so the stage can answer
-    "where is everything" without re-running layout.
+    Hosts record ``interface`` / ``field`` → ``Area`` (plus ``z``) while
+    laying out each frame so the stage can answer where everything is
+    without re-running layout.
     """
 
     def __init__(self) -> None:
@@ -222,7 +222,7 @@ class LayoutMap:
             field: Field name, or ``None`` for the interface root.
 
         Returns:
-            The stored :class:`~xnano._types.Area`, or ``None``.
+            The stored ``Area``, or ``None``.
         """
         entry = self._index.get((id(interface), field))
         if entry is None:
@@ -233,16 +233,16 @@ class LayoutMap:
         """Return recorded entries in record order.
 
         Returns:
-            A sequence of :class:`LayoutEntry` values.
+            A sequence of ``LayoutEntry`` values.
         """
         return tuple(self._entries)
 
 
 class StageRegion:
-    """Paintable view of an :class:`~xnano._types.Area` on the Stage.
+    """Paintable view of an ``Area`` on the stage.
 
-    Coordinates passed to :meth:`paint` / :meth:`map_cells` are relative
-    to this region's top-left corner.
+    Coordinates passed to ``paint`` / ``map_cells`` are relative to this
+    region's top-left corner.
     """
 
     def __init__(self, stage: "Stage", area: Area) -> None:
@@ -269,12 +269,7 @@ class StageRegion:
             char: Character to paint (first codepoint used).
             style: Optional style payload.
         """
-        if (
-            x < 0
-            or y < 0
-            or x >= self._area.width
-            or y >= self._area.height
-        ):
+        if x < 0 or y < 0 or x >= self._area.width or y >= self._area.height:
             return
         self._stage._paint_absolute(
             self._area.x + x,
@@ -320,12 +315,11 @@ class StageRegion:
 
 
 class Stage:
-    """Imperative facade: active grid as an addressable cell lattice.
+    """Treat the active grid as an addressable cell lattice.
 
     Exposed as ``host.stage`` / ``ctx.stage``. Layout geometry is read
-    from the always-on :class:`LayoutMap`; paints accumulate into a
-    per-frame :class:`CellCanvas` overlay retrieved via
-    :meth:`take_overlay`.
+    from the always-on ``LayoutMap``; paints accumulate into a
+    per-frame ``CellCanvas`` overlay retrieved via ``take_overlay``.
     """
 
     def __init__(self, host: "AbstractHost | None" = None) -> None:
@@ -390,7 +384,7 @@ class Stage:
             area: Absolute cell area on the stage.
 
         Returns:
-            A :class:`StageRegion` bound to this stage.
+            A ``StageRegion`` bound to this stage.
         """
         return StageRegion(self, area)
 
@@ -406,7 +400,7 @@ class Stage:
             field: Field name, or ``None`` for the interface root.
 
         Returns:
-            A :class:`StageRegion`, or ``None`` if unmapped.
+            A ``StageRegion``, or ``None`` if unmapped.
         """
         area = self._layout.region_of(interface, field)
         if area is None:
@@ -445,14 +439,14 @@ class Stage:
         """Return whether wireframe mode is enabled.
 
         Returns:
-            ``True`` when :meth:`wireframe` last enabled the flag.
+            ``True`` when ``wireframe`` last enabled the flag.
         """
         return self._wireframe
 
     def take_overlay(self) -> CellCanvas | None:
-        """Return accumulated :class:`CellCanvas` paints this frame.
+        """Return accumulated ``CellCanvas`` paints this frame.
 
-        Does not clear paints; call :meth:`clear_paints` at frame end.
+        Does not clear paints; call ``clear_paints`` at frame end.
 
         Returns:
             The paint canvas if any cells were written, else ``None``.
@@ -475,10 +469,7 @@ class Stage:
                 entry
                 for entry in entries
                 if _areas_intersect(entry.area, target)
-                or (
-                    entry.interface is interface
-                    and entry.field == field
-                )
+                or (entry.interface is interface and entry.field == field)
             ]
         if self._wireframe_region is not None:
             region = self._wireframe_region
@@ -494,10 +485,10 @@ class Stage:
 
         Overlay-only: does not modify field content. Labels prefer the
         field name, falling back to the interface type name. Honors the
-        scope set by :meth:`wireframe` (full map, region, or field).
+        scope set by ``wireframe`` (full map, region, or field).
 
         Returns:
-            A wireframe :class:`CellCanvas`, or ``None``.
+            A wireframe ``CellCanvas``, or ``None``.
         """
         entries = self._wireframe_entries()
         if not entries:
@@ -527,7 +518,7 @@ class Stage:
         return canvas
 
     def _ensure_paint_canvas(self) -> CellCanvas:
-        """Return the paint canvas, allocating from :attr:`size`."""
+        """Return the paint canvas, allocating from ``size``."""
         if self._paint_canvas is None:
             size = self.size
             width = size.width

--- a/xnano/effects.py
+++ b/xnano/effects.py
@@ -1,23 +1,11 @@
 """xnano.effects
 
-Declarative, controller-agnostic descriptions of visual effects that can be
-played against one or more ``BaseGrid`` layout fields.
+---
 
-Every ``AbstractEffect`` subclass here only describes *intent* — duration,
-interpolation, color, motion, composition — using ``xnano`` types and
-literals. Nothing in this module assumes a terminal. The terminal-only
-lowering of a description to a ``tachyonfx`` native effect lives in
-``xnano.tui.effects``, which the terminal controller calls. A future web
-controller would instead dispatch over these same dataclasses to a CSS
-transition/animation.
-
-``key`` lives on ``AbstractEffect`` (alongside ``duration_ms`` and
-``interpolation``) rather than being passed separately wherever an effect
-is played, because it is the effect's own dedup/identity — the same
-category of thing as its duration, not a per-call detail like which fields
-to target this time. A controller's ``play_effect(effect, *, fields=...)``
-reads ``effect.key`` itself rather than accepting a redundant ``key``
-argument.
+Declarative visual effect descriptions for ``BaseGrid`` layout fields
+(duration, motion, color, composition). Host controllers lower these
+intents to their platform (for example terminal effects via
+``xnano.tui.effects``).
 """
 
 from __future__ import annotations

--- a/xnano/events.py
+++ b/xnano/events.py
@@ -2,10 +2,8 @@
 
 ---
 
-Also provides the public ``@on_*`` hook decorators (``on_event``,
-``on_keyboard``, ``on_mouse``, ``on_click``, ``on_resize``, ``on_focus``,
-``on_clipboard``, ``on_state``, ``on_field``, ``on_poll``, ``on_tick``)
-used to annotate ``BaseGrid`` methods for event handling.
+Unified terminal and application events, plus the public ``@on_*`` hook
+decorators used to annotate ``BaseGrid`` methods for event handling.
 """
 
 from __future__ import annotations
@@ -240,7 +238,9 @@ def parse_binding_tuple(
         return ([], "")
     modifiers_set, key = normalized
     modifiers: list[KeyboardModifier | None] = [
-        m for m in ("ctrl", "alt", "shift") if m in modifiers_set  # type: ignore[misc]
+        m
+        for m in ("ctrl", "alt", "shift")
+        if m in modifiers_set  # type: ignore[misc]
     ]
     return (modifiers, key)
 
@@ -1248,8 +1248,6 @@ def on_poll(
         return _decorate(fn, resolved)
 
     return decorator
-
-
 
 
 def on(

--- a/xnano/fields.py
+++ b/xnano/fields.py
@@ -1,9 +1,12 @@
 """xnano.fields
 
-Provides a set of `Field` descriptors for defining and annotating grid
-fields with layout, sizing, and style information.
+---
+
+``Field`` descriptors for grid layout, sizing, style, and state
+attributes.
 
 Example:
+
     ```python
     from xnano import BaseGrid, Field
 
@@ -266,7 +269,6 @@ class GridFieldInfo:
         return self.get_style()
 
 
-# Canonical name per architecture plan; ``GridFieldInfo`` kept as alias.
 FieldInfo = GridFieldInfo
 
 

--- a/xnano/grid.py
+++ b/xnano/grid.py
@@ -2,12 +2,8 @@
 
 ---
 
-This module provides the `BaseGrid` base class and related types for building
-structured, declarative terminal user interfaces. Grids use annotated
-`Field` descriptors to define slots/areas with associated layout, sizing,
-and style information, and can be configured via the `GridSettings` class.
-Grids support flex-style, nested, and stateful layouts, with unified
-rendering and event integration.
+``BaseGrid`` and related types for declarative layout: ``Field`` slots,
+sizing, nesting, and host-driven rendering with event hooks.
 
 Example:
 
@@ -213,12 +209,7 @@ _GRID_FIELD_IMMUTABLE_KEYS: frozenset[str] = frozenset(
 
 
 _GridLayoutConstraint = LayoutConstraint
-"""Alias kept so nothing that names the old grid-private constraint type
-breaks. Layout constraints are the shared `xnano.controllers.abstract.LayoutConstraint`
-now, not a dataclass private to `BaseGrid` — the same kind/weight vocabulary is
-meant to be portable to a future web controller too, not just a terminal
-split.
-"""
+"""Local name for the shared layout constraint type used while sizing grids."""
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -522,11 +513,11 @@ def _resolve_slot_area(
     """Complete a slot's geometry from the split result and its cross sizing.
 
     ``split_layout`` sizes each slot along the parent's layout axis
-    (through :func:`_layout_constraint_for_field`); this stage resolves the
+    (through ``_layout_constraint_for_field``); this stage resolves the
     *cross* axis through the same unified ``Sizing`` model, so both ``width``
     and ``height`` are first-class in any grid rather than the cross axis being
     an afterthought. Both axes therefore flow from one vocabulary — the layout
-    axis via the ratatui split, the cross axis via :meth:`Sizing.resolve`.
+    axis via the ratatui split, the cross axis via ``Sizing.resolve``.
 
     A cross-constrained slot keeps its top-left corner. When the cross axis has
     no sizing or fills (the common case), the split slot is already final and
@@ -1178,7 +1169,10 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             if self._grid_field_info(field_name).slide:
                 return True
             value = getattr(self, field_name, None)
-            if isinstance(value, BaseGrid) and value._grid_needs_mouse_geometry():
+            if (
+                isinstance(value, BaseGrid)
+                and value._grid_needs_mouse_geometry()
+            ):
                 return True
             from xnano._types import is_input_text
 
@@ -1567,4 +1561,3 @@ __all__ = (
     "Grid",
     "GridSettings",
 )
-

--- a/xnano/state.py
+++ b/xnano/state.py
@@ -1,7 +1,9 @@
 """xnano.state
 
-Provides a simple data container that can be used to store and define
-new state variables dynamically.
+---
+
+Lightweight dynamic state container for simple apps (prefer dataclasses
+or models when you need a fixed schema).
 """
 
 from __future__ import annotations

--- a/xnano/tui/__init__.py
+++ b/xnano/tui/__init__.py
@@ -2,8 +2,8 @@
 
 ---
 
-Terminal interface kind: ``Terminal`` host, cursor/device facades, nodes,
-native effects lowering.
+Terminal interface kind: ``Terminal`` host, cursor and device controls,
+render nodes, and native effects lowering.
 """
 
 from __future__ import annotations
@@ -25,7 +25,6 @@ def __getattr__(name: str):
         from xnano.tui import terminal as _terminal
 
         return getattr(_terminal, name)
-    # Legacy alias used by a few call sites
     if name == "exit":
         from xnano.tui.terminal import exit_terminal
 

--- a/xnano/tui/_node_base_tmp.py
+++ b/xnano/tui/_node_base_tmp.py
@@ -1,30 +1,12 @@
 """xnano.tui._node_base_tmp
 
-A node is the smallest unit of drawable content in xnano: a span of text,
-a progress bar, a frame around some other node, and so on. Every interface
-xnano supports (terminal today, web later) has its own family of node
-types, and this module defines the base every one of them shares.
+---
 
-That shared base only covers structure, not behavior: a z-index for
-layering, and a visibility flag. It does not define how a node draws
-itself, because that genuinely differs between interfaces. A terminal
-node measures its own size in character cells, because nothing else will
-— there's no layout engine underneath it. A web node has no equivalent
-step, because the browser's layout engine handles that instead. Giving
-both a shared "draw yourself" method would only paper over that
-difference, not remove it.
+Shared structural base for drawable nodes (z-index and visibility).
 
-So each interface defines its own base with its own drawing methods —
-see `AbstractTerminalNode` in `xnano.tui.nodes` — and every
-concrete node (a span, a paragraph, a frame, ...) implements those methods
-on itself. This matters beyond style: the previous implementation
-(`xnano.beta.core.nodes.NodeAssembler`) instead used one big function that
-checked "is this node a paragraph? a table? a chart?" one type at a time,
-and had to repeat that same check across three separate functions
-(measuring, building, and lowering nodes) that could drift out of sync
-with each other. Letting each node describe its own behavior removes that
-whole class of bug and means adding a new node type never requires
-touching code outside that node's own class.
+Interface kinds define their own drawing methods on top of this base —
+for example ``AbstractTerminalNode`` in ``xnano.tui.nodes`` — because
+measurement and paint differ between terminal cells and browser layout.
 """
 
 from __future__ import annotations

--- a/xnano/tui/content_lower.py
+++ b/xnano/tui/content_lower.py
@@ -35,7 +35,9 @@ from xnano.tui.nodes import (
 from xnano._types import Frame
 
 
-def lower_content(content: AbstractContent | Any) -> AbstractTerminalNode | None:
+def lower_content(
+    content: AbstractContent | Any,
+) -> AbstractTerminalNode | None:
     """Lower a Content tree (or passthrough node) to a terminal node.
 
     Args:
@@ -222,21 +224,23 @@ def _lower_text_block(block: TextBlock) -> AbstractTerminalNode:
     )
 
 
-def _lower_cell_canvas(canvas: CellCanvas) -> AbstractTerminalNode:
+def _lower_cell_canvas(canvas: Any) -> AbstractTerminalNode:
     """Lower a CellCanvas to a non-wrapping paragraph of run-length spans."""
     rows = getattr(canvas, "rows", None)
-    if rows is None and hasattr(canvas, "as_span_rows"):
-        rows = canvas.as_span_rows()
+    as_span_rows = getattr(canvas, "as_span_rows", None)
+    if rows is None and callable(as_span_rows):
+        rows = as_span_rows()
     if not rows:
-        # Per-cell storage fallback (local Stage CellCanvas).
-        if hasattr(canvas, "get_cell"):
+        # Per-cell storage fallback (Stage paint lattice).
+        get_cell = getattr(canvas, "get_cell", None)
+        if callable(get_cell):
             lines: list[LineNode] = []
-            for y in range(getattr(canvas, "height", 0)):
+            for y in range(int(getattr(canvas, "height", 0) or 0)):
                 spans: list[SpanNode] = []
                 current = ""
                 current_style: Any = None
-                for x in range(getattr(canvas, "width", 0)):
-                    glyph, style = canvas.get_cell(x, y)
+                for x in range(int(getattr(canvas, "width", 0) or 0)):
+                    glyph, style = get_cell(x, y)
                     if current and style != current_style:
                         spans.append(
                             _span_from_cell_run(current, current_style)
@@ -250,8 +254,8 @@ def _lower_cell_canvas(canvas: CellCanvas) -> AbstractTerminalNode:
             return ParagraphNode(
                 text=TextNode(lines=lines),
                 wrap=False,
-                z=canvas.z,
-                visible=canvas.visible,
+                z=getattr(canvas, "z", 0),
+                visible=getattr(canvas, "visible", True),
             )
         return ParagraphNode(text="", wrap=False)
 

--- a/xnano/tui/cursor.py
+++ b/xnano/tui/cursor.py
@@ -1,4 +1,10 @@
-"""xnano.tui.cursor"""
+"""xnano.tui.cursor
+
+---
+
+Terminal cursor controls (visibility, style, position) for a live
+``Terminal`` session.
+"""
 
 from __future__ import annotations
 
@@ -50,12 +56,10 @@ Values:
 
 
 class TerminalCursor(AbstractCursor):
-    """Accessor/controller to the live cursor visible on the terminal
-    screen.
+    """Show, hide, style, and move the terminal cursor.
 
-    NOTE: This class should not be initialized on it's own and is
-    instead accessible through a live ``Terminal`` session within
-    the class directly or through ``@on_<event>`` hooks.
+    Obtained from a live ``Terminal`` (``terminal.cursor`` or
+    ``ctx.cursor`` in hooks). Do not construct this class yourself.
     """
 
     __slots__ = (

--- a/xnano/tui/device.py
+++ b/xnano/tui/device.py
@@ -1,4 +1,10 @@
-"""xnano.tui.device"""
+"""xnano.tui.device
+
+---
+
+Terminal device controls (title, clear, size, scroll, clipboard, mode
+flags) for a live ``Terminal`` session.
+"""
 
 from __future__ import annotations
 
@@ -34,11 +40,11 @@ _NATIVE_CLEAR_TYPES: dict[ClearType, Any] = {
 
 
 class TerminalDevice(AbstractDevice):
-    """Accessor/controller to the terminal device settings during an
-    active session.
+    """Control terminal device settings during a live session.
 
-    NOTE: This class should not be initialized on its own and is
-    instead accessible through a live ``Terminal`` session.
+    Title, clear, size, scroll, clipboard, raw mode, alternate screen,
+    mouse capture, and related flags. Obtained from ``terminal.device``
+    or ``ctx.device`` — do not construct this class yourself.
     """
 
     __slots__ = (
@@ -219,7 +225,6 @@ class TerminalDevice(AbstractDevice):
     def copy_to_clipboard(self, text: str) -> None:
         """Copy ``text`` via the host terminal's clipboard path."""
         self._terminal.copy_to_clipboard(text)
-
 
 
 __all__ = ("TerminalDevice", "ClearType")

--- a/xnano/tui/effects.py
+++ b/xnano/tui/effects.py
@@ -3,10 +3,7 @@
 ---
 
 Lowers neutral ``xnano.effects`` descriptions to native ``tachyonfx``
-effects. This is the terminal-only half promised by the old
-``xnano.effects`` module docstring: it dispatches over the concrete
-``AbstractEffect`` subclasses and builds a native ``tachyonfx`` effect
-for the terminal controller.
+effects for the terminal controller.
 """
 
 from __future__ import annotations
@@ -221,9 +218,7 @@ def build_native_effect(effect: AbstractEffect) -> native.Effect:
         )
     if isinstance(effect, PaintBackgroundEffect):
         return native.paint_bg(
-            _require_native_color(
-                effect.background, label="background"
-            ),
+            _require_native_color(effect.background, label="background"),
             effect.duration_ms,
             _resolve_native_interpolation(effect.interpolation),
         )
@@ -248,9 +243,7 @@ def build_native_effect(effect: AbstractEffect) -> native.Effect:
         if effect.times is not None:
             return native.repeat_effect(child, times=effect.times)
         if effect.duration_ms != 300:
-            return native.repeat_effect(
-                child, duration_ms=effect.duration_ms
-            )
+            return native.repeat_effect(child, duration_ms=effect.duration_ms)
         return native.repeat_effect(child)
     if isinstance(effect, DelayEffect):
         if effect.child is None:
@@ -277,9 +270,7 @@ def apply_native_cell_filter(
         "background": native.CellFilter.BACKGROUND,
         "background_only": native.CellFilter.BACKGROUND_ONLY,
     }
-    return native_effect.with_filter(
-        filters[effect_description.cell_filter]
-    )
+    return native_effect.with_filter(filters[effect_description.cell_filter])
 
 
 def resolve_native_effect(
@@ -336,6 +327,4 @@ def resolve_native_effect(
         times=times,
         key=key,
     )
-    return apply_native_cell_filter(
-        resolved, build_native_effect(resolved)
-    )
+    return apply_native_cell_filter(resolved, build_native_effect(resolved))

--- a/xnano/tui/nodes.py
+++ b/xnano/tui/nodes.py
@@ -1,25 +1,12 @@
 """xnano.tui.nodes
 
-The terminal's node types: text, panels, charts, tables, and everything
-else a `BaseGrid` can paint into a region of the screen. Every concrete node
-here (`SpanNode`, `ParagraphNode`, `FrameNode`, ...) implements its own
-drawing behavior directly, instead of being matched from the outside by a
-central dispatcher that checks "is this a paragraph? a table? a chart?"
-one type at a time.
+---
 
-Most nodes only need to implement `to_ir`, returning a `CoreRenderIR` —
-a lightweight, mostly-Rust description that a controller can paint
-directly. A handful of nodes have no such representation, either always
-(a chart) or only in a particular case (a sparkline with per-bar colors,
-where the shared color of a whole bar can't be expressed in the IR); those
-override `lower` directly and build native content themselves.
-
-A container node (`FrameNode`, `ContainerNode`, `StackNode`) never needs
-to know what kind of node its children are — it measures and lowers them
-by calling `child.measure()` / `child.lower(...)`, the same two methods
-every node defines. That's the whole point of putting this behavior on
-the node: nothing outside this module has to change when a new node type
-is added.
+Terminal node types (text, panels, charts, tables, and other drawable
+content). Most nodes implement ``to_ir`` and return a ``CoreRenderIR``
+the controller can paint; a few override ``lower`` when IR cannot
+express the content. Containers measure and lower children through the
+shared node methods.
 """
 
 from __future__ import annotations

--- a/xnano/tui/terminal.py
+++ b/xnano/tui/terminal.py
@@ -1,4 +1,10 @@
-"""xnano.tui.terminal"""
+"""xnano.tui.terminal
+
+---
+
+``Terminal`` host: session lifecycle, run loop, viewport sizing, and
+hook dispatch for interactive TUI apps.
+"""
 
 from __future__ import annotations
 
@@ -51,7 +57,7 @@ StateT = TypeVar("StateT")
 class _ResolvedRun:
     """The viewport/root sizing resolved for a single ``run`` / ``render``.
 
-    Returned by :meth:`Terminal._resolve_run` so the resolution is an explicit
+    Returned by ``Terminal._resolve_run`` so the resolution is an explicit
     value rather than a hidden mutation. The terminal stores its fields where
     frame-time consumers read them (the inline height for session creation, the
     root width sizing for per-frame area resolution).
@@ -573,7 +579,7 @@ class Terminal(AbstractHost, Generic[StateT]):
         inline viewport. The width sizing constrains the root box within that
         viewport.
 
-        Returns a :class:`_ResolvedRun`; the caller is responsible for wiring
+        Returns a ``_ResolvedRun``; the caller is responsible for wiring
         its fields onto the terminal so the resolution is explicit rather than
         a side effect.
         """
@@ -613,7 +619,7 @@ class Terminal(AbstractHost, Generic[StateT]):
         """Store a ``_ResolvedRun`` where frame-time consumers read it.
 
         ``_inline_height`` is consumed once when the deferred session is created
-        (:meth:`_ensure_session`); ``_root_width_sizing`` is consumed every
+        (``_ensure_session``); ``_root_width_sizing`` is consumed every
         frame when resolving the root area.
         """
         self._inline_height = resolved.inline_height
@@ -622,7 +628,7 @@ class Terminal(AbstractHost, Generic[StateT]):
     def _recreate_session(self, resolved: _ResolvedRun) -> None:
         """Tear down the live session so the next access recreates it.
 
-        Used when a one-shot :meth:`render` needs a different inline viewport
+        Used when a one-shot ``render`` needs a different inline viewport
         height than the session that is already open.
         """
         if self._session is not None:
@@ -638,7 +644,7 @@ class Terminal(AbstractHost, Generic[StateT]):
     ) -> None:
         """Resolve viewport sizing for a one-shot render and prepare the session.
 
-        Each :meth:`render` call is content-sized. When an inline session is
+        Each ``render`` call is content-sized. When an inline session is
         already open but the new content needs a different inline viewport
         height, the existing session is torn down and recreated on the next
         paint.
@@ -743,7 +749,9 @@ class Terminal(AbstractHost, Generic[StateT]):
         """
         from xnano.grid import BaseGrid
 
-        is_grid = len(renderables) == 1 and isinstance(renderables[0], BaseGrid)
+        is_grid = len(renderables) == 1 and isinstance(
+            renderables[0], BaseGrid
+        )
 
         # Non-BaseGrid content renders inline; build its style field up front so
         # the inline viewport can be sized to include any border/padding.

--- a/xnano/webui/device.py
+++ b/xnano/webui/device.py
@@ -2,9 +2,8 @@
 
 ---
 
-Web implementations of ``AbstractDevice`` / ``AbstractCursor``. Thin
-adapters: page title, logical size, scroll/clipboard intents that the
-host can lower to browser APIs later.
+Browser device and cursor controls for web sessions (title, size,
+scroll, clipboard, caret style).
 """
 
 from __future__ import annotations
@@ -58,7 +57,7 @@ class WebDevice(AbstractDevice):
 
 
 class WebCursor(AbstractCursor):
-    """Browser caret / pointer style facade."""
+    """Browser caret / pointer style controls for a web session."""
 
     def __init__(self, host: Any) -> None:
         self._host = host

--- a/xnano/webui/nodes.py
+++ b/xnano/webui/nodes.py
@@ -1,4 +1,9 @@
-"""xnano.webui.nodes"""
+"""xnano.webui.nodes
+
+---
+
+Web render nodes that lower component content to HTML fragments.
+"""
 
 from __future__ import annotations
 

--- a/xnano/webui/session.py
+++ b/xnano/webui/session.py
@@ -23,10 +23,11 @@ from xnano._function_hooks import (
 
 
 class WebSession(AbstractHost):
-    """One live grid plus its hooks — the web analogue of a terminal.
+    """One live browser grid session with hooks, state, and device access.
 
-    Declared ``AbstractHost`` subtype so dispatch, ``perform``, device /
-    cursor / stage / actions share one contract with ``Terminal``.
+    Web analogue of ``Terminal``: renders the root grid to HTML, pumps
+    tick/state/field hooks, and exposes ``device``, ``cursor``,
+    ``actions``, and ``stage``.
     """
 
     def __init__(self, grid: Any, state: Any) -> None:
@@ -47,14 +48,14 @@ class WebSession(AbstractHost):
 
     @property
     def device(self) -> AbstractDevice:
-        """Live web device facade."""
+        """Browser device controls (title, size, scroll, clipboard)."""
         if self._device is None:
             self._device = WebDevice(self)
         return self._device
 
     @property
     def cursor(self) -> AbstractCursor:
-        """Live web cursor facade."""
+        """Browser caret / pointer style controls."""
         if self._cursor is None:
             self._cursor = WebCursor(self)
         return self._cursor
@@ -275,8 +276,6 @@ document.addEventListener("keydown", function (event) {
 """
 
 
-
-# Back-compat private name used by older call sites.
 _WebSession = WebSession
 
 

--- a/xnano/webui/web.py
+++ b/xnano/webui/web.py
@@ -116,7 +116,9 @@ class Web:
     def _is_factory(self) -> bool:
         from xnano.grid import BaseGrid
 
-        return callable(self._source) and not isinstance(self._source, BaseGrid)
+        return callable(self._source) and not isinstance(
+            self._source, BaseGrid
+        )
 
     def _make_session(self) -> WebSession:
         grid = self._source() if self._is_factory() else self._source
@@ -442,8 +444,6 @@ class Web:
             raise ExtraNotInstalledError("web") from error
 
         uvicorn.run(app, host=host, port=port)
-
-
 
 
 __all__ = ("Web",)


### PR DESCRIPTION
## Summary

- Package-wide docstring cleanup (user-focused, no Sphinx roles / process notes).
- Stronger Action coverage on TUI and WebUI (`tests/test_actions.py`, `tests/webui/test_web_actions.py`).
- Type-check fixes (Stage paint lattice vs Content `CellCanvas`, Action kind casts, host dispatch typing).
- `prek` / `ty` clean.

## Test plan

- [x] `uv run prek run --all-files`
- [x] `uv run pytest --ignore=tests/core -q`