### PR TITLE
feat: Pyodide/WebAssembly wheel support for xnano-core

### DIFF
--- a/.github/wasm_smoke_test.py
+++ b/.github/wasm_smoke_test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Smoke test the xnano-core wasm wheel inside a Pyodide runtime."""
+
+import sys
+
+
+def main() -> int:
+    import xnano_core
+
+    print(f"platform: {sys.platform}")
+    print(f"xnano_core: {xnano_core.__version__}")
+
+    from xnano_core.core import (
+        CoreEvent,
+        CoreKeyBinding,
+        CoreRenderContent,
+        CoreRenderIR,
+        CoreRenderNode,
+        CoreSession,
+        CoreTerminalEventKind,
+        CoreTerminalRef,
+        CoreTickEvent,
+        IrLine,
+    )
+
+    imported = (
+        CoreEvent,
+        CoreRenderContent,
+        CoreRenderIR,
+        CoreRenderNode,
+        CoreTerminalEventKind,
+        CoreTerminalRef,
+        CoreTickEvent,
+        IrLine,
+    )
+    print(f"imported {len(imported) + 2} engine classes")
+
+    binding = CoreKeyBinding.parse("ctrl+q")
+    print(f"key binding: {binding!r}")
+
+    try:
+        CoreSession()
+    except RuntimeError as error:
+        print(f"CoreSession unavailable as expected: {error}")
+    else:
+        print("✖ CoreSession should raise RuntimeError on wasm")
+        return 1
+
+    print("✓ wasm smoke test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,101 @@ jobs:
           --find-links dist --force-reinstall
       - run: uv run --no-sync python -c "import xnano_core; print(xnano_core.__version__)"
 
+  build-xnano-core-wasm:
+    name: build xnano-core wasm (pyodide/emscripten)
+    needs: resolve-release
+    if: needs.resolve-release.outputs.run_core_pipeline == 'true'
+    runs-on: ubuntu-latest
+
+    env:
+      # xnano-core's MSRV (1.88) is newer than the rust toolchain pinned
+      # by the current pyodide xbuildenv, so build against the newest
+      # prebuilt wasm-eh sysroot published by the pyodide team. Drop
+      # these overrides (and the manual sysroot install below) once
+      # `pyodide config get rust_toolchain` reaches rust 1.88+.
+      RUST_TOOLCHAIN: nightly-2025-06-27
+      RUST_EMSCRIPTEN_SYSROOT_URL: >-
+        https://github.com/pyodide/rust-emscripten-wasm-eh-sysroot/releases/download/emcc-4.0.9_nightly-2025-06-27/emcc-4.0.9_nightly-2025-06-27.tar.bz2
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: set up python
+        uses: actions/setup-python@v6
+        with:
+          # must match `pyodide config get python_version`
+          python-version: "3.13"
+
+      - name: install pyodide-build
+        run: pip install pyodide-build
+
+      - name: install rust toolchain with pyodide wasm-eh sysroot
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          sysroot="$(rustup run "$RUST_TOOLCHAIN" rustc --print sysroot)"
+          curl -sL "$RUST_EMSCRIPTEN_SYSROOT_URL" |
+            tar -xj -C "$sysroot/lib/rustlib/"
+
+      - name: cache rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: xnano-core
+
+      - name: build wasm wheel
+        working-directory: xnano-core
+        env:
+          RUSTUP_TOOLCHAIN: ${{ env.RUST_TOOLCHAIN }}
+        run: pyodide build -o dist -C build-args=--no-default-features
+
+      - run: pip install -U twine
+
+      - name: check wheels
+        working-directory: xnano-core
+        run: twine check --strict dist/*
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: pypi_files_xnano_core_wasm_emscripten
+          path: xnano-core/dist
+
+  test-xnano-core-wasm-wheel:
+    name: test xnano-core wasm wheel in pyodide
+    needs: [resolve-release, build-xnano-core-wasm]
+    if: needs.resolve-release.outputs.run_core_pipeline == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: set up python
+        uses: actions/setup-python@v6
+        with:
+          # must match `pyodide config get python_version`
+          python-version: "3.13"
+
+      - name: install pyodide-build
+        run: pip install pyodide-build
+
+      - name: get dist artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: pypi_files_xnano_core_wasm_emscripten
+          path: dist
+
+      - name: create pyodide virtual environment
+        run: pyodide venv .venv-pyodide
+
+      - name: install xnano-core wasm wheel
+        run: >-
+          .venv-pyodide/bin/pip install xnano-core
+          --no-index --no-deps --find-links dist
+
+      - name: import smoke test
+        run: .venv-pyodide/bin/python .github/wasm_smoke_test.py
+
   build-xnano:
     name: build xnano sdist and wheel
     needs: resolve-release
@@ -322,7 +417,9 @@ jobs:
         test-os,
         build-xnano-core-sdist,
         build-xnano-core-wheels,
+        build-xnano-core-wasm,
         test-xnano-core-wheel-install,
+        test-xnano-core-wasm-wheel,
       ]
     if: >-
       needs.resolve-release.outputs.should_publish_core == 'true' &&
@@ -330,7 +427,9 @@ jobs:
       (needs.test-os.result == 'success' || needs.test-os.result == 'skipped') &&
       (needs.build-xnano-core-sdist.result == 'success' || needs.build-xnano-core-sdist.result == 'skipped') &&
       (needs.build-xnano-core-wheels.result == 'success' || needs.build-xnano-core-wheels.result == 'skipped') &&
-      (needs.test-xnano-core-wheel-install.result == 'success' || needs.test-xnano-core-wheel-install.result == 'skipped')
+      (needs.build-xnano-core-wasm.result == 'success' || needs.build-xnano-core-wasm.result == 'skipped') &&
+      (needs.test-xnano-core-wheel-install.result == 'success' || needs.test-xnano-core-wheel-install.result == 'skipped') &&
+      (needs.test-xnano-core-wasm-wheel.result == 'success' || needs.test-xnano-core-wasm-wheel.result == 'skipped')
     runs-on: ubuntu-latest
 
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .benchmarks/
 .workspace/
 .ruff_cache/
+dist-wasm/
 .DS_Store
 
 # Byte-compiled / optimized / DLL files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.0.2"
+version = "1.0.3"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic-core>=2.0.0",
-    "xnano-core==0.0.8",
+    "xnano-core==0.0.9",
 ]
 
 [project.optional-dependencies]
@@ -71,12 +71,13 @@ dev = [
     "marimo",
     # docs (zensical is a project by the mkdocs-material team, that
     # aims to be the successor to mkdocs-material and mkdocs itself)
-    "zensical",
+    "zensical>=0.0.50",
     "termynal>=0.14.0",
     "griffe-typingdoc",
     "mkdocs-material",
     "mkdocs-click",
     "mkdocstrings-python",
+    "markdown-exec[ansi]",
 
     # test / beta testing related dependencies
     "pydantic>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -929,6 +929,23 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-exec"
+version = "1.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/76/c47da8edb6a12b066728432fb3724109d9d91de5331df5073d12d272493f/markdown_exec-1.12.3.tar.gz", hash = "sha256:006b9cac46470a9499797bc9c579305ae4719e0a8e495e5401dfbf1e66ce7fb4", size = 77841, upload-time = "2026-07-07T09:53:13.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/a7/0279016386d611183ccc508c5688eb1e2133e8182164d7a2c6213b176f69/markdown_exec-1.12.3-py3-none-any.whl", hash = "sha256:48ac12a565f3f4331b1acd9efc48a0773e717eb7ca7c38e23c1d72ee61660de6", size = 37995, upload-time = "2026-07-07T09:53:12.619Z" },
+]
+
+[package.optional-dependencies]
+ansi = [
+    { name = "pygments-ansi-color" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1703,6 +1720,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pygments-ansi-color"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/f9/7f417aaee98a74b4f757f2b72971245181fcf25d824d2e7a190345669eaf/pygments-ansi-color-0.3.0.tar.gz", hash = "sha256:7018954cf5b11d1e734383a1bafab5af613213f246109417fee3f76da26d5431", size = 7317, upload-time = "2023-05-18T22:44:35.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/17/8306a0bcd8c88d7761c2e73e831b0be026cd6873ce1f12beb3b4c9a03ffa/pygments_ansi_color-0.3.0-py3-none-any.whl", hash = "sha256:7eb063feaecadad9d4d1fd3474cbfeadf3486b64f760a8f2a00fc25392180aba", size = 10242, upload-time = "2023-05-18T22:44:34.287Z" },
 ]
 
 [[package]]
@@ -2557,7 +2586,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-core" },
@@ -2578,6 +2607,7 @@ dev = [
     { name = "isort" },
     { name = "logfire" },
     { name = "marimo" },
+    { name = "markdown-exec", extra = ["ansi"] },
     { name = "maturin" },
     { name = "mkdocs-click" },
     { name = "mkdocs-material" },
@@ -2613,6 +2643,7 @@ dev = [
     { name = "isort" },
     { name = "logfire" },
     { name = "marimo" },
+    { name = "markdown-exec", extras = ["ansi"] },
     { name = "maturin", specifier = ">=1.9.4,<2.0" },
     { name = "mkdocs-click" },
     { name = "mkdocs-material" },
@@ -2628,7 +2659,7 @@ dev = [
     { name = "twine", specifier = ">=6.1.0" },
     { name = "ty" },
     { name = "uv" },
-    { name = "zensical" },
+    { name = "zensical", specifier = ">=0.0.50" },
 ]
 
 [[package]]
@@ -2678,7 +2709,7 @@ dev = [
     { name = "isort" },
     { name = "logfire" },
     { name = "marimo" },
-    { name = "maturin", specifier = ">=1.9.4,<2.0" },
+    { name = "maturin", specifier = ">=1.14,<2.0" },
     { name = "mkdocs-click" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings-python" },
@@ -2695,7 +2726,7 @@ dev = [
 
 [[package]]
 name = "zensical"
-version = "0.0.46"
+version = "0.0.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2707,20 +2738,20 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/57/c7bbb71f943e1e0ba5ce460f4930ec836ead7286969e7fd742f7a6c049ab/zensical-0.0.46.tar.gz", hash = "sha256:3ec21f4fb1e78cd7c0d6b07ae336b04770e27ba020dabc457b2790e5d34f1978", size = 3973968, upload-time = "2026-06-21T18:52:40.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/79/f7959b13c766a831f1248779bb718555f70f40c5b8e68db7de1de9936662/zensical-0.0.50.tar.gz", hash = "sha256:7040e52ebe5e6a275e4edeb351bf2bc314d007f3fb5750f178a38d840723e69c", size = 3979246, upload-time = "2026-07-09T13:52:11.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/bd/bbc499ee35ac9ec5459dbfec7bb7231556689e97eaa13a5eddbe1f0443b5/zensical-0.0.46-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d91af81ab058c8693dfd75f2f77b4c73bcba4125681d1d276f38624291820bd2", size = 12796482, upload-time = "2026-06-21T18:52:07.369Z" },
-    { url = "https://files.pythonhosted.org/packages/88/1b/7acc273184d59b8e894d15ebe3cf1c5e81b3a822fde1792ea3e33be37a2e/zensical-0.0.46-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d9221264a9a87409900a47e29985607b0c9245dacb89077e87c8e16e31edc167", size = 12660030, upload-time = "2026-06-21T18:52:10.186Z" },
-    { url = "https://files.pythonhosted.org/packages/80/df/bd0a68de98a19fc6050c58be11f36d05ea72a213b6a7ff7395d33c793747/zensical-0.0.46-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec43018d5343ca2e1d71aa352eeddd560fef504effd03025840a5a783abefa4f", size = 13057130, upload-time = "2026-06-21T18:52:12.911Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/db/e27635f5787a42245f900e658340698a6654e165d466f9a3b640efced2cd/zensical-0.0.46-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26e98fb8ab7ab50cdd20a73e2c7d4d9aae0b46cf2d8691e6bb22f9c261b8a60a", size = 13022345, upload-time = "2026-06-21T18:52:15.84Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/9d/6ce2ba11c97154870b458a8dae4637ade93b7097912f0102f5ea7fe8cf5b/zensical-0.0.46-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:46fe578f26963f8ee89567983e62737b6fadc9197d4742e1020b522e092d7baa", size = 13377445, upload-time = "2026-06-21T18:52:18.538Z" },
-    { url = "https://files.pythonhosted.org/packages/68/06/9930d43cd9d2f899b648d63491007c1b4f9716cf118b0c98e867b933069c/zensical-0.0.46-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aef03fa186a5589148e10b62610500989c6b075a2c08e1554233adbf91b2a3dc", size = 13086749, upload-time = "2026-06-21T18:52:21.452Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ed/2342cf860fbb02314938b0d1f1b02344935801b04d185ff3151ef1812898/zensical-0.0.46-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:bc7446cdf97a8dea390f20ed2bd6b030cddc1bd36a8ce113ea3efef6fa61c573", size = 13231120, upload-time = "2026-06-21T18:52:24.171Z" },
-    { url = "https://files.pythonhosted.org/packages/de/b0/d2ece02f63cd767fcf10fd7608dc8e0a995f87dc5261209b1dbc296fd57b/zensical-0.0.46-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:bbee37801f1ed500f158dc0992c569282950f780ae353c37fe6969f99983d701", size = 13295035, upload-time = "2026-06-21T18:52:26.942Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/b2/cb0048a612e63e615399fc507472a557d1c5b7c2f74065c5bf11998fd597/zensical-0.0.46-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:9487c147c9cceb50c04d0ad70b024821a6eab1629dafd70ab6d1e86ec841e623", size = 13437191, upload-time = "2026-06-21T18:52:29.69Z" },
-    { url = "https://files.pythonhosted.org/packages/91/16/515f81db8055b109a510063be481e60a657c4fad1a883680b2ee4aa9a424/zensical-0.0.46-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f42a4683c762f026878d19ede4bcf7bfbb84dbecb5ad923949abb77806ed88a5", size = 13369382, upload-time = "2026-06-21T18:52:32.521Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/5c/da54ee65b642eb7d88dd4a3db35845d0765915638e05d5d434a10b42f1c3/zensical-0.0.46-cp310-abi3-win32.whl", hash = "sha256:85f018f2a7ee76a83915c87ddb12b58cf343fd6154081d33ac95b6751b011dd7", size = 12354298, upload-time = "2026-06-21T18:52:34.976Z" },
-    { url = "https://files.pythonhosted.org/packages/73/26/fc7ef081acbdada8436825221cb728ee84a81d4d78a7bb79aa58bd150d31/zensical-0.0.46-cp310-abi3-win_amd64.whl", hash = "sha256:1543a693a160de60e86ca589592401b584670e7e12c5ae30e3c2ba76786f7ec3", size = 12599687, upload-time = "2026-06-21T18:52:37.913Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d2/e126d56642a5fd437eeb5a067b7c0d1f766c08e22d6a708bb923986f1d44/zensical-0.0.50-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:26dda9dbacab84db2743726f83202798e1893fbfddecb6a845812d7a331043ad", size = 12817706, upload-time = "2026-07-09T13:51:29.624Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9b/e1a22fb4ea8fc3e8377d7b394ee06cf0349e7f9a64ecb4c9873dee79b102/zensical-0.0.50-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:376887def6470c57509b48519870f74e2b987e30509cf5c819fcf372771f9403", size = 12691061, upload-time = "2026-07-09T13:51:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f5/16c087635680efb39e1d7b7aa3c2cca548305aa29ad51dee04f37b32b65f/zensical-0.0.50-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bbf3034a2cb1a9d2a72a5ee7047688717c93da0d8a90d25dd871db8d5f33a6d", size = 13129505, upload-time = "2026-07-09T13:51:36.383Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/50d02402e53aa01a5c5c116a3522c7bb18d6ae4da964d8b236173b6fa086/zensical-0.0.50-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26fe4167663d544ca385ef420a49d3b738c7606a79d7a62a6bedcbf74cd383e7", size = 13055300, upload-time = "2026-07-09T13:51:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/0f/45f4f3e56a6483ea9f88478b20d6b434718e7c46579239589202e5135ec1/zensical-0.0.50-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8813d1f8895b19520d4a982d6bfcfd06372d73d96e6a63f0d2cf8f3b6036d5a1", size = 13445447, upload-time = "2026-07-09T13:51:43.106Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9b/1f5065c664afde6a63e0ada8c14eae75f9e6960df597a5ca28c07340f938/zensical-0.0.50-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a64f957f94f7d8e8847a7f1e8205509ba4b188c93c157c5e7be49bcb8556a127", size = 13098775, upload-time = "2026-07-09T13:51:46.437Z" },
+    { url = "https://files.pythonhosted.org/packages/46/65/1e42e18d8f9a0cb9fcc8b871852810c7fe196237b79aaa831e863325091e/zensical-0.0.50-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:781d333bcb42c6a6b92360e05eadc944e2674794e1a95537971de1bf64cb9f89", size = 13305922, upload-time = "2026-07-09T13:51:51.107Z" },
+    { url = "https://files.pythonhosted.org/packages/50/36/9cace194ba13aef3bdde8ca2d327f3a05cdf5c456e94f6d896852e2cbd38/zensical-0.0.50-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:5d0f86eec76c23efb04566cd444bf025845ac8a02e75c8a6b4af13a39a2a9955", size = 13325488, upload-time = "2026-07-09T13:51:54.883Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/2891a9316e486794dae43151561b49f3313499cfb2c95c7886abad7bcf2d/zensical-0.0.50-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:392a7299a3c4d1ac7ff288bbed181d77a9fd23e6614180476e01630aaee0d67e", size = 13496866, upload-time = "2026-07-09T13:51:58.257Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/09/fbd3af58081a0d399fa913ef1f2fd6a007f2f06f7026c8d6a6096e34b996/zensical-0.0.50-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cac3448d8c8a76dfb43e55908b4ca9ad17596aee89a9287a184c1a0ba7dce2a2", size = 13437565, upload-time = "2026-07-09T13:52:01.766Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/79/709311ff202326260ff223fb6e9ddefa3100474c428e3c70a04036cefe0e/zensical-0.0.50-cp310-abi3-win32.whl", hash = "sha256:32b244f96a930f68e049b2e03d50790c120ef701b6277ddd854905a33040c75f", size = 12371966, upload-time = "2026-07-09T13:52:05.207Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e1/4babb30544d7465c95a6a93abc0680b1c51752411a225c2b7f2cb44e80c7/zensical-0.0.50-cp310-abi3-win_amd64.whl", hash = "sha256:2f054769bf96ae46353de3eca2463ad4db6df1da9fde515c6d7fc54c3608e615", size = 12604832, upload-time = "2026-07-09T13:52:09.013Z" },
 ]
 
 [[package]]

--- a/xnano-core/Cargo.toml
+++ b/xnano-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xnano-core"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/hsaeed3/xnano"
@@ -24,15 +24,31 @@ name = "xnano_core"
 crate-type = ["cdylib", "rlib"]
 path = "rust/src/lib.rs"
 
+[features]
+# The crossterm-backed terminal engine. Emscripten (Pyodide/WebAssembly)
+# wheels build with --no-default-features because crossterm's event
+# machinery cannot compile to wasm (mio has no WebAssembly support);
+# those builds ship rendering primitives plus stub session classes.
+default = ["terminal"]
+# ratatui/underline-color also lives here because it enables
+# dep:crossterm inside ratatui.
+terminal = [
+    "dep:crossterm",
+    "ratatui/crossterm",
+    "ratatui/underline-color",
+]
+
 [dependencies]
-crossterm = "0.28"
+crossterm = { version = "0.28", optional = true }
 palette = "0.7"
 pyo3 = { version = "0.29.0", features = [
     "extension-module",
     "abi3-py310",
     "generate-import-lib",
 ] }
-ratatui = { version = "0.29", features = ["palette", "underline-color"] }
+ratatui = { version = "0.29", default-features = false, features = [
+    "palette",
+] }
 ratatui-core = "0.1"
 tachyonfx = "0.25"
 lru = "0.16.3"

--- a/xnano-core/pyproject.toml
+++ b/xnano-core/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.9.4,<2.0"]
+requires = ["maturin>=1.14,<2.0"]
 build-backend = "maturin"
 
 [tool.maturin]
@@ -42,7 +42,7 @@ Documentation = "https://xnano.dev"
 
 [dependency-groups]
 dev = [
-    "maturin>=1.9.4,<2.0",
+    "maturin>=1.14,<2.0",
     "prek",
     "logfire",
     "black",

--- a/xnano-core/rust/src/bindings/crossterm_types.rs
+++ b/xnano-core/rust/src/bindings/crossterm_types.rs
@@ -1,0 +1,187 @@
+//! Portable mirrors of `crossterm::event` types for Emscripten builds.
+//!
+//! crossterm's `events` feature cannot compile for
+//! `wasm32-unknown-emscripten` (mio has no WebAssembly support), so
+//! Pyodide builds compile the event *types* from this module instead.
+//! Variant sets and bitflag values are copied verbatim from
+//! crossterm 0.28 so that key/mouse event data stays wire-compatible
+//! with native builds. No event *source* exists on Emscripten; these
+//! types only keep the binding structs and key-binding parser
+//! compiling.
+
+/// Mirror of `crossterm::event::KeyModifiers` (bitflags over `u8`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyModifiers {
+    bits: u8,
+}
+
+impl KeyModifiers {
+    pub const SHIFT: Self = Self { bits: 0b0000_0001 };
+    pub const CONTROL: Self = Self { bits: 0b0000_0010 };
+    pub const ALT: Self = Self { bits: 0b0000_0100 };
+    pub const SUPER: Self = Self { bits: 0b0000_1000 };
+    pub const HYPER: Self = Self { bits: 0b0001_0000 };
+    pub const META: Self = Self { bits: 0b0010_0000 };
+    pub const NONE: Self = Self { bits: 0b0000_0000 };
+
+    const ALL_BITS: u8 = 0b0011_1111;
+
+    pub const fn bits(&self) -> u8 {
+        self.bits
+    }
+
+    pub const fn from_bits_truncate(bits: u8) -> Self {
+        Self {
+            bits: bits & Self::ALL_BITS,
+        }
+    }
+
+    pub const fn contains(&self, other: Self) -> bool {
+        (self.bits & other.bits) == other.bits
+    }
+}
+
+/// Mirror of `crossterm::event::KeyEventState` (bitflags over `u8`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyEventState {
+    bits: u8,
+}
+
+impl KeyEventState {
+    pub const KEYPAD: Self = Self { bits: 0b0000_0001 };
+    pub const CAPS_LOCK: Self = Self { bits: 0b0000_0010 };
+    pub const NUM_LOCK: Self = Self { bits: 0b0000_0100 };
+    pub const NONE: Self = Self { bits: 0b0000_0000 };
+
+    const ALL_BITS: u8 = 0b0000_0111;
+
+    pub const fn bits(&self) -> u8 {
+        self.bits
+    }
+
+    pub const fn from_bits_truncate(bits: u8) -> Self {
+        Self {
+            bits: bits & Self::ALL_BITS,
+        }
+    }
+
+    pub const fn contains(&self, other: Self) -> bool {
+        (self.bits & other.bits) == other.bits
+    }
+}
+
+/// Mirror of `crossterm::event::KeyEventKind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyEventKind {
+    Press,
+    Repeat,
+    Release,
+}
+
+/// Mirror of `crossterm::event::MediaKeyCode`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaKeyCode {
+    Play,
+    Pause,
+    PlayPause,
+    Reverse,
+    Stop,
+    FastForward,
+    Rewind,
+    TrackNext,
+    TrackPrevious,
+    Record,
+    LowerVolume,
+    RaiseVolume,
+    MuteVolume,
+}
+
+/// Mirror of `crossterm::event::ModifierKeyCode`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModifierKeyCode {
+    LeftShift,
+    LeftControl,
+    LeftAlt,
+    LeftSuper,
+    LeftHyper,
+    LeftMeta,
+    RightShift,
+    RightControl,
+    RightAlt,
+    RightSuper,
+    RightHyper,
+    RightMeta,
+    IsoLevel3Shift,
+    IsoLevel5Shift,
+}
+
+/// Mirror of `crossterm::event::KeyCode`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyCode {
+    Backspace,
+    Enter,
+    Left,
+    Right,
+    Up,
+    Down,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    Tab,
+    BackTab,
+    Delete,
+    Insert,
+    F(u8),
+    Char(char),
+    Null,
+    Esc,
+    CapsLock,
+    ScrollLock,
+    NumLock,
+    PrintScreen,
+    Pause,
+    Menu,
+    KeypadBegin,
+    Media(MediaKeyCode),
+    Modifier(ModifierKeyCode),
+}
+
+/// Mirror of `crossterm::event::KeyEvent`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyEvent {
+    pub code: KeyCode,
+    pub modifiers: KeyModifiers,
+    pub kind: KeyEventKind,
+    pub state: KeyEventState,
+}
+
+/// Mirror of `crossterm::event::MouseButton`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseButton {
+    Left,
+    Right,
+    Middle,
+}
+
+/// Mirror of `crossterm::event::MouseEventKind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseEventKind {
+    Down(MouseButton),
+    Up(MouseButton),
+    Drag(MouseButton),
+    Moved,
+    ScrollDown,
+    ScrollUp,
+    ScrollLeft,
+    ScrollRight,
+}
+
+/// Mirror of `crossterm::event::MouseEvent`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MouseEvent {
+    pub kind: MouseEventKind,
+    pub column: u16,
+    pub row: u16,
+    pub modifiers: KeyModifiers,
+}

--- a/xnano-core/rust/src/bindings/engine/events.rs
+++ b/xnano-core/rust/src/bindings/engine/events.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "terminal")]
 use crossterm::event::Event as CtEvent;
 use pyo3::prelude::*;
 
@@ -42,6 +43,7 @@ pub struct PyEvent {
 }
 
 impl PyEvent {
+    #[cfg_attr(not(feature = "terminal"), allow(dead_code))]
     pub(crate) fn tick(elapsed_ms: u64) -> Self {
         Self {
             kind: PyTerminalEventKind::Tick,
@@ -54,6 +56,7 @@ impl PyEvent {
         }
     }
 
+    #[cfg(feature = "terminal")]
     pub(crate) fn from_crossterm(ev: CtEvent) -> Self {
         match ev {
             CtEvent::Key(key) => Self {

--- a/xnano-core/rust/src/bindings/engine/key_binding.rs
+++ b/xnano-core/rust/src/bindings/engine/key_binding.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "terminal")]
 use crossterm::event::{KeyCode, KeyModifiers};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+
+#[cfg(not(feature = "terminal"))]
+use super::super::crossterm_types::{KeyCode, KeyModifiers};
 
 use super::super::terminal::PyKeyEvent;
 

--- a/xnano-core/rust/src/bindings/engine/mod.rs
+++ b/xnano-core/rust/src/bindings/engine/mod.rs
@@ -1,11 +1,19 @@
+#[cfg(feature = "terminal")]
 mod clock;
 mod content_bridge;
 pub(crate) mod events;
 mod key_binding;
+#[cfg(feature = "terminal")]
 mod panic_hook;
 mod render_ir;
 mod render_tree;
+#[cfg(feature = "terminal")]
 mod session;
+#[cfg(not(feature = "terminal"))]
+mod session_stub;
+#[cfg(not(feature = "terminal"))]
+use session_stub as session;
+#[cfg(feature = "terminal")]
 pub(crate) mod terminal_reset;
 
 use pyo3::prelude::*;

--- a/xnano-core/rust/src/bindings/engine/session_stub.rs
+++ b/xnano-core/rust/src/bindings/engine/session_stub.rs
@@ -1,0 +1,50 @@
+//! Emscripten stand-ins for the native terminal session classes.
+//!
+//! `CoreSession` and `CoreTerminalRef` drive a real terminal through
+//! crossterm, which cannot exist under Pyodide/WebAssembly. The stubs
+//! keep the `xnano_core.rust.engine` import surface identical across
+//! platforms while failing loudly if terminal functionality is used.
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
+
+const UNSUPPORTED_MESSAGE: &str = "the xnano-core terminal engine is not \
+     available on Emscripten/WebAssembly builds; only rendering \
+     primitives are supported in this environment";
+
+#[pyclass(name = "CoreSession", module = "xnano_core.rust.engine", unsendable)]
+pub struct PySession;
+
+#[pymethods]
+impl PySession {
+    #[new]
+    #[pyo3(signature = (*args, **kwargs))]
+    fn new(
+        args: &Bound<'_, PyTuple>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Self> {
+        let _ = (args, kwargs);
+        Err(PyRuntimeError::new_err(UNSUPPORTED_MESSAGE))
+    }
+}
+
+#[pyclass(
+    name = "CoreTerminalRef",
+    module = "xnano_core.rust.engine",
+    unsendable
+)]
+pub struct PyTerminalRef;
+
+#[pymethods]
+impl PyTerminalRef {
+    #[new]
+    #[pyo3(signature = (*args, **kwargs))]
+    fn new(
+        args: &Bound<'_, PyTuple>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Self> {
+        let _ = (args, kwargs);
+        Err(PyRuntimeError::new_err(UNSUPPORTED_MESSAGE))
+    }
+}

--- a/xnano-core/rust/src/bindings/mod.rs
+++ b/xnano-core/rust/src/bindings/mod.rs
@@ -1,10 +1,16 @@
 mod buffer;
+#[cfg(feature = "terminal")]
 mod command;
 mod convert;
 mod convert_core;
+#[cfg(feature = "terminal")]
 mod crossterm_exec;
+#[cfg(not(feature = "terminal"))]
+pub(crate) mod crossterm_types;
+#[cfg(feature = "terminal")]
 mod cursor;
 mod engine;
+#[cfg(feature = "terminal")]
 mod event_setup;
 mod frame_ext;
 mod fx;
@@ -12,6 +18,7 @@ mod layout;
 mod palette;
 mod style;
 mod terminal;
+#[cfg(feature = "terminal")]
 mod terminal_device;
 mod text;
 mod widgets;
@@ -28,10 +35,13 @@ pub fn register(native: &Bound<'_, PyModule>) -> PyResult<()> {
     widgets_extra::register(native)?;
     buffer::register(native)?;
     terminal::register(native)?;
-    cursor::register(native)?;
-    terminal_device::register(native)?;
-    event_setup::register(native)?;
-    command::register(native)?;
+    #[cfg(feature = "terminal")]
+    {
+        cursor::register(native)?;
+        terminal_device::register(native)?;
+        event_setup::register(native)?;
+        command::register(native)?;
+    }
     fx::register(native)?;
 
     let engine = PyModule::new(native.py(), "engine")?;

--- a/xnano-core/rust/src/bindings/style.rs
+++ b/xnano-core/rust/src/bindings/style.rs
@@ -270,12 +270,14 @@ impl PyStyle {
         }
     }
 
+    #[cfg(feature = "terminal")]
     fn underline_color(&self, color: PyColor) -> Self {
         Self {
             inner: self.inner.underline_color(color.inner),
         }
     }
 
+    #[cfg(feature = "terminal")]
     fn get_underline_color(&self) -> Option<PyColor> {
         self.inner.underline_color.map(PyColor::from)
     }

--- a/xnano-core/rust/src/bindings/terminal.rs
+++ b/xnano-core/rust/src/bindings/terminal.rs
@@ -1,15 +1,25 @@
+#[cfg(feature = "terminal")]
 use std::time::Duration;
 
+#[cfg(feature = "terminal")]
 use crossterm::event::{
     self, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent,
     MouseEventKind,
 };
 use pyo3::prelude::*;
 use ratatui::Frame;
+#[cfg(feature = "terminal")]
 use ratatui::{init, restore, DefaultTerminal};
 
 use super::buffer::{render_stateful_inner, render_widget_inner, PyBuffer};
+#[cfg(feature = "terminal")]
 use super::crossterm_exec::io_to_py;
+#[cfg(not(feature = "terminal"))]
+use super::crossterm_types::{
+    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent,
+    MouseEventKind,
+};
+#[cfg(feature = "terminal")]
 use super::engine::events::PyEvent;
 use super::convert_core::{sync_from_core_buffer, sync_to_core_buffer, to_core_rect};
 use super::frame_ext::frame_hide_cursor;
@@ -646,11 +656,13 @@ impl From<KeyEvent> for PyKeyEvent {
     }
 }
 
+#[cfg(feature = "terminal")]
 #[pyclass(name = "Terminal", module = "xnano_core.rust.native", unsendable)]
 pub struct PyTerminal {
     inner: DefaultTerminal,
 }
 
+#[cfg(feature = "terminal")]
 #[pymethods]
 impl PyTerminal {
     #[staticmethod]
@@ -742,11 +754,13 @@ impl PyTerminal {
     }
 }
 
+#[cfg(feature = "terminal")]
 #[pyfunction]
 fn restore_terminal() {
     restore();
 }
 
+#[cfg(feature = "terminal")]
 #[pyfunction]
 fn poll_event(py: Python<'_>, timeout_ms: u64) -> PyResult<Option<PyEvent>> {
     let ready = py
@@ -760,6 +774,7 @@ fn poll_event(py: Python<'_>, timeout_ms: u64) -> PyResult<Option<PyEvent>> {
     Ok(Some(PyEvent::from_crossterm(ev)))
 }
 
+#[cfg(feature = "terminal")]
 #[pyfunction]
 fn read_event(py: Python<'_>) -> PyResult<PyEvent> {
     loop {
@@ -772,6 +787,7 @@ fn read_event(py: Python<'_>) -> PyResult<PyEvent> {
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyFrame>()?;
     m.add_class::<PyCompletedFrame>()?;
+    #[cfg(feature = "terminal")]
     m.add_class::<PyTerminal>()?;
     m.add_class::<PyKeyEventKind>()?;
     m.add_class::<PyKeyEventState>()?;
@@ -781,8 +797,11 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyMouseEventKind>()?;
     m.add_class::<PyMouseEvent>()?;
     m.add_class::<PyKeyEvent>()?;
-    m.add_function(wrap_pyfunction!(restore_terminal, m)?)?;
-    m.add_function(wrap_pyfunction!(poll_event, m)?)?;
-    m.add_function(wrap_pyfunction!(read_event, m)?)?;
+    #[cfg(feature = "terminal")]
+    {
+        m.add_function(wrap_pyfunction!(restore_terminal, m)?)?;
+        m.add_function(wrap_pyfunction!(poll_event, m)?)?;
+        m.add_function(wrap_pyfunction!(read_event, m)?)?;
+    }
     Ok(())
 }

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -6,7 +6,7 @@
 >>> from xnano import BaseGrid, Field, Terminal
 """
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 from typing import TYPE_CHECKING
 

--- a/xnano/_dispatch.py
+++ b/xnano/_dispatch.py
@@ -12,7 +12,6 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Coroutine, Sequence, cast
 
-from xnano._core_bindings import get_area_from_native_rect
 from xnano._function_hooks import (
     _EventHooksRegistry,
     _OnFieldHookFunctionEntry,
@@ -420,6 +419,8 @@ def render_frame(
     terminal._mouse_geometry_active = (
         terminal.mouse_events and is_grid and root._grid_needs_mouse_geometry()
     )
+    from xnano._core_bindings import get_area_from_native_rect
+
     sess = terminal.session
     sess.begin_viewport_frame()
     viewport = get_area_from_native_rect(sess.get_native_viewport_area())

--- a/xnano/_renderable.py
+++ b/xnano/_renderable.py
@@ -313,6 +313,40 @@ def _abstract_component_to_lines(value: Any) -> list[str] | None:
     return repr(value).splitlines() or [""]
 
 
+def _base_grid_to_lines(value: Any) -> list[str] | None:
+    """Plain-text fallback for ``BaseGrid`` outside a live terminal session.
+
+    Used by Pyodide / stdout ``render()`` so interactive docs can show field
+    content without ``xnano-core``.
+    """
+    # Duck-type via ClassVar maps set by ``BaseGrid`` metaclass.
+    render_fields = getattr(type(value), "_grid_fields", None)
+    if not isinstance(render_fields, Mapping) or not render_fields:
+        return None
+
+    lines: list[str] = []
+    for name, info in render_fields.items():
+        if getattr(info, "state", False):
+            continue
+        field_value = getattr(value, name, None)
+        if field_value is None:
+            continue
+        border = getattr(info, "border", None)
+        title = getattr(info, "title", None) or (name if border else None)
+        field_lines = _renderable_to_lines(field_value)
+        if border:
+            field_lines = _apply_border(
+                field_lines,
+                border,
+                getattr(info, "border_sides", None),
+                "",
+                title,
+                getattr(info, "title_position", None),
+            )
+        lines.extend(field_lines)
+    return lines or [f"[{type(value).__name__}]"]
+
+
 def _renderable_to_lines(value: Any) -> list[str]:
     """Convert a renderable to display lines (ANSI allowed for styled Text)."""
     component_lines = _abstract_component_to_lines(value)
@@ -327,6 +361,9 @@ def _renderable_to_lines(value: Any) -> list[str]:
         for item in value:
             lines.extend(_renderable_to_lines(item))
         return lines
+    grid_lines = _base_grid_to_lines(value)
+    if grid_lines is not None:
+        return grid_lines
     return repr(value).splitlines() or [""]
 
 
@@ -709,9 +746,7 @@ def render(
     sep_value = " " if sep is None else sep
     end_value = "\n" if end is None else end
 
-    from xnano._core_bindings import get_area_from_native_rect
     from xnano.fields import GridFieldInfo
-    from xnano.tui.terminal import _ACTIVE_TERMINAL
 
     field = GridFieldInfo(
         color=color,
@@ -727,7 +762,16 @@ def render(
         direction=direction,
     )
 
-    terminal = _ACTIVE_TERMINAL.get()
+    # Native / live-session imports are deferred so pure-Python installs
+    # (e.g. Pyodide docs via micropip) can use the stdout ANSI path without
+    # ``xnano-core`` being present.
+    try:
+        from xnano.tui.terminal import _ACTIVE_TERMINAL
+
+        terminal = _ACTIVE_TERMINAL.get()
+    except ImportError:
+        terminal = None
+
     stream_id = _normalize_stream_id(stream)
 
     # Explicit non-stdout file always takes the text path, even mid-session.
@@ -757,6 +801,8 @@ def render(
     if terminal is not None and getattr(terminal, "_is_live", False):
         # Prefer the terminal's full paint path when a live session owns the
         # display — streams re-paint the whole region with the latest content.
+        from xnano._core_bindings import get_area_from_native_rect
+
         if stream_id is not None:
             region = _STREAM_REGIONS.setdefault(stream_id, _StreamRegion())
             if update or not region.renderables:


### PR DESCRIPTION
## Summary

- **xnano-core**: the crossterm-backed terminal engine now sits behind a default-on `terminal` cargo feature; Emscripten wheels build with `--no-default-features` (crossterm's event machinery depends on mio, which cannot compile to wasm). Wasm builds keep the full render stack (widgets, buffers, render IR/tree, effects, styles), portable mirrors of crossterm's event types, and stub `CoreSession`/`CoreTerminalRef` classes that raise `RuntimeError` — the Python import surface is identical across platforms. Native builds are unchanged (all 1340 tests pass).
- **xnano**: defers the `_core_bindings` import in `render_frame` and adds a plain-text `BaseGrid` fallback so `render()` works in Pyodide / stdout environments.
- **CI**: new `build-xnano-core-wasm` job builds the PEP 783 `pyemscripten_2025_0_wasm32` wheel with pyodide-build, and `test-xnano-core-wasm-wheel` installs it into a `pyodide venv` under node and runs a smoke test. The wheel artifact rides the existing `pypi_files_xnano_core_*` glob, so it is published to PyPI and the GitHub release alongside the native wheels — no separate wasm tag needed.
- **Versions**: xnano 1.0.3, xnano-core 0.0.9; maturin `>=1.14` for PEP 783 tag support.

## Notes

- xnano-core's MSRV (1.88) is newer than pyodide 0.29's pinned rust nightly, so CI overrides `RUST_TOOLCHAIN=nightly-2025-06-27` and installs the pyodide team's prebuilt wasm-eh sysroot manually; the workflow comments explain when the override can be dropped.

## Test plan

- [x] `cargo check` for both feature configurations, plus `wasm32-unknown-emscripten`
- [x] Full native test suite (1340 passed)
- [x] Wheel built locally end-to-end with `pyodide build`, passes `twine check`, installs into a `pyodide venv`, and the smoke test passes inside the wasm runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)