### PR TITLE
release(xnano/v1.0.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.0.6"
+pip install "xnano>=1.0.7"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.0.6"
+uv add "xnano>=1.0.7"
 ```
 
 > [!TIP]

--- a/docs/xnano/getting-started.md
+++ b/docs/xnano/getting-started.md
@@ -22,13 +22,13 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "pip"
 
     ```bash
-    pip install "xnano>=1.0.6"
+    pip install "xnano>=1.0.7"
     ```
 
 === "uv"
 
     ```bash
-    uv pip install "xnano>=1.0.6"
+    uv pip install "xnano>=1.0.7"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -37,7 +37,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "poetry"
 
     ```bash
-    poetry install "xnano>=1.0.6"
+    poetry install "xnano>=1.0.7"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -46,7 +46,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "conda"
 
     ```bash
-    conda install "xnano>=1.0.6"
+    conda install "xnano>=1.0.7"
     ```
 
 ## What is xnano?
@@ -70,7 +70,7 @@ The main featureset of the library revolves around it's rust-based terminal rend
 
     The following example is interactive and can be run directly in the browser by hitting the <kbd>Run</kbd> button.
 
-```pyodide install="xnano>=1.0.5"
+```pyodide install="xnano>=1.0.7"
 import xnano
 
 xnano.render("hello, terminal!", color="blue")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.0.6"
+version = "1.0.7"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -630,7 +630,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.13'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -2586,7 +2586,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-core" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -6,7 +6,7 @@
 >>> from xnano import BaseGrid, Field, Terminal
 """
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 from typing import TYPE_CHECKING
 
@@ -30,7 +30,11 @@ if TYPE_CHECKING:
         on_tick,
     )
     from xnano.fields import Field
-    from xnano.grid import BaseGrid, Grid, GridSettings
+    from xnano.grid import (
+        BaseGrid,
+        Grid,  # ty: ignore[deprecated]
+        GridSettings,
+    )
     from xnano.tui.terminal import Terminal
 
 
@@ -86,9 +90,20 @@ def __getattr__(name: str):
         return BaseGrid
 
     elif name == "Grid":
-        from xnano.grid import Grid
+        from xnano.grid import Grid  # ty: ignore[deprecated]
+        import os as _os
+        _ignore = _os.environ.get("XNANO_IGNORE_DEPRECATION_WARNINGS")
+        if _ignore is None or not _ignore.lower() in ["1", "true", "yes", "y"]:
+            import warnings
 
-        return Grid
+            warnings.warn(
+                "Grid is deprecated and will be removed in a future version. Use BaseGrid instead.\n"
+                "You can set the `XNANO_IGNORE_DEPRECATION_WARNINGS` environment variable to ignore this warning.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return Grid  # ty: ignore[deprecated]
 
     elif name == "GridSettings":
         from xnano.grid import GridSettings


### PR DESCRIPTION
## Summary
- Bump xnano version to 1.0.7 across pyproject.toml, uv.lock, xnano/__init__.py, README.md, and docs/xnano/getting-started.md install pins.
- Fix ty deprecation warnings raised by xnano's own internal re-export of the deprecated `Grid` alias in `__init__.py`.

## Test plan
- [ ] `uv run ty check` no longer reports deprecation warnings for `Grid` re-exports
- [ ] `uv run pytest`