### PR TITLE
release(xnano/v1.0.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.0.7"
+pip install "xnano>=1.0.8"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.0.7"
+uv add "xnano>=1.0.8"
 ```
 
 > [!TIP]

--- a/docs/xnano/getting-started.md
+++ b/docs/xnano/getting-started.md
@@ -22,13 +22,13 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "pip"
 
     ```bash
-    pip install "xnano>=1.0.7"
+    pip install "xnano>=1.0.8"
     ```
 
 === "uv"
 
     ```bash
-    uv pip install "xnano>=1.0.7"
+    uv pip install "xnano>=1.0.8"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -37,7 +37,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "poetry"
 
     ```bash
-    poetry install "xnano>=1.0.7"
+    poetry install "xnano>=1.0.8"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -46,7 +46,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "conda"
 
     ```bash
-    conda install "xnano>=1.0.7"
+    conda install "xnano>=1.0.8"
     ```
 
 ## What is xnano?
@@ -70,7 +70,7 @@ The main featureset of the library revolves around it's rust-based terminal rend
 
     The following example is interactive and can be run directly in the browser by hitting the <kbd>Run</kbd> button.
 
-```pyodide install="xnano>=1.0.7"
+```pyodide install="xnano>=1.0.8"
 import xnano
 
 xnano.render("hello, terminal!", color="blue")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.0.7"
+version = "1.0.8"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/tests/test_pyodide_render.py
+++ b/tests/test_pyodide_render.py
@@ -1,0 +1,274 @@
+"""Tests for ``Terminal._render_buffer_backed`` — the wasm/Pyodide path.
+
+Pyodide (and any other build of ``xnano-core`` without the ``terminal``
+cargo feature) never has a live terminal to attach to, so a one-shot
+``render()`` call goes through ``Terminal._render_buffer_backed``: it sizes
+an offscreen ``CoreSession`` buffer and paints one frame into it, with no
+event loop. This module can't build an actual wasm wheel, so it forces the
+same code path locally by monkeypatching ``Terminal._supports_live_terminal``
+to ``False`` and going through the public ``render()`` entry point — the
+same one a ``xnano.render(...)`` call inside a ``pyodide`` fence hits.
+
+Passing ``file=`` to ``render()`` is deliberately avoided here: it routes to
+a completely different renderer (``xnano._renderable.render``, the plain
+ANSI-fallback path already covered by ``test_render_fallback.py``) and never
+reaches ``_render_buffer_backed`` at all. Only the default-stdout call shape
+(no ``file``/``stream``/``update``) takes the buffer-backed path, so these
+tests capture real stdout via ``capsys`` instead.
+
+Regression coverage in here guards two distinct bugs found while writing the
+``core-concepts/grids.md`` interactive example:
+
+1. A lone ``BaseGrid`` renderable was never routed through ``root=`` into
+   ``_dispatch.render_frame``, so ``isinstance(root, BaseGrid)`` was always
+   ``False`` and the grid's fields never got laid out — only whatever the
+   inline/text path happened to paint (effectively one line).
+2. Multiple plain (non-grid) renderables were measured with
+   ``measure_renderable`` instead of ``measure_renderable_in_field``,
+   dropping border/padding overhead from the offscreen buffer's height.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xnano.fields import Field
+from xnano.grid import BaseGrid
+from xnano.tui import Terminal
+
+
+@pytest.fixture(autouse=True)
+def _force_headless(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every ``Terminal`` in this module think it's a wasm build.
+
+    Without this, ``Terminal.render()`` on a real desktop build takes the
+    live-terminal branch instead of ``_render_buffer_backed`` — the one
+    Pyodide actually uses.
+    """
+    monkeypatch.setattr(
+        Terminal, "_supports_live_terminal", staticmethod(lambda: False)
+    )
+
+
+def _render(
+    *renderables: Any,
+    capsys: pytest.CaptureFixture[str],
+    width: Any = None,
+    height: Any = None,
+    **render_kwargs: Any,
+) -> str:
+    Terminal(width=width, height=height).render(*renderables, **render_kwargs)
+    return capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Regression: a lone BaseGrid root must drive the real layout engine
+# ---------------------------------------------------------------------------
+
+
+def test_grid_root_renders_every_field_not_just_first_line(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class App(BaseGrid, direction="vertical"):
+        title: str = Field(default="My App", border="rounded")
+        body: str = Field(default="Hello, world!")
+
+    out = _render(App(), capsys=capsys)
+    lines = out.splitlines()
+    assert lines[0].startswith("╭")
+    assert any("My App" in line for line in lines)
+    assert any(line.startswith("╰") for line in lines)
+    assert any("Hello, world!" in line for line in lines)
+
+
+def test_grid_root_with_explicit_height_still_lays_out_fields(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class App(BaseGrid, direction="vertical"):
+        title: str = Field(default="My App", border="rounded")
+        body: str = Field(default="Hello, world!")
+
+    out = _render(App(), capsys=capsys, height=4)
+    lines = out.splitlines()
+    assert len(lines) == 4
+    assert lines[0].startswith("╭")
+    assert "My App" in lines[1]
+    assert lines[2].startswith("╰")
+    assert "Hello, world!" in lines[3]
+
+
+def test_grid_root_default_sizing_is_not_one_line(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # No explicit height/width: falls back to the 80x24 default viewport,
+    # same as a live terminal would, rather than a bogus str()-based guess.
+    class App(BaseGrid, direction="vertical"):
+        title: str = Field(default="My App", border="rounded")
+        body: str = Field(default="Hello, world!")
+
+    out = _render(App(), capsys=capsys)
+    lines = out.splitlines()
+    assert len(lines) > 1
+    assert any("Hello, world!" in line for line in lines)
+
+
+def test_grid_root_state_field_is_never_painted(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class App(BaseGrid, direction="vertical"):
+        title: str = Field(default="My App", border="rounded")
+        body: str = Field(default="")
+        name: str = Field(default="Hammad", state=True)
+
+        def __post_init__(self) -> None:
+            self.body = f"Hello, {self.name}!"
+
+    out = _render(App(), capsys=capsys, height=4)
+    assert "Hammad" not in out.split("Hello,", 1)[0]
+    assert "Hello, Hammad!" in out
+
+
+def test_nested_grid_root_still_lays_out_through_buffer_backed_path(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class Inner(BaseGrid, direction="vertical"):
+        label: str = Field(default="inner", border="rounded")
+
+    class Outer(BaseGrid, direction="vertical"):
+        inner: Inner = Field(default_factory=Inner)
+        footer: str = Field(default="footer text")
+
+    out = _render(Outer(), capsys=capsys, height=6)
+    lines = out.splitlines()
+    assert any("inner" in line for line in lines)
+    assert any("footer text" in line for line in lines)
+
+
+def test_grid_mixed_with_other_renderables_is_a_known_gap(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # KNOWN LIMITATION, not asserted as desired behavior: the BaseGrid
+    # routing fix only applies when the grid is the *sole* renderable.
+    # Mixed in with anything else, its own field content is lost entirely —
+    # only the group's shared border/footer text paints. Pinned here so a
+    # future fix for this case is a deliberate change, not a silent one, and
+    # so nobody mistakes this for already being covered by the routing fix.
+    class App(BaseGrid, direction="vertical"):
+        title: str = Field(default="My App", border="rounded")
+
+    out = _render(App(), "footer", capsys=capsys)
+    assert "footer" in out
+    assert "My App" not in out
+
+
+# ---------------------------------------------------------------------------
+# Regression: multiple plain (non-grid) renderables keep border overhead
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_bordered_renderables_each_keep_full_border(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    out = _render("line one", "line two", capsys=capsys, border="rounded")
+    assert out.count("╭") == 2
+    assert out.count("╰") == 2
+    assert "line one" in out
+    assert "line two" in out
+
+
+def test_multiple_renderables_height_matches_bordered_row_count(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Two bordered single-line renderables: 3 rows each (top/content/bottom).
+    out = _render("a", "b", capsys=capsys, border="rounded")
+    assert len(out.splitlines()) == 6
+
+
+def test_single_non_grid_renderable_with_border_unaffected_by_grid_fix(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    out = _render("solo", capsys=capsys, border="rounded")
+    lines = out.splitlines()
+    assert lines[0].startswith("╭")
+    assert "solo" in lines[1]
+    assert lines[2].startswith("╰")
+
+
+# ---------------------------------------------------------------------------
+# Sizing overrides on the buffer-backed path
+#
+# Explicit ``width=``/``height=`` on ``Terminal`` control the *offscreen
+# buffer* allocation, not necessarily how much of it fit-width/fit-height
+# inline content stretches to fill — so these assert on the ``cols=``/
+# ``rows=`` actually handed to ``CoreSession.offscreen`` rather than on
+# rendered text width, which auto-fit content wouldn't reflect anyway.
+# ---------------------------------------------------------------------------
+
+
+def _offscreen_dims(
+    *renderables: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    width: Any = None,
+    height: Any = None,
+    **render_kwargs: Any,
+) -> tuple[int, int]:
+    calls: list[tuple[int, int]] = []
+    real_offscreen = Terminal.offscreen.__func__
+
+    def _spy(cls: type[Terminal[Any]], *, cols: int, rows: int, **kwargs: Any) -> Terminal[Any]:
+        calls.append((cols, rows))
+        return real_offscreen(cls, cols=cols, rows=rows, **kwargs)
+
+    monkeypatch.setattr(Terminal, "offscreen", classmethod(_spy))
+    Terminal(width=width, height=height).render(*renderables, **render_kwargs)
+    assert calls, "offscreen() was never called"
+    return calls[0]
+
+
+def test_explicit_width_overrides_measured_width(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cols, _ = _offscreen_dims(
+        "hi", monkeypatch=monkeypatch, width=30, border="plain"
+    )
+    assert cols == 30
+
+
+def test_explicit_height_overrides_measured_height(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, rows = _offscreen_dims("hi", monkeypatch=monkeypatch, height=12)
+    assert rows == 12
+
+
+def test_default_width_and_height_when_nothing_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cols, rows = _offscreen_dims("hi", monkeypatch=monkeypatch)
+    assert (cols, rows) == (2, 1)
+
+
+def test_explicit_height_smaller_than_content_truncates(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    out = _render("a\nb\nc\nd\ne", capsys=capsys, height=2)
+    assert out.splitlines() == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# print()-compatible kwargs still work through the buffer-backed path
+# ---------------------------------------------------------------------------
+
+
+def test_end_kwarg_is_respected(capsys: pytest.CaptureFixture[str]) -> None:
+    out = _render("no-newline", capsys=capsys, end="")
+    assert out == "no-newline"
+
+
+def test_flush_does_not_raise(capsys: pytest.CaptureFixture[str]) -> None:
+    # flush=True on a headless render just needs to not blow up — there's no
+    # custom file object here to assert flush-call-count against, since that
+    # would require passing file= (which skips this code path entirely).
+    _render("x", capsys=capsys, flush=True, end="")

--- a/uv.lock
+++ b/uv.lock
@@ -2586,7 +2586,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-core" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -6,7 +6,7 @@
 >>> from xnano import BaseGrid, Field, Terminal
 """
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 
 from typing import TYPE_CHECKING
 
@@ -90,8 +90,10 @@ def __getattr__(name: str):
         return BaseGrid
 
     elif name == "Grid":
-        from xnano.grid import Grid  # ty: ignore[deprecated]
         import os as _os
+
+        from xnano.grid import Grid  # ty: ignore[deprecated]
+
         _ignore = _os.environ.get("XNANO_IGNORE_DEPRECATION_WARNINGS")
         if _ignore is None or not _ignore.lower() in ["1", "true", "yes", "y"]:
             import warnings

--- a/xnano/tui/terminal.py
+++ b/xnano/tui/terminal.py
@@ -864,26 +864,39 @@ class Terminal(AbstractHost, Generic[StateT]):
         to ``file`` (default stdout). There is no interactive event loop.
         """
         from xnano import _dispatch
+        from xnano.grid import BaseGrid
+
+        # A lone ``BaseGrid`` root drives the full layout engine and sizes
+        # itself to the (default or explicitly set) viewport, the same as a
+        # live terminal — its content isn't measurable in isolation the way
+        # plain renderables are, since fields can fill/fraction-size against
+        # whatever area they're given.
+        root: Any = None
+        if len(renderables) == 1 and isinstance(renderables[0], BaseGrid):
+            root = renderables[0]
 
         # Prefer measured content size so the buffer matches the grid/layout.
         width = 80
         height = 24
         try:
-            if field is not None and len(renderables) == 1:
+            if root is not None:
+                pass
+            elif field is not None and len(renderables) == 1:
                 w, h = _dispatch.measure_renderable_in_field(
                     renderables[0], field
                 )
                 width = max(1, w)
                 height = max(1, h)
             elif renderables:
-                total_h = 0
                 max_w = 1
                 for item in renderables:
-                    w, h = _dispatch.measure_renderable(item)
+                    w, _ = _dispatch.measure_renderable_in_field(item, field)
                     max_w = max(max_w, w)
-                    total_h += h
                 width = max_w
-                height = max(1, total_h)
+                height = max(
+                    1,
+                    _dispatch.measure_renderables_height(renderables, field),
+                )
         except Exception:
             pass
 
@@ -914,7 +927,11 @@ class Terminal(AbstractHost, Generic[StateT]):
         )
         try:
             terminal._root_width_sizing = self._root_width_sizing
-            terminal._render_frame(renderables=tuple(renderables), field=field)
+            terminal._render_frame(
+                root,
+                renderables=None if root is not None else tuple(renderables),
+                field=field,
+            )
             text = terminal.get_output().rstrip("\n")
             out = sys.stdout if file is None else file
             out.write(text)


### PR DESCRIPTION
## Summary
- Bump xnano to 1.0.8 across pyproject.toml, uv.lock, xnano/__init__.py, README.md, and docs/xnano/getting-started.md install pins.
- Fix `Terminal._render_buffer_backed` (the wasm/Pyodide one-shot render path used when there's no live terminal to attach to):
  - A lone `BaseGrid` renderable was never routed through `root=` into `_dispatch.render_frame`, so `isinstance(root, BaseGrid)` was always `False` and the grid's fields never got laid out through the real layout engine — it collapsed to effectively one line.
  - Multiple plain (non-grid) renderables were sized with `measure_renderable` instead of `measure_renderable_in_field`, dropping border/padding overhead from the offscreen buffer height.
- Add `tests/test_pyodide_render.py`, a full regression suite for this path (grid routing, nested grids, border-overhead sizing, explicit width/height overrides, print-compatible kwargs, and a documented known limitation for grids mixed with other renderables).

## Test plan
- [x] `uv run pytest tests/test_pyodide_render.py` — 15 passed
- [x] `uv run pytest` — full suite, 1358 passed / 6 skipped
- [x] `uv run prek run --all-files` — all hooks pass, including `ty` type check