### PR TITLE
fix(pyodide): preserve terminal output colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.0.8"
+pip install "xnano>=1.0.9"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.0.8"
+uv add "xnano>=1.0.9"
 ```
 
 > [!TIP]

--- a/docs/js/pyodide-ansi.js
+++ b/docs/js/pyodide-ansi.js
@@ -1,0 +1,189 @@
+/* Render ANSI SGR emitted by client-side Python inside Pyodide output nodes. */
+(function installPyodideAnsi(global) {
+  "use strict";
+
+  const ESCAPE_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+  const OSC_PATTERN = /\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
+  const ANSI_COLORS = [
+    "#282a36",
+    "#ff5555",
+    "#50fa7b",
+    "#ffb86c",
+    "#6272a4",
+    "#bd93f9",
+    "#8be9fd",
+    "#f8f8f2",
+    "#6272a4",
+    "#ff6e6e",
+    "#69ff94",
+    "#ffffa5",
+    "#7b8ab8",
+    "#d6acff",
+    "#a4ffff",
+    "#ffffff",
+  ];
+
+  function escapeHtml(value) {
+    return value.replace(
+      /[&<>"']/g,
+      (character) =>
+        ({
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          '"': "&quot;",
+          "'": "&#39;",
+        })[character],
+    );
+  }
+
+  function getIndexedColor(index) {
+    if (index < 16) return ANSI_COLORS[index];
+    if (index < 232) {
+      const offset = index - 16;
+      const red = Math.floor(offset / 36);
+      const green = Math.floor((offset % 36) / 6);
+      const blue = offset % 6;
+      const channel = (value) => (value === 0 ? 0 : 55 + value * 40);
+      return `rgb(${channel(red)}, ${channel(green)}, ${channel(blue)})`;
+    }
+    const gray = 8 + (index - 232) * 10;
+    return `rgb(${gray}, ${gray}, ${gray})`;
+  }
+
+  function getSpanStyle(state) {
+    let foreground = state.foreground;
+    let background = state.background;
+    if (state.inverse) {
+      [foreground, background] = [
+        background || "var(--md-code-bg-color)",
+        foreground || "var(--md-code-fg-color)",
+      ];
+    }
+    const styles = [];
+    if (foreground) styles.push(`color:${foreground}`);
+    if (background) styles.push(`background-color:${background}`);
+    if (state.bold) styles.push("font-weight:700");
+    if (state.dim) styles.push("opacity:.65");
+    if (state.italic) styles.push("font-style:italic");
+    if (state.underline && state.strike) {
+      styles.push("text-decoration:underline line-through");
+    } else if (state.underline) {
+      styles.push("text-decoration:underline");
+    } else if (state.strike) {
+      styles.push("text-decoration:line-through");
+    }
+    if (state.hidden) styles.push("visibility:hidden");
+    return styles.join(";");
+  }
+
+  function resetState(state) {
+    Object.assign(state, {
+      foreground: null,
+      background: null,
+      bold: false,
+      dim: false,
+      italic: false,
+      underline: false,
+      inverse: false,
+      hidden: false,
+      strike: false,
+    });
+  }
+
+  function applySgr(state, parameters) {
+    const codes = parameters === "" ? [0] : parameters.split(";").map(Number);
+    for (let index = 0; index < codes.length; index += 1) {
+      const code = codes[index];
+      if (code === 0) resetState(state);
+      else if (code === 1) state.bold = true;
+      else if (code === 2) state.dim = true;
+      else if (code === 3) state.italic = true;
+      else if (code === 4) state.underline = true;
+      else if (code === 7) state.inverse = true;
+      else if (code === 8) state.hidden = true;
+      else if (code === 9) state.strike = true;
+      else if (code === 22) {
+        state.bold = false;
+        state.dim = false;
+      } else if (code === 23) state.italic = false;
+      else if (code === 24) state.underline = false;
+      else if (code === 27) state.inverse = false;
+      else if (code === 28) state.hidden = false;
+      else if (code === 29) state.strike = false;
+      else if (code >= 30 && code <= 37) state.foreground = ANSI_COLORS[code - 30];
+      else if (code >= 90 && code <= 97) state.foreground = ANSI_COLORS[code - 82];
+      else if (code === 39) state.foreground = null;
+      else if (code >= 40 && code <= 47) state.background = ANSI_COLORS[code - 40];
+      else if (code >= 100 && code <= 107) state.background = ANSI_COLORS[code - 92];
+      else if (code === 49) state.background = null;
+      else if ((code === 38 || code === 48) && codes[index + 1] === 5) {
+        const color = getIndexedColor(codes[index + 2]);
+        if (code === 38) state.foreground = color;
+        else state.background = color;
+        index += 2;
+      } else if ((code === 38 || code === 48) && codes[index + 1] === 2) {
+        const color = `rgb(${codes[index + 2]}, ${codes[index + 3]}, ${codes[index + 4]})`;
+        if (code === 38) state.foreground = color;
+        else state.background = color;
+        index += 4;
+      }
+    }
+  }
+
+  function convertAnsiToHtml(value) {
+    const input = value.replace(OSC_PATTERN, "");
+    const state = {};
+    resetState(state);
+    let html = "";
+    let offset = 0;
+    let match;
+    ESCAPE_PATTERN.lastIndex = 0;
+    while ((match = ESCAPE_PATTERN.exec(input)) !== null) {
+      const text = input.slice(offset, match.index);
+      const style = getSpanStyle(state);
+      const escaped = escapeHtml(text);
+      html += style && text ? `<span style="${style}">${escaped}</span>` : escaped;
+      if (match[0].endsWith("m")) applySgr(state, match[0].slice(2, -1));
+      offset = ESCAPE_PATTERN.lastIndex;
+    }
+    const tail = input.slice(offset);
+    const style = getSpanStyle(state);
+    const escaped = escapeHtml(tail);
+    html += style && tail ? `<span style="${style}">${escaped}</span>` : escaped;
+    return html;
+  }
+
+  function renderOutput(output) {
+    const value = output.textContent || "";
+    if (!value.includes("\x1b")) return;
+    output.innerHTML = convertAnsiToHtml(value);
+  }
+
+  const observed = new WeakSet();
+  function observeOutput(output) {
+    if (observed.has(output)) return;
+    observed.add(output);
+    new MutationObserver(() => renderOutput(output)).observe(output, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+    renderOutput(output);
+  }
+
+  function observePage(root) {
+    root.querySelectorAll(".pyodide-output").forEach(observeOutput);
+  }
+
+  global.__xnanoAnsiToHtml = convertAnsiToHtml;
+  if (typeof document === "undefined") return;
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => observePage(document));
+  } else {
+    observePage(document);
+  }
+  if (typeof document$ !== "undefined") {
+    document$.subscribe((root) => observePage(root));
+  }
+})(globalThis);

--- a/docs/xnano/getting-started.md
+++ b/docs/xnano/getting-started.md
@@ -22,13 +22,13 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "pip"
 
     ```bash
-    pip install "xnano>=1.0.8"
+    pip install "xnano>=1.0.9"
     ```
 
 === "uv"
 
     ```bash
-    uv pip install "xnano>=1.0.8"
+    uv pip install "xnano>=1.0.9"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -37,7 +37,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "poetry"
 
     ```bash
-    poetry install "xnano>=1.0.8"
+    poetry install "xnano>=1.0.9"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -46,7 +46,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "conda"
 
     ```bash
-    conda install "xnano>=1.0.8"
+    conda install "xnano>=1.0.9"
     ```
 
 ## What is xnano?
@@ -70,7 +70,7 @@ The main featureset of the library revolves around it's rust-based terminal rend
 
     The following example is interactive and can be run directly in the browser by hitting the <kbd>Run</kbd> button.
 
-```pyodide install="xnano>=1.0.8"
+```pyodide install="xnano>=1.0.9"
 import xnano
 
 xnano.render("hello, terminal!", color="blue")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.0.8"
+version = "1.0.9"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/tests/test_pyodide_render.py
+++ b/tests/test_pyodide_render.py
@@ -217,7 +217,9 @@ def _offscreen_dims(
     calls: list[tuple[int, int]] = []
     real_offscreen = Terminal.offscreen.__func__
 
-    def _spy(cls: type[Terminal[Any]], *, cols: int, rows: int, **kwargs: Any) -> Terminal[Any]:
+    def _spy(
+        cls: type[Terminal[Any]], *, cols: int, rows: int, **kwargs: Any
+    ) -> Terminal[Any]:
         calls.append((cols, rows))
         return real_offscreen(cls, cols=cols, rows=rows, **kwargs)
 
@@ -272,3 +274,37 @@ def test_flush_does_not_raise(capsys: pytest.CaptureFixture[str]) -> None:
     # custom file object here to assert flush-call-count against, since that
     # would require passing file= (which skips this code path entirely).
     _render("x", capsys=capsys, flush=True, end="")
+
+
+def test_cell_styles_are_preserved_as_ansi(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    out = _render(
+        "painted",
+        capsys=capsys,
+        color="#8b7fd4",
+        background=(20, 30, 40),
+        modifiers=["bold", "italic"],
+    )
+    assert "\x1b[38;2;139;127;212;48;2;20;30;40;1;3mpainted\x1b[0m" in out
+
+
+def test_grid_field_colors_are_preserved_as_ansi(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class Hello(BaseGrid, direction="vertical"):
+        message: str = Field(
+            default="Hello, xnano!",
+            color="violet",
+            modifiers=["bold"],
+            height=1,
+        )
+        hint: str = Field(
+            default="press q to quit",
+            color="slate-500",
+            height=1,
+        )
+
+    out = _render(Hello(), capsys=capsys, height=2)
+    assert "\x1b[38;2;238;130;238;1mHello, xnano!\x1b[0m" in out
+    assert "\x1b[38;2;100;116;139mpress q to quit\x1b[0m" in out

--- a/uv.lock
+++ b/uv.lock
@@ -2586,7 +2586,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.0.8"
+version = "1.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-core" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -6,7 +6,7 @@
 >>> from xnano import BaseGrid, Field, Terminal
 """
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 from typing import TYPE_CHECKING
 

--- a/xnano/core/controllers/tui.py
+++ b/xnano/core/controllers/tui.py
@@ -11,6 +11,7 @@ layer that talks to ``xnano_core`` for rendering.
 from __future__ import annotations
 
 import dataclasses
+import re
 import threading
 from typing import TYPE_CHECKING, Any, Generic, Sequence, TypeVar
 
@@ -49,6 +50,108 @@ SESSION_DEVICE_LOCK: threading.RLock = threading.RLock()
 """Device lock for thread-safe access to the cursor / device configuration
 options during an active session.
 """
+
+
+_ANSI_NAMED_FOREGROUNDS: dict[str, int] = {
+    "Black": 30,
+    "Red": 31,
+    "Green": 32,
+    "Yellow": 33,
+    "Blue": 34,
+    "Magenta": 35,
+    "Cyan": 36,
+    "Gray": 37,
+    "DarkGray": 90,
+    "LightRed": 91,
+    "LightGreen": 92,
+    "LightYellow": 93,
+    "LightBlue": 94,
+    "LightMagenta": 95,
+    "LightCyan": 96,
+    "White": 97,
+}
+"""ANSI foreground codes keyed by native color representation."""
+
+
+_ANSI_MODIFIERS: dict[str, int] = {
+    "BOLD": 1,
+    "DIM": 2,
+    "ITALIC": 3,
+    "UNDERLINED": 4,
+    "SLOW_BLINK": 5,
+    "RAPID_BLINK": 6,
+    "REVERSED": 7,
+    "HIDDEN": 8,
+    "CROSSED_OUT": 9,
+}
+"""ANSI SGR codes keyed by native modifier representation."""
+
+
+def _get_ansi_color_code(
+    color: native.Color, *, background: bool
+) -> str | None:
+    """Return the SGR fragment for a native terminal color."""
+    value = repr(color)
+    named = _ANSI_NAMED_FOREGROUNDS.get(value)
+    if named is not None:
+        if background:
+            named += 10
+        return str(named)
+    match = re.fullmatch(r"Rgb\((\d+), (\d+), (\d+)\)", value)
+    if match is not None:
+        channel = 48 if background else 38
+        return f"{channel};2;{';'.join(match.groups())}"
+    match = re.fullmatch(r"Indexed\((\d+)\)", value)
+    if match is not None:
+        channel = 48 if background else 38
+        return f"{channel};5;{match.group(1)}"
+    return None
+
+
+def _get_ansi_style(cell: native.BufferCell) -> tuple[str, ...]:
+    """Return all SGR fragments needed to reproduce a buffer cell style."""
+    codes: list[str] = []
+    foreground = _get_ansi_color_code(cell.fg, background=False)
+    background = _get_ansi_color_code(cell.bg, background=True)
+    if foreground is not None:
+        codes.append(foreground)
+    if background is not None:
+        codes.append(background)
+    modifier_names = set(repr(cell.modifier).split(" | "))
+    codes.extend(
+        str(code)
+        for name, code in _ANSI_MODIFIERS.items()
+        if name in modifier_names
+    )
+    return tuple(codes)
+
+
+def _get_buffer_as_ansi(buffer: native.Buffer) -> str:
+    """Serialize a native buffer while preserving its terminal cell styles."""
+    area = buffer.area
+    lines: list[str] = []
+    for y in range(area.y, area.y + area.height):
+        cells = [buffer.cell(x, y) for x in range(area.x, area.x + area.width)]
+        while cells and (cells[-1] is None or not cells[-1].symbol.strip()):
+            cells.pop()
+
+        parts: list[str] = []
+        active_style: tuple[str, ...] = ()
+        for cell in cells:
+            if cell is None:
+                continue
+            style = _get_ansi_style(cell)
+            if style != active_style:
+                if active_style:
+                    parts.append("\x1b[0m")
+                if style:
+                    parts.append(f"\x1b[{';'.join(style)}m")
+                active_style = style
+            parts.append(cell.symbol)
+        if active_style:
+            parts.append("\x1b[0m")
+        lines.append("".join(parts))
+    return "\n".join(lines)
 
 
 @dataclasses.dataclass(slots=True)
@@ -201,6 +304,10 @@ class TerminalController(AbstractController, Generic[StateT]):
         """Return the buffered terminal output as a newline-joined string."""
         buffer = self._core_session.buffer_snapshot()
         return "\n".join(buffer.to_string_lines())
+
+    def get_core_session_output_as_ansi(self) -> str:
+        """Return buffered terminal output with ANSI cell styles preserved."""
+        return _get_buffer_as_ansi(self._core_session.buffer_snapshot())
 
     def poll_core_event(self, timeout: int = 0) -> core.CoreEvent | None:
         """Poll for a core event; returns ``None`` for offscreen sessions.

--- a/xnano/tui/terminal.py
+++ b/xnano/tui/terminal.py
@@ -522,6 +522,10 @@ class Terminal(AbstractHost, Generic[StateT]):
         """Return the offscreen buffer text (only valid for offscreen sessions)."""
         return self.session.get_core_session_output_text()
 
+    def get_output_as_ansi(self) -> str:
+        """Return offscreen buffer text with ANSI cell styles preserved."""
+        return self.session.get_core_session_output_as_ansi()
+
     def copy_to_clipboard(self, text: str) -> bool:
         """Copy ``text`` to the system clipboard via an OSC 52 escape.
 
@@ -932,7 +936,7 @@ class Terminal(AbstractHost, Generic[StateT]):
                 renderables=None if root is not None else tuple(renderables),
                 field=field,
             )
-            text = terminal.get_output().rstrip("\n")
+            text = terminal.get_output_as_ansi().rstrip("\n")
             out = sys.stdout if file is None else file
             out.write(text)
             out.write(end)

--- a/zensical.toml
+++ b/zensical.toml
@@ -104,6 +104,7 @@ extra_css = [
 ]
 
 extra_javascript = [
+    "js/pyodide-ansi.js",
     "js/code-lang.js",
     "js/custom.js",
     "js/showcase-hover.js",


### PR DESCRIPTION
## Summary

- preserve ratatui cell colors and modifiers when rendering through the headless Pyodide path
- safely render ANSI SGR output in Zensical Pyodide output nodes
- bump xnano to 1.0.9 and update tracked installation examples

## Validation

- 1360 passed, 6 skipped
- 17 Pyodide rendering tests passed
- Zensical documentation build completed without issues
- browser ANSI parser true-color and bold conversion check passed

The full pre-commit suite passes except for the pre-existing type error in the untracked local test.py file, which is not part of this PR.