### PR TITLE
docs: rewrite and restyle documentation

### DIFF
--- a/docs/api/xnano/events.md
+++ b/docs/api/xnano/events.md
@@ -3,3 +3,59 @@ title: "xnano.events"
 ---
 
 ::: xnano.events
+
+## Actions
+
+`events.py` describes *what happened* — a keypress, a click, a tick — after the fact. `xnano.core.actions` describes the same thing as a value: something you can build once, store, compare, and hand to `@on(...)` instead of repeating a binding across every handler that cares about it.
+
+```python
+from xnano.core.actions import Action
+from xnano.events import on
+
+SAVE = Action.keyboard("ctrl+s")
+
+@on(SAVE)
+def save(self, ctx) -> None:
+    ...
+```
+
+<br/>
+
+Every `@on_*` decorator in this module is really building one of these under the hood — `@on_keyboard("ctrl+s")` and `@on(Action.keyboard("ctrl+s"))` register the exact same hook.
+
+### Action Types
+
+Each event family gets its own frozen `Action` subclass, built through a classmethod on the base `Action` class:
+
+| Classmethod | Returns | Matches |
+|---|---|---|
+| `Action.keyboard(*bindings, kind=None)` | `KeyboardAction` | A key binding, optionally filtered by press/release/repeat. |
+| `Action.mouse(*buttons, kind=None)` | `MouseAction` | Any mouse button/kind combination. |
+| `Action.click(field=None, button="left")` | `ClickAction` | A button press, optionally scoped to a layout field. |
+| `Action.focus(field=None, kind=None)` | `FocusAction` | Terminal window or field focus changes. |
+| `Action.clipboard(text=None)` | `ClipboardAction` | A paste event, optionally an exact match. |
+| `Action.tick(interval_ms=0)` | `TickAction` | A host clock tick, at or below an interval. |
+| `Action.resize(width=None, height=None)` | `ResizeAction` | A terminal resize, optionally an exact size. |
+| `Action.request(method, path)` | `RequestAction` | An HTTP request to a web host route — no terminal equivalent. |
+
+<br/>
+
+Every subclass implements the same two-method contract: `matches(event)` — does this event satisfy the action's filters — and `to_event()`, which synthesizes an equivalent event. `to_event()` is what makes `Actions` (below) possible: performing an action means synthesizing its event and running it through the same dispatch pump a real one would take.
+
+### Performing Actions
+
+Hooks bind Actions to *reactions*. `Actions` — reached as `ctx.actions` — goes the other way: it lets code *perform* an action against the live host, as if the matching input had actually happened.
+
+```python
+@on_keyboard("ctrl+r")
+def replay_save(self, ctx) -> None:
+    ctx.actions.press("ctrl+s") # (1)!
+```
+
+1. `ctx.actions.press(...)` synthesizes a keyboard event and runs it through the same dispatch pump a real key press would — any `@on_keyboard("ctrl+s")` hook fires exactly as if the user had pressed it.
+
+<br/>
+
+`Actions` exposes one method per action family — `press`, `click`, `focus`, `paste`, `resize`, `tick`, and `request` — each a thin wrapper around the matching `Action.<name>(...)` builder plus `perform()`.
+
+::: xnano.core.actions

--- a/docs/architecture/hosts-and-controllers.md
+++ b/docs/architecture/hosts-and-controllers.md
@@ -1,0 +1,150 @@
+---
+title: "Hosts, Interfaces & Controllers"
+icon: "lucide/server"
+---
+
+# Hosts, Interfaces & Controllers
+
+`xnano.core` defines the contracts shared by terminal and web hosts.
+These contracts separate field state, session behavior, and backend
+rendering across three classes: `AbstractInterface`, `AbstractHost`, and
+`AbstractController`.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: an interface's field mutation notifying its host, which drives a controller to measure, layout, and paint">
+<svg viewBox="0 0 760 170" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <marker id="hcd-arrowhead" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <rect class="gcd-panel" x="20" y="40" width="200" height="70" rx="10" />
+  <text class="gcd-label" x="120" y="80" text-anchor="middle">interface</text>
+  <text class="gcd-chrome-label" x="120" y="128" text-anchor="middle">field state, dirty notify</text>
+
+  <rect class="gcd-panel" x="280" y="40" width="200" height="70" rx="10" />
+  <text class="gcd-label" x="380" y="80" text-anchor="middle">host</text>
+  <text class="gcd-chrome-label" x="380" y="128" text-anchor="middle">session, dispatch, perform</text>
+
+  <rect class="gcd-panel gcd-panel-accent" x="540" y="40" width="200" height="70" rx="10" />
+  <text class="gcd-label gcd-label-accent" x="640" y="80" text-anchor="middle">controller</text>
+  <text class="gcd-chrome-label" x="640" y="128" text-anchor="middle">measure, layout, paint</text>
+
+  <line class="gcd-arrow" x1="220" y1="75" x2="276" y2="75" marker-end="url(#hcd-arrowhead)" />
+  <line class="gcd-arrow" x1="480" y1="75" x2="536" y2="75" marker-end="url(#hcd-arrowhead)" />
+  <text class="gcd-z-caption" x="248" y="65" text-anchor="middle">notifies</text>
+  <text class="gcd-z-caption" x="508" y="65" text-anchor="middle">drives</text>
+</svg>
+</div>
+
+## `AbstractInterface`: field state
+
+`BaseGrid` inherits from `xnano.core.interface.AbstractInterface` to
+manage declared fields and their per-instance `FieldState` objects.
+Layout remains the responsibility of `BaseGrid`; `AbstractInterface`
+tracks field values and reports changes.
+
+It has two main responsibilities:
+
+- `_init_field_states()` allocates one `FieldState` per declared field
+  (both rendered fields, `_grid_fields`, and `state=True` fields,
+  `_grid_state_fields`) when an instance is constructed.
+- `mark_field_dirty(name)` marks that field's state dirty, refreshes
+  its cached value, and calls `_notify_field_changed()`.
+
+`_notify_field_changed()` is best-effort. It obtains the active host from
+`xnano.core.hosts.get_active_host()`, finds its private `_session` or
+`controller` handle, and calls `notify_field_changed()` when that method
+is available. Notification errors are ignored. As a result, mutating a
+grid without an active host, including in a unit test, updates its state
+without raising an exception.
+
+## `AbstractHost`: shared session behavior
+
+`Terminal` and web sessions both implement
+`xnano.core.hosts.AbstractHost`. It provides behavior that is independent
+of the output surface:
+
+- **Dispatch state:** `_hooks`, `_attached_grids`,
+  `_attached_frame_grids`, and `state` form the common interface used by
+  `xnano._dispatch`. They are documented on the class without strict
+  types because dispatch accepts any compatible host, not only
+  `Terminal`.
+- **`perform(action)`:** converts an `Action`, or another object with
+  `to_event()`, into an event and passes it to `dispatch_hooks()`.
+  Reentrant calls are queued to avoid nested dispatch. A chain longer
+  than `_MAX_PERFORM_DEPTH` (32) raises `HookError`, which stops actions
+  that repeatedly trigger the same hook.
+- **`navigate(key)` and `RouteTable`:** map route keys to interface
+  factories. Subclasses implement `on_navigate()` when navigation also
+  needs to reattach hooks or replace the controller root.
+- **Lazy `actions` and `stage` properties:** create `Actions(self)` and
+  `Stage(self)` on first access and reuse those instances afterward.
+- **`enter_host()` and `leave_host()`:** set and clear the active host in
+  `_ACTIVE_HOST`, a `contextvars.ContextVar`. Code such as
+  `AbstractInterface.mark_field_dirty()` can then find the current host
+  without receiving it as an argument or relying on a process-wide
+  singleton.
+
+## `AbstractController`: painting, measurement, and layout
+
+`xnano.core.controllers.abstract.AbstractController` defines the
+rendering backend API. `xnano.tui` uses `TerminalController`, while
+`xnano.webui` provides its own implementation. Only
+`get_capabilities()` is required. Other methods raise
+`NotImplementedError` by default, so each backend implements the
+features it supports.
+
+`AbstractControllerCapabilities` is the negotiation surface:
+
+```python
+supports_effects: bool             # does grid_play_effect do anything?
+supports_movement: bool            # can fields be pointer-dragged?
+supports_absolute_geometry: bool   # do Area coords map to real cells,
+                                    # or are they logical/flex only?
+```
+
+A grid or component calls controller methods without checking the host
+type. Capability flags and unimplemented methods define the available
+backend features. Controller methods fall into these groups:
+
+- **Frame lifecycle:** `begin_viewport_frame()`, `commit_requests()`,
+  `get_viewport_area()`.
+- **Chrome:** `paint_frame(area, frame)` paints borders, padding, and a
+  title. `paint_chrome(area, style)` first converts a `Style` to a
+  `Frame`, allowing callers to work directly with styles.
+- **Layout:** `split_layout(area, direction, gap, constraints)` turns
+  an `AbstractLayoutConstraint` sequence into concrete sub-`Area`s;
+  `measure_field_slot()` sizes one slot's content ahead of layout.
+- **Content painting:** `render_content()` handles a neutral `Content`
+  tree, `render_ir()` accepts a pre-lowered `CoreRenderIR`, and
+  `render_native()` accepts a backend-native widget without a portable
+  IR form. `paint_node()` asks the node to lower itself, so the
+  controller does not inspect its concrete type.
+- **Effects and fields:** `play_effect()`, `paint_field_slot()`, and
+  `notify_field_changed()`. `AbstractInterface` calls the last method
+  whenever a field becomes dirty.
+
+`LayoutConstraint` in `xnano.core.controllers.abstract` is the concrete
+constraint type built by `BaseGrid`. Both controllers receive the same
+constraint values. The terminal controller resolves them against cells
+through the native layout engine, while the web controller converts them
+to CSS layout values.
+
+## Frame sequence
+
+A field change begins in `BaseGrid`, which is an `AbstractInterface`, and
+notifies the active `AbstractHost` controller. During the next
+`render_frame()`, the controller measures and lays out fields with
+`measure_field_slot()` and `split_layout()`. It then paints each field
+through `paint_field_slot()`, followed by `render_ir()`,
+`render_native()`, or `paint_node()`. The sequence is shared by
+`xnano.tui.Terminal` and `xnano.webui.Web`; their controller
+implementations determine how each operation is performed.
+
+See [Event & Render Lifecycle]{data-preview} for the dispatch path and
+[Render Nodes & IR]{data-preview} for the terminal controller's render
+path.
+
+[Event & Render Lifecycle]: lifecycle.md
+[Render Nodes & IR]: render-nodes.md

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -1,0 +1,196 @@
+---
+title: "Event & Render Lifecycle"
+icon: "lucide/refresh-cw"
+---
+
+# Event & Render Lifecycle
+
+This page traces one iteration of the terminal run loop, from a raw key
+event received by `xnano_core` through rendering the next frame. It is
+intended for contributors working on `xnano`. Application-facing hook
+and event behavior is documented in [Events & Hooks]{data-preview}.
+
+The loop is implemented in `xnano._event_processing` and
+`xnano._dispatch` and driven by `Terminal.run()`. Each iteration polls
+for an event, normalizes it, dispatches matching hooks, and renders a
+frame.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: the run loop cycling through poll, normalize, dispatch, hooks, and render, then looping back to poll">
+<svg viewBox="0 0 760 190" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <marker id="lcd-arrowhead" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <!-- Stage boxes -->
+  <g>
+    <rect class="gcd-panel" x="20" y="55" width="120" height="60" rx="10" />
+    <text class="gcd-label" x="80" y="90" text-anchor="middle">poll</text>
+
+    <rect class="gcd-panel" x="168" y="55" width="120" height="60" rx="10" />
+    <text class="gcd-label" x="228" y="90" text-anchor="middle">normalize</text>
+
+    <rect class="gcd-panel" x="316" y="55" width="120" height="60" rx="10" />
+    <text class="gcd-label" x="376" y="90" text-anchor="middle">dispatch</text>
+
+    <rect class="gcd-panel" x="464" y="55" width="120" height="60" rx="10" />
+    <text class="gcd-label" x="524" y="90" text-anchor="middle">hooks</text>
+
+    <rect class="gcd-panel gcd-panel-accent" x="612" y="55" width="128" height="60" rx="10" />
+    <text class="gcd-label gcd-label-accent" x="676" y="90" text-anchor="middle">render</text>
+  </g>
+
+  <!-- Forward arrows -->
+  <line class="gcd-arrow" x1="140" y1="85" x2="164" y2="85" marker-end="url(#lcd-arrowhead)" />
+  <line class="gcd-arrow" x1="288" y1="85" x2="312" y2="85" marker-end="url(#lcd-arrowhead)" />
+  <line class="gcd-arrow" x1="436" y1="85" x2="460" y2="85" marker-end="url(#lcd-arrowhead)" />
+  <line class="gcd-arrow" x1="584" y1="85" x2="608" y2="85" marker-end="url(#lcd-arrowhead)" />
+
+  <!-- Loop-back arrow: render -> poll, next iteration -->
+  <path class="gcd-z-connector" d="M676 115 C 676 160, 80 160, 80 119" marker-end="url(#lcd-arrowhead)" fill="none" />
+  <text class="gcd-z-caption" x="378" y="152" text-anchor="middle">next iteration</text>
+</svg>
+</div>
+
+## Polling
+
+`pump_events()` asks the active `xnano_core.core.CoreSession` for the
+next event through `poll_core_event()`, which blocks for up to
+`terminal.tick_interval` milliseconds. Three outcomes follow:
+
+- **Nothing arrives within the window:** the poll is treated as idle,
+  and `pump_poll()` fires any `@on_poll(when="idle")` hooks before the
+  loop continues.
+- **No hook consumes the event type:** `pump_events()`
+  checks the terminal's hook registry (`terminal._hooks`) for
+  interest before doing more work. For example, keyboard events check
+  `on_keyboard_hooks` and resize events check `on_resize_hooks`. If the
+  corresponding registry is empty, the event is dropped and polling
+  continues immediately with `timeout=-1`.
+- **A hook consumes the event type:** the raw `core.CoreEvent` is
+  normalized and passed to `dispatch_hooks()`.
+
+## Normalizing: native event to `Event`
+
+Native input from `ratatui` and `crossterm` arrives through
+`xnano_core.rust.native` as values such as `KeyEvent` and `MouseEvent`.
+`xnano._event_processing.get_event_data_from_core_event()` converts
+them to the public `xnano.events.EventData` subclasses:
+`KeyboardEventData`, `MouseEventData`, `ResizeEventData`,
+`ClipboardEventData`, and `FocusEventData`.
+
+Keyboard normalization requires additional processing. A native
+`KeyEvent` carries a
+`code_name`, optional `char`, and modifier bits, and
+`get_keyboard_binding_tuple_from_native_event()` converts that data to
+the `(modifiers, key)` shape produced when a binding string such as
+`"ctrl+s"` is parsed. Results are cached by `(code_name, char,
+function_number, modifier_bits)` because this function runs for every
+key event and the same combinations occur repeatedly.
+
+The resulting `xnano.events.Event` is stored in a `Context` with the
+terminal and user state, then passed through the remaining dispatch
+stages.
+
+## Dispatch: matching hooks to the event
+
+`dispatch_hooks(terminal, ctx)` in `xnano._dispatch` first runs the
+terminal's `on_event_hooks`. These are the general `@on(event=...)`
+hooks that receive every event. It then checks
+`event.is_keyboard_event()`, `is_mouse_event()`, `is_resize_event()`,
+`is_clipboard_event()`, or `is_focus_event()` and runs the matching
+registry.
+
+Two framework behaviors are reserved ahead of user hooks on the
+keyboard branch:
+
+1. **Tab and backtab focus navigation** (`_handle_focus_navigation`)
+   consumes the key only when focus moves to a field. An
+   `on_keyboard("tab")` hook still runs when no fields can receive focus.
+2. **Focused text input** (`_handle_focused_text_input`) allows an
+   editable `Text` field with input focus to consume character and edit
+   keys before any user `@on_keyboard` hook sees them.
+
+Matching is implemented by `Action` in `xnano.core.actions`.
+`keyboard_matches()` and `mouse_matches()` build and cache an
+`Action.keyboard(...)` or `Action.mouse(...)`, then call `.matches()`
+against a lightweight event object. Real device input and synthetic
+`host.perform(action)` calls therefore use the same matching logic.
+
+`resolve_hook_grid()` identifies the grid instance for each dispatched
+hook. Bound methods provide the instance through `__self__`. For
+unbound handlers collected from a class, the function walks
+`terminal._attached_frame_grids` and compares the owner in
+`__qualname__` with each grid's MRO. Hooks declared on a base grid class
+can therefore resolve to a live subclass instance.
+
+## Hook collection and rebinding
+
+Hooks are collected once per grid class, not rediscovered for each
+event. `_EventHooksRegistry._get_component_class_hooks` is cached with
+`functools.cache`; it walks the MRO and reads the `__xnano_on_*__`
+attributes added by the `@on_*` decorators. If a subclass overrides a
+method name, only the override is registered.
+
+The cached class template contains unbound functions. The first time
+`render_frame()` encounters a grid instance, `track_frame_grid()` copies
+the template with `_EventHooksRegistry.from_component_class()`.
+`merge_hooks()` then uses `rebind_hook_handler()` to bind each handler to
+the live instance before adding it to the terminal's `_hooks` registry.
+The registration lasts for the terminal session, so grid instances are
+expected to remain stable across frames.
+
+## Other pumps: tick, poll, field/state hooks
+
+Two more pumps run inside the same loop iteration, independent of
+whether an event arrived:
+
+- `pump_tick()` fires `@on_tick` hooks whose interval has elapsed
+  (`interval=0` means every iteration), then evaluates `@on_state` /
+  `@on_field` expressions (`evaluate_state_expression`) against shared
+  state or the grid's own fields and fires any that are newly truthy.
+- `pump_poll()` fires `@on_poll(when="idle")` after an empty poll and
+  `when="frame"` hooks every iteration regardless of events.
+
+All three pumps call `invoke_hook()`. It resolves handler arity through
+`_call_hook` and runs coroutine results through `run_awaitable` on a new
+event loop because the TUI loop is synchronous. `Exit`,
+`KeyboardInterrupt`, and `SystemExit` propagate so `Terminal.run()` can
+restore the terminal before exiting. Other uncaught exceptions are
+logged and re-raised.
+
+## Rendering the next frame
+
+After dispatch completes, `render_frame()` paints the next frame. A
+`BaseGrid` root follows this layout path:
+
+1. `track_frame_grid()` registers the root. Nested grids attach lazily
+   as `TerminalController.paint_field_slot()` reaches them during
+   painting.
+2. The first editable `Text` field receives focus on the first frame so
+   its caret is rendered before the first key event.
+3. `resolve_root_area()` constrains the viewport to the root's width
+   setting. Fixed widths and bounded `fit` values require measurement;
+   `fill` and unbounded `fit` values do not.
+4. `root._grid_build_frame(root_area, session)` runs the grid's own
+   layout engine. `BaseGrid` walks the fields, resolves constraints,
+   and paints each field slot.
+5. Stage overlays (wireframe / paint canvas from `ctx.stage`) are
+   composited at a high z-index without changing field content.
+6. `session.commit_requests()` flushes the frame's batched paint
+   requests to `xnano_core` in one call.
+
+A non-grid root from an inline `render()` call skips the grid layout
+engine. Its renderables are placed downward from the root area's
+top-left corner. Each one is measured with
+`measure_renderable_in_field()` and limited to the remaining viewport
+height.
+
+[Render Nodes & IR]{data-preview} describes how
+`TerminalController.commit_requests()` converts queued `RenderRequest`
+objects into a `CoreRenderNode` tree and passes it to
+`CoreSession.render()`.
+
+[Events & Hooks]: ../core-concepts/events.md
+[Render Nodes & IR]: render-nodes.md

--- a/docs/architecture/render-nodes.md
+++ b/docs/architecture/render-nodes.md
@@ -1,0 +1,184 @@
+---
+title: "Render Nodes & IR"
+icon: "lucide/network"
+---
+
+# Render Nodes & IR
+
+This page follows a field value from a Python terminal node to the cells
+painted by `xnano_core`. It covers the final render stages introduced in
+[Event & Render Lifecycle]{data-preview}.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: Content and Node stay in Python; CoreRenderIR is the single crossing into xnano_core, which paints the terminal buffer">
+<svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <pattern id="rnd-cell-grid" width="14" height="14" patternUnits="userSpaceOnUse">
+      <path d="M 14 0 L 0 0 0 14" class="gcd-grid-line" />
+    </pattern>
+    <marker id="rnd-arrowhead" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <!-- Left panel: Python side -->
+  <rect class="gcd-panel" x="16" y="28" width="280" height="244" rx="16" />
+  <text class="gcd-label" x="156" y="54" text-anchor="middle">python</text>
+
+  <!-- Content box -->
+  <g transform="translate(40, 74)">
+    <rect class="gcd-window" x="0" y="0" width="232" height="72" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="232" height="22" rx="10" />
+    <rect class="gcd-chrome" x="0" y="12" width="232" height="10" />
+    <circle class="gcd-dot" cx="14" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="26" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="38" cy="11" r="3.5" />
+    <text class="gcd-chrome-label" x="116" y="15" text-anchor="middle">content</text>
+    <path class="gcd-line" d="M16 40 h56" stroke-width="3" stroke-linecap="round" />
+    <path class="gcd-line-soft" d="M16 54 h96" stroke-width="3" stroke-linecap="round" />
+  </g>
+
+  <!-- Node box -->
+  <g transform="translate(40, 166)">
+    <rect class="gcd-window" x="0" y="0" width="232" height="72" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="232" height="22" rx="10" />
+    <rect class="gcd-chrome" x="0" y="12" width="232" height="10" />
+    <circle class="gcd-dot" cx="14" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="26" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="38" cy="11" r="3.5" />
+    <text class="gcd-chrome-label" x="116" y="15" text-anchor="middle">node</text>
+    <path class="gcd-line" d="M16 40 h72" stroke-width="3" stroke-linecap="round" />
+    <path class="gcd-line-soft" d="M16 54 h48" stroke-width="3" stroke-linecap="round" />
+  </g>
+
+  <!-- Arrow across the boundary -->
+  <line class="gcd-arrow" x1="320" y1="150" x2="392" y2="150" marker-end="url(#rnd-arrowhead)" />
+  <text class="gcd-chrome-label" x="356" y="136" text-anchor="middle">CoreRenderIR</text>
+
+  <!-- Right panel: Rust side -->
+  <rect class="gcd-panel gcd-panel-accent" x="424" y="28" width="280" height="244" rx="16" />
+  <text class="gcd-label gcd-label-accent" x="564" y="54" text-anchor="middle">xnano_core (rust)</text>
+
+  <!-- Painted terminal box -->
+  <g transform="translate(448, 90)">
+    <rect class="gcd-window" x="0" y="0" width="232" height="140" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="232" height="22" rx="10" />
+    <rect class="gcd-chrome" x="0" y="12" width="232" height="10" />
+    <circle class="gcd-dot" cx="14" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="26" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="38" cy="11" r="3.5" />
+    <text class="gcd-chrome-label" x="116" y="15" text-anchor="middle">CoreSession.render()</text>
+    <rect class="gcd-grid-fill" x="8" y="28" width="216" height="104" rx="6" />
+    <rect x="8" y="28" width="216" height="104" rx="6" fill="url(#rnd-cell-grid)" />
+  </g>
+</svg>
+</div>
+
+## Nodes: `AbstractTerminalNode`
+
+Every terminal-renderable value is represented by a frozen
+`AbstractTerminalNode` dataclass from `xnano.tui.nodes`. This includes
+text, tables, progress bars, frames, and containers. Two methods define
+how each node is rendered:
+
+- **`to_ir()`** returns the node's `CoreRenderIR` representation or
+  `None` when no IR representation exists. Most node types only
+  implement this method. `SpanNode`, `TextNode`, `ProgressBarNode`, and
+  `TableNode` each call the corresponding `CoreRenderIR` constructor.
+- **`lower(area, controller, *, z, effect_key)`** paints the node into
+  `area` through a controller. The default implementation (defined
+  once on `AbstractTerminalNode`) calls `to_ir()` and enqueues the
+  result through `controller.render_ir()`. Nodes that implement only
+  `to_ir()` use this default without overriding `lower()`.
+
+The controller calls `node.measure()` and `node.lower(...)` without
+checking the concrete node type. `AbstractController.paint_node()`
+therefore works with both leaf nodes such as `SpanNode` and composite
+nodes such as `ContainerNode`.
+
+Three kinds of node override `lower()` directly instead of relying on
+the `to_ir()` path:
+
+1. **Containers** (`ContainerNode`, `StackNode`, `FrameNode`) do not have
+   a single IR representation. They divide an area among children with
+   `controller.split_layout()` or paint a frame with
+   `controller.paint_frame()`, then call `lower()` on each child.
+2. **Native-only widgets** (`ChartNode`) have no `CoreRenderIR`
+   representation. `lower()` builds a native `ratatui` `Chart`
+   object directly (via `xnano_core.rust.native`) and calls
+   `controller.render_native()` instead of `render_ir()`.
+3. **Instance-dependent native widgets** include `SparklineNode` when
+   constructed with per-bar `bars` instead of a flat `data` list. The IR
+   cannot represent individual bar colors, so this form uses
+   `render_native()`. Other `SparklineNode` instances use `to_ir()`.
+
+## Content: the interface-neutral tree
+
+Nodes are specific to the terminal backend. Components first compose
+host-neutral primitives from `xnano.core.content`, including `Run`,
+`TextBlock`, `Panel`, `Stack`, `Clear`, `CellCanvas`, and `Native`.
+`xnano.tui.content_lower.lower_content()` walks this tree and produces
+an `AbstractTerminalNode` tree. It converts a `Run` to a `SpanNode`, a
+`Stack` to a `ContainerNode`, and a `Panel` to a `FrameNode` around its
+lowered child. `Native(interface_kind="tui", payload=...)` lets a
+component provide an existing terminal node or backend object without
+first representing that value as `Content`.
+
+## `CoreRenderIR`: the single Python↔Rust crossing
+
+`CoreRenderIR` is exported from `xnano_core.core` and implemented in
+`xnano-core/rust/src/bindings/engine/render_ir.rs`. Its constructors pack
+widget data into Rust enum variants in one PyO3 call. Constructors
+include `span(...)`, `text_lines(...)`, `progress_bar(...)`, and
+`table(...)`. The `.measure()` method calculates size without a live
+terminal buffer. `AbstractTerminalNode.measure()` uses it during layout,
+including when `xnano._dispatch.measure_renderable` resolves a root
+box's `fit` width.
+
+`IrLine` is the line-level representation. `IrLine.raw(str)` stores plain
+text, `IrLine.styled(...)` applies one style to a line, and
+`IrLine.from_spans([...])` combines spans with different styles. Nodes
+create these values through `_ir_line()` in `xnano.tui.nodes`. A
+`LineNode` is therefore lowered consistently whether it appears in a
+`TableNode` cell, a `ListNode` item, or another parent.
+
+## From node to screen: `TerminalController`
+
+`xnano.core.controllers.tui.TerminalController` is the terminal
+implementation of `AbstractController` and the framework layer that
+submits render work to `xnano_core`. `render_ir()` and `render_native()`
+do not paint immediately. Each appends a `RenderRequest` containing the
+native rectangle, content, z-index, and optional effect key to
+`self._render_requests`.
+
+`render_frame()` calls `commit_requests()` once per frame. The method
+combines queued requests into one `core.CoreRenderNode` tree:
+
+1. Each `RenderRequest` becomes `core.CoreRenderContent.ir(...)`,
+   `.widget(...)`, or `.stateful(...)`, depending on whether it contains
+   IR, a stateless native widget, or a native widget with render-time
+   state such as a selection `ListState`.
+2. Each content wraps into a `core.CoreRenderNode(x, y, width, height,
+   content=..., effect_key=..., z=...)`, which forms a scene graph leaf.
+3. Multiple requests are combined under a viewport-sized
+   `CoreRenderNode.stack(...)`. Requests are sorted by z-index when any
+   request uses a non-default value.
+4. The resulting node or stack is passed to
+   `self._core_session.render(node)`.
+
+`CoreSession.render()` then walks the `CoreRenderNode` tree, resolves
+each leaf's `CoreRenderContent` to a `ratatui` widget, and paints it into
+the terminal buffer at the requested geometry. The buffer is diffed
+against the previous frame so only changed cells are written to the
+terminal.
+
+## IR and native rendering
+
+The IR covers widgets that benefit from a compact, portable
+representation. More specialized widgets, such as charts with series
+markers and legends, use `render_native()` instead of expanding the IR
+for features that are rarely needed. The usual `to_ir()` to
+`render_ir()` path requires one compact Rust call. Native-only widgets
+construct a `ratatui` object graph in Python and pass it across the PyO3
+boundary directly.
+
+[Event & Render Lifecycle]: lifecycle.md

--- a/docs/architecture/xnano-core.md
+++ b/docs/architecture/xnano-core.md
@@ -1,0 +1,97 @@
+---
+title: "xnano-core"
+icon: "lucide/cpu"
+---
+
+# xnano-core
+
+Grids, fields, hooks, and components are implemented in Python. They do
+not access the terminal directly. `xnano-core` provides the Rust runtime
+that owns the terminal session, processes terminal events, and renders
+the output described by Python.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: Python owns grids and fields; a single IR crossing into xnano-core handles session, paint, and events">
+<svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <pattern id="xcd-cell" width="12" height="12" patternUnits="userSpaceOnUse">
+      <path d="M 12 0 L 0 0 0 12" class="gcd-grid-line" />
+    </pattern>
+    <marker id="xcd-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <!-- Python -->
+  <rect class="gcd-panel" x="28" y="28" width="280" height="224" rx="16" />
+  <text class="gcd-label" x="168" y="56" text-anchor="middle">python · xnano</text>
+
+  <rect class="gcd-window" x="56" y="80" width="224" height="40" rx="8" />
+  <text class="gcd-chrome-label" x="168" y="104" text-anchor="middle">BaseGrid · Field · hooks</text>
+
+  <rect class="gcd-window" x="56" y="136" width="224" height="40" rx="8" />
+  <text class="gcd-chrome-label" x="168" y="160" text-anchor="middle">components · Content</text>
+
+  <rect class="gcd-window" x="56" y="192" width="224" height="40" rx="8" />
+  <text class="gcd-chrome-label" x="168" y="216" text-anchor="middle">controllers · nodes</text>
+
+  <!-- Crossing -->
+  <line class="gcd-arrow" x1="308" y1="140" x2="380" y2="140" marker-end="url(#xcd-arrow)" />
+  <text class="gcd-z-caption gcd-z-caption-on" x="344" y="126" text-anchor="middle">IR</text>
+  <text class="gcd-z-caption" x="344" y="160" text-anchor="middle">once / frame</text>
+
+  <!-- Rust -->
+  <rect class="gcd-panel gcd-panel-accent" x="392" y="28" width="300" height="224" rx="16" />
+  <text class="gcd-label gcd-label-accent" x="542" y="56" text-anchor="middle">rust · xnano-core</text>
+
+  <rect class="gcd-window" x="420" y="80" width="244" height="40" rx="8" />
+  <text class="gcd-chrome-label" x="542" y="104" text-anchor="middle">CoreSession</text>
+
+  <rect class="gcd-window" x="420" y="136" width="244" height="40" rx="8" />
+  <text class="gcd-chrome-label" x="542" y="160" text-anchor="middle">ratatui · tachyonfx</text>
+
+  <g transform="translate(420, 192)">
+    <rect class="gcd-window" x="0" y="0" width="244" height="40" rx="8" />
+    <rect class="gcd-grid-fill" x="12" y="10" width="220" height="20" rx="3" />
+    <rect x="12" y="10" width="220" height="20" rx="3" fill="url(#xcd-cell)" />
+  </g>
+</svg>
+</div>
+
+## Why Rust
+
+A terminal interface may redraw after every input event or clock tick.
+Buffer updates, cell diffs, and terminal I/O all run frequently, so xnano
+keeps that work in Rust. `CoreSession` manages the live terminal and render
+cycle, [ratatui](https://ratatui.rs) updates and diffs the buffer, and
+[tachyonfx](https://github.com/ratatui/tachyonfx) runs terminal effects.
+The normal render path crosses from Python into Rust once per frame. See
+[Render Nodes & IR]{data-preview} for the details of that boundary.
+
+## Scope
+
+`xnano-core` does not define `BaseGrid`, `Field`, hooks, or components. Its
+API deals with sessions, render nodes, key bindings, terminal events, and
+other runtime primitives.
+
+This boundary keeps application-facing APIs in Python and moves terminal
+lifecycle and rendering work into Rust. [Interfaces & Hosts]{data-preview}
+describes the Python contracts that sit above the runtime.
+
+## Direct installation
+
+Applications normally install and import `xnano`, which includes
+`xnano-core` as a dependency. The package is published separately so the
+native extension and the WASM/Pyodide build can be distributed
+independently. The WASM build uses buffer-backed sessions and does not
+open a live terminal.
+
+```bash
+pip install xnano-core
+```
+
+The [xnano-core]{data-preview} API reference documents `CoreSession`,
+`CoreRenderNode`, `CoreKeyBinding`, and the rest of the public runtime API.
+
+[Render Nodes & IR]: render-nodes.md
+[Interfaces & Hosts]: hosts-and-controllers.md
+[xnano-core]: ../api/xnano-core/xnano-core.md

--- a/docs/components/chart.md
+++ b/docs/components/chart.md
@@ -1,0 +1,72 @@
+---
+title: "Chart"
+icon: "lucide/bar-chart"
+---
+
+# Chart
+
+`Chart` turns a mapping of series name to points into a line, scatter, or bar plot — legend, axis bounds, and per-series color all derived from the data.
+
+Points can be bare `y` values, with the x-axis becoming the index, or explicit `(x, y)` pairs.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4 5 6 7"
+    from xnano import Terminal
+    from xnano.components.chart import Chart
+
+    Terminal(height=14).render(
+        Chart(series={
+            "cpu": [30, 42, 38, 55, 61],
+            "mem": [60, 61, 63, 62, 64],
+        })
+    )
+    ```
+
+```python title="A Multi-Series Chart" hl_lines="4 5 6 7"
+from xnano import Terminal
+from xnano.components.chart import Chart
+
+Terminal(height=14).render(
+    Chart(series={
+        "cpu": [30, 42, 38, 55, 61], # (1)!
+        "mem": [60, 61, 63, 62, 64],
+    })
+)
+```
+
+1. One line per key — legend labels, colors, and axis bounds are all inferred, cycling through a built-in palette.
+
+<div class="xnano-demo" markdown>
+![chart lines dark](../assets/components/chart_lines-dark.gif){.demo-dark}
+![chart lines light](../assets/components/chart_lines-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Switch `kind` for a bar plot, or mix explicit points in:
+
+```python title="A Bar Plot" hl_lines="4"
+from xnano import Terminal
+from xnano.components.chart import Chart
+
+Terminal(height=14).render(
+    Chart(series={"load": [(0, 3), (1, 5), (2, 4)]}, kind="bar")
+)
+```
+
+<div class="xnano-demo" markdown>
+![chart bars dark](../assets/components/chart_bars-dark.gif){.demo-dark}
+![chart bars light](../assets/components/chart_bars-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Give a series its own color or plot kind by subclassing with `Series()` descriptors instead of a bare mapping — see [Schema]{data-preview}.
+
+The full parameter list — axis titles, explicit bounds, legend position, and more — lives on the [Chart]{data-preview} API reference.
+
+[Chart]: ../api/xnano/components/chart.md
+[Schema]: schema.md

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -1,0 +1,202 @@
+---
+title: "Components"
+icon: "lucide/box"
+---
+
+# Components
+
+Every built-in widget xnano ships — `Text`, `Table`, `Progress`, `Chart`, `Sparkline`, `Schema` — is an [AbstractComponent]{data-preview} subclass: a small, self-contained class that knows how to measure its own size and describe its own content, independent of whatever grid or field it ends up living in.
+
+A component is the same shape as a [BaseGrid]{data-preview} in spirit — self-contained, host-agnostic — but built for reuse as a *value*, not a whole app. You drop one into a `Field()`, or hand it straight to `render()`, rather than running it.
+
+A component:
+
+- Measures itself <small>(`get_size()` — how much space it wants)</small>
+- Describes its own content <small>(`compose()` — what to paint, host-agnostic)</small>
+- Renders on any host with no extra code <small>(the same content tree lowers for both terminal and browser)</small>
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: a component measures size and composes host-agnostic content, which lowers to terminal cells or HTML">
+<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <pattern id="cid-cell" width="12" height="12" patternUnits="userSpaceOnUse">
+      <path d="M 12 0 L 0 0 0 12" class="gcd-grid-line" />
+    </pattern>
+    <marker id="cid-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <rect class="gcd-panel gcd-panel-accent" x="40" y="70" width="160" height="100" rx="14" />
+  <text class="gcd-label gcd-label-accent" x="120" y="112" text-anchor="middle">component</text>
+  <text class="gcd-chrome-label" x="120" y="138" text-anchor="middle">Badge · Progress…</text>
+
+  <line class="gcd-arrow" x1="200" y1="100" x2="248" y2="80" marker-end="url(#cid-arrow)" />
+  <line class="gcd-arrow" x1="200" y1="140" x2="248" y2="160" marker-end="url(#cid-arrow)" />
+
+  <rect class="gcd-panel" x="260" y="48" width="160" height="56" rx="12" />
+  <text class="gcd-label" x="340" y="72" text-anchor="middle">get_size()</text>
+  <text class="gcd-chrome-label" x="340" y="90" text-anchor="middle">preferred cells</text>
+
+  <rect class="gcd-panel" x="260" y="132" width="160" height="56" rx="12" />
+  <text class="gcd-label" x="340" y="156" text-anchor="middle">compose()</text>
+  <text class="gcd-chrome-label" x="340" y="174" text-anchor="middle">Content tree</text>
+
+  <line class="gcd-arrow" x1="420" y1="160" x2="468" y2="160" marker-end="url(#cid-arrow)" />
+
+  <rect class="gcd-panel" x="480" y="48" width="200" height="64" rx="12" />
+  <text class="gcd-chrome-label" x="580" y="76" text-anchor="middle">terminal cells</text>
+  <rect class="gcd-grid-fill" x="500" y="88" width="160" height="14" rx="2" />
+  <rect x="500" y="88" width="160" height="14" rx="2" fill="url(#cid-cell)" />
+
+  <rect class="gcd-panel" x="480" y="132" width="200" height="64" rx="12" />
+  <text class="gcd-chrome-label" x="580" y="160" text-anchor="middle">HTML / HTMX</text>
+  <path class="gcd-line" d="M508 176 h120" stroke-width="3" stroke-linecap="round" />
+  <path class="gcd-line-soft" d="M508 188 h80" stroke-width="3" stroke-linecap="round" />
+</svg>
+</div>
+
+## Defining a Component
+
+A component overrides two methods: `get_size()`, so the grid around it knows how much room to give it, and `compose()`, which returns interface-neutral content — a `Panel`, a `TextBlock`, a `Gauge`, or one of the other primitives xnano lowers for you.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="5 6 9 10"
+    from xnano import render
+    from xnano._types import Size
+    from xnano.components.abstract import AbstractComponent
+    from xnano.core.content import Panel, TextBlock
+    import dataclasses
+
+    @dataclasses.dataclass
+    class Badge(AbstractComponent):
+        text: str = ""
+        color: str = "white"
+
+        def get_size(self, ctx):
+            return Size(width=len(self.text) + 4, height=3)
+
+        def compose(self, ctx):
+            return Panel(child=TextBlock.from_plain(self.text, color=self.color), border="rounded")
+
+    render(Badge(text="NEW", color="emerald-400"))
+    ```
+
+```python title="Defining a Component" hl_lines="5 6 9 10"
+import dataclasses
+from xnano._types import Size
+from xnano.components.abstract import AbstractComponent
+from xnano.core.content import Panel, TextBlock
+
+@dataclasses.dataclass
+class Badge(AbstractComponent):
+    text: str = ""
+    color: str = "white"
+
+    def get_size(self, ctx): # (1)!
+        return Size(width=len(self.text) + 4, height=3)
+
+    def compose(self, ctx): # (2)!
+        return Panel(
+            child=TextBlock.from_plain(self.text, color=self.color),
+            border="rounded",
+        )
+```
+
+1. `get_size()` returns the component's preferred cell size — here, just wide enough for the text plus its border, three rows tall to fit the frame. `ctx` is a `ComponentRenderContext`, the same render-time scope every component method receives.
+2. `compose()` returns *content*, not a widget for one specific host — a `Panel` wrapping a `TextBlock`. Whatever host paints this `Badge` lowers that same tree into cells or HTML; there's nothing terminal- or browser-specific to write.
+
+<div class="xnano-demo" markdown>
+![custom badge dark](../assets/components/custom_badge-dark.gif){.demo-dark}
+![custom badge light](../assets/components/custom_badge-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Neither method is required on its own — a component that skips `get_size()` just measures as `0x0` and relies on its field's own sizing, and one that skips `compose()` paints nothing. Most components implement both.
+
+## Using a Component
+
+A component works as a field's value exactly like a plain string does.
+
+```python title="Using a Component" hl_lines="4"
+from xnano import BaseGrid, Field
+
+class Dashboard(BaseGrid, direction="vertical"):
+    status: Badge = Field(default_factory=lambda: Badge(text="LIVE", color="red"))
+```
+
+It also renders standalone, the same way a bordered string does — `render(Badge(text="NEW"))`, as shown above, needs no grid at all.
+
+## Built-in Components
+
+xnano ships a handful of components ready to use — [Text]{data-preview} for styled and editable strings, [Table]{data-preview} for tabular data, [Progress]{data-preview} for bars and gauges, [Chart]{data-preview} for plots and bar charts, [Sparkline]{data-preview} for compact trend lines, and [Schema]{data-preview} for rendering a Pydantic model's fields directly. Each gets its own page next, starting with `Text` — the one you'll reach for most.
+
+<div class="grid cards" markdown>
+
+-   :material-format-text:{ .lg .middle } **Text**
+
+    ---
+
+    Styled spans, composed lines and paragraphs, plus editable text inputs.
+
+    [Text | Guide]{.xnano-card-link data-preview}
+
+-   :material-table:{ .lg .middle } **Table**
+
+    ---
+
+    Tabular data with configurable columns, selection, and row highlighting.
+
+    [Table | Guide]{.xnano-card-link data-preview}
+
+-   :material-progress-clock:{ .lg .middle } **Progress**
+
+    ---
+
+    Bars, gauges, and compact indicators for values moving toward a total.
+
+    [Progress | Guide]{.xnano-card-link data-preview}
+
+-   :material-chart-line:{ .lg .middle } **Chart**
+
+    ---
+
+    Line plots and bar charts with multiple series, axes, and legends.
+
+    [Chart | Guide]{.xnano-card-link data-preview}
+
+-   :material-chart-timeline-variant-shimmer:{ .lg .middle } **Sparkline**
+
+    ---
+
+    Small inline trend charts for dense dashboards and live metrics.
+
+    [Sparkline | Guide]{.xnano-card-link data-preview}
+
+-   :material-code-json:{ .lg .middle } **Schema**
+
+    ---
+
+    Declarative columns and series derived from typed model fields.
+
+    [Schema | Guide]{.xnano-card-link data-preview}
+
+</div>
+
+[AbstractComponent]: ../api/xnano/components/abstract.md
+[BaseGrid]: ../api/xnano/grid.md
+[Text]: ../api/xnano/components/text.md
+[Table]: ../api/xnano/components/table.md
+[Progress]: ../api/xnano/components/progress.md
+[Chart]: ../api/xnano/components/chart.md
+[Sparkline]: ../api/xnano/components/sparkline.md
+[Schema]: ../api/xnano/components/schema.md
+[Text | Guide]: text.md
+[Table | Guide]: table.md
+[Progress | Guide]: progress.md
+[Chart | Guide]: chart.md
+[Sparkline | Guide]: sparkline.md
+[Schema | Guide]: schema.md

--- a/docs/components/progress.md
+++ b/docs/components/progress.md
@@ -1,0 +1,55 @@
+---
+title: "Progress"
+icon: "lucide/activity"
+---
+
+# Progress
+
+`Progress` renders how much of something is done — as a `0.0`–`1.0` ratio, or a `value` out of a `total` — with a percentage label derived automatically.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4"
+    from xnano import render
+    from xnano.components.progress import Progress
+
+    render(Progress(value=0.6, color="emerald-400"))
+    ```
+
+```python title="A Progress Bar" hl_lines="4"
+from xnano import render
+from xnano.components.progress import Progress
+
+render(Progress(value=0.6, color="emerald-400")) # (1)!
+```
+
+1. No `total` means `value` is already the ratio — `0.6` renders as a 60% filled bar labeled `"60%"`.
+
+<div class="xnano-demo" markdown>
+![progress bar dark](../assets/components/progress_bar-dark.gif){.demo-dark}
+![progress bar light](../assets/components/progress_bar-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Pass a `total` instead when the raw numbers are more natural than a ratio, and switch `style` for a thinner line gauge:
+
+```python title="Value Over Total" hl_lines="4"
+from xnano import render
+from xnano.components.progress import Progress
+
+render(Progress(value=340, total=500, style="line", label="downloading"))
+```
+
+<div class="xnano-demo" markdown>
+![progress line dark](../assets/components/progress_line-dark.gif){.demo-dark}
+![progress line light](../assets/components/progress_line-light.gif){.demo-light}
+</div>
+
+<br/>
+
+The full parameter list — colors for the filled and unfilled portions, hiding the label, and more — lives on the [Progress]{data-preview} API reference.
+
+[Progress]: ../api/xnano/components/progress.md

--- a/docs/components/schema.md
+++ b/docs/components/schema.md
@@ -1,0 +1,96 @@
+---
+title: "Schema"
+icon: "lucide/braces"
+---
+
+# Schema
+
+There's no `Schema` widget to instantiate. `Column` and `Series` are descriptors — declared once as class attributes on a `Table` or `Chart` subclass, the same way a `BaseGrid` declares `Field`.
+
+Reach for a bare `Table(data=..., columns=...)` when the shape of your data changes call to call. Reach for a subclass when it doesn't — the columns become part of the class itself, not an argument you pass around.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: data-driven Table with columns= argument versus declarative Table subclass with Column descriptors">
+<svg viewBox="0 0 720 220" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <marker id="sch-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <!-- Data-driven -->
+  <rect class="gcd-panel" x="36" y="28" width="300" height="164" rx="14" />
+  <text class="gcd-label" x="186" y="58" text-anchor="middle">data-driven</text>
+  <rect class="gcd-window" x="60" y="76" width="252" height="40" rx="8" />
+  <text class="gcd-chrome-label" x="186" y="100" text-anchor="middle">Table(data=…, columns=…)</text>
+  <path class="gcd-line" d="M80 140 h80" stroke-width="3" stroke-linecap="round" />
+  <path class="gcd-line-soft" d="M80 156 h160" stroke-width="3" stroke-linecap="round" />
+  <text class="gcd-z-caption" x="186" y="176" text-anchor="middle">shape changes per call</text>
+
+  <!-- Declarative -->
+  <rect class="gcd-panel gcd-panel-accent" x="384" y="28" width="300" height="164" rx="14" />
+  <text class="gcd-label gcd-label-accent" x="534" y="58" text-anchor="middle">declarative</text>
+  <rect class="gcd-window" x="408" y="76" width="252" height="40" rx="8" />
+  <text class="gcd-chrome-label" x="534" y="100" text-anchor="middle">class Services(Table)</text>
+  <text class="gcd-z-label gcd-z-label-on" x="534" y="140" text-anchor="middle">service = Column()</text>
+  <text class="gcd-z-label gcd-z-label-on" x="534" y="160" text-anchor="middle">latency = Column(…)</text>
+  <text class="gcd-z-caption gcd-z-caption-on" x="534" y="182" text-anchor="middle">schema on the class</text>
+</svg>
+</div>
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4 5 6"
+    from xnano import render
+    from xnano.components.table import Column, Table
+
+    class Services(Table):
+        service: str = Column()
+        status: str = Column(color=lambda v: "green" if v == "ok" else "red")
+        latency: int = Column(align="right", format="{}ms")
+
+    render(Services(data=[
+        {"service": "api", "status": "ok", "latency": 12},
+        {"service": "db", "status": "degraded", "latency": 340},
+    ]))
+    ```
+
+```python title="A Declarative Table" hl_lines="4 5 6"
+from xnano.components.table import Column, Table
+
+class Services(Table):
+    service: str = Column() # (1)!
+    status: str = Column(color=lambda v: "green" if v == "ok" else "red") # (2)!
+    latency: int = Column(align="right", format="{}ms")
+
+Services(data=rows, selected=0)
+```
+
+1. A bare `Column()` derives its header from the attribute name (`service` → `"Service"`) and reads the same-named key or attribute off each row.
+2. `color` — and `background`, `format` — accept a callable, so a cell's style can depend on its own value.
+
+<div class="xnano-demo" markdown>
+![table declarative dark](../assets/components/table_declarative-dark.gif){.demo-dark}
+![table declarative light](../assets/components/table_declarative-light.gif){.demo-light}
+</div>
+
+<br/>
+
+`Chart` follows the same pattern with `Series()` instead of `Column()`, for styling one series at a time:
+
+```python title="A Declarative Chart" hl_lines="2 3"
+class Latency(Chart):
+    p50 = Series(color="green")
+    p99 = Series(color="red")
+
+Latency(series={"p50": [12, 14, 11], "p99": [88, 95, 90]})
+```
+
+<br/>
+
+Both descriptors are documented in full on the [Schema]{data-preview} API reference, alongside [Table]{data-preview} and [Chart]{data-preview}.
+
+[Schema]: ../api/xnano/components/schema.md
+[Table]: table.md
+[Chart]: chart.md

--- a/docs/components/sparkline.md
+++ b/docs/components/sparkline.md
@@ -1,0 +1,57 @@
+---
+title: "Sparkline"
+icon: "lucide/trending-up"
+---
+
+# Sparkline
+
+`Sparkline` compresses a sequence of samples into a compact inline bar chart, scaling every bar to fill whatever slot it's placed in.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4"
+    from xnano import Terminal
+    from xnano.components.sparkline import Sparkline
+
+    Terminal(height=4).render(Sparkline(data=[1, 4, 2, 8, 5, 9, 3, 7]))
+    ```
+
+```python title="A Sparkline" hl_lines="4"
+from xnano import Terminal
+from xnano.components.sparkline import Sparkline
+
+Terminal(height=4).render(Sparkline(data=[1, 4, 2, 8, 5, 9, 3, 7])) # (1)!
+```
+
+1. Bar heights auto-scale to the tallest sample — pass `max_value` to fix the ceiling instead, useful when comparing several sparklines against the same scale.
+
+<div class="xnano-demo" markdown>
+![sparkline basic dark](../assets/components/sparkline_basic-dark.gif){.demo-dark}
+![sparkline basic light](../assets/components/sparkline_basic-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Tint individual bars by passing one color per sample — handy for gradients across a time series:
+
+```python title="Per-Bar Colors" hl_lines="5"
+from xnano import Terminal
+from xnano.components.sparkline import Sparkline
+
+Terminal(height=4).render(
+    Sparkline(data=[1, 4, 2, 8], colors=("slate-500", "slate-400", "amber-400", "red-400"))
+)
+```
+
+<div class="xnano-demo" markdown>
+![sparkline colors dark](../assets/components/sparkline_colors-dark.gif){.demo-dark}
+![sparkline colors light](../assets/components/sparkline_colors-light.gif){.demo-light}
+</div>
+
+<br/>
+
+The full parameter list — default/absent-value colors and glyphs — lives on the [Sparkline]{data-preview} API reference.
+
+[Sparkline]: ../api/xnano/components/sparkline.md

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1,0 +1,75 @@
+---
+title: "Table"
+icon: "lucide/table"
+---
+
+# Table
+
+`Table` turns a list of rows into a scrollable, styled terminal table — no manual column layout required.
+
+Feed it dicts, dataclasses, or any attribute-bearing object and it derives columns straight from the data.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4 5 6 7"
+    from xnano import render
+    from xnano.components.table import Table
+
+    render(
+        Table(data=[
+            {"service": "api", "status": "ok", "latency": 12},
+            {"service": "db", "status": "degraded", "latency": 340},
+        ])
+    )
+    ```
+
+```python title="A Data-Driven Table" hl_lines="4 5 6 7"
+from xnano import render
+from xnano.components.table import Table
+
+render(
+    Table(data=[
+        {"service": "api", "status": "ok", "latency": 12},
+        {"service": "db", "status": "degraded", "latency": 340},
+    ]) # (1)!
+)
+```
+
+1. Column names, header text, and cell values all come from the dict keys — nothing else to declare.
+
+<div class="xnano-demo" markdown>
+![table basic dark](../assets/components/table_basic-dark.gif){.demo-dark}
+![table basic light](../assets/components/table_basic-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Override individual columns without giving up the data-driven path — a mapping of field name to header text, formatter, or a full `Column`:
+
+```python title="Overriding Columns" hl_lines="2 3 4 5"
+from xnano.components.table import Column, Table
+
+Table(
+    data=rows,
+    columns={
+        "service": "Service",
+        "latency": Column(align="right", format="{}ms"),
+    },
+)
+```
+
+<div class="xnano-demo" markdown>
+![table declarative dark](../assets/components/table_declarative-dark.gif){.demo-dark}
+![table declarative light](../assets/components/table_declarative-light.gif){.demo-light}
+</div>
+
+<br/>
+
+For a table whose columns are fixed ahead of time, subclassing with `Column()` descriptors reads more like a schema — see [Schema]{data-preview}.
+
+The full parameter list — selection, highlighting, column spacing, and more — lives on the [Table]{data-preview} API reference.
+
+[Table]: ../api/xnano/components/table.md
+[Schema]: schema.md

--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -1,0 +1,166 @@
+---
+title: "Text"
+icon: "lucide/type"
+---
+
+# Text
+
+`Text` is xnano's one component for strings — a single styled span, a line of spans stitched together, a multi-line paragraph, or an editable input, all through the same class.
+
+Every mode is the same constructor, just handed a different shape of `content`: a plain string, a list of `Text` children, or a list of lists.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: Text content shapes — leaf string, line of spans, paragraph of lines">
+<svg viewBox="0 0 720 230" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <!-- Leaf -->
+  <rect class="gcd-panel" x="28" y="36" width="200" height="160" rx="14" />
+  <text class="gcd-label" x="128" y="68" text-anchor="middle">leaf</text>
+  <text class="gcd-chrome-label" x="128" y="90" text-anchor="middle">str</text>
+  <rect class="gcd-cell-highlight-strong" x="52" y="118" width="152" height="36" rx="6" />
+  <text class="gcd-z-label gcd-z-label-on" x="128" y="140" text-anchor="middle">hello</text>
+  <text class="gcd-z-caption" x="128" y="178" text-anchor="middle">one run · one style</text>
+
+  <!-- Line -->
+  <rect class="gcd-panel" x="260" y="36" width="200" height="160" rx="14" />
+  <text class="gcd-label" x="360" y="68" text-anchor="middle">line</text>
+  <text class="gcd-chrome-label" x="360" y="90" text-anchor="middle">list of leaves</text>
+  <rect class="gcd-cell-highlight" x="284" y="118" width="68" height="36" rx="6" />
+  <rect class="gcd-cell-highlight-strong" x="360" y="118" width="76" height="36" rx="6" />
+  <text class="gcd-z-label gcd-z-label-on" x="318" y="140" text-anchor="middle">Hi</text>
+  <text class="gcd-z-label gcd-z-label-on" x="398" y="140" text-anchor="middle">you</text>
+  <text class="gcd-z-caption" x="360" y="178" text-anchor="middle">spans side by side</text>
+
+  <!-- Paragraph -->
+  <rect class="gcd-panel gcd-panel-accent" x="492" y="36" width="200" height="160" rx="14" />
+  <text class="gcd-label gcd-label-accent" x="592" y="68" text-anchor="middle">paragraph</text>
+  <text class="gcd-chrome-label" x="592" y="90" text-anchor="middle">list of lines</text>
+  <rect class="gcd-cell-highlight" x="516" y="108" width="152" height="28" rx="5" />
+  <rect class="gcd-cell-highlight-strong" x="516" y="144" width="120" height="28" rx="5" />
+  <text class="gcd-z-caption gcd-z-caption-on" x="592" y="178" text-anchor="middle">rows stacked</text>
+</svg>
+</div>
+
+## Composing Text
+
+A bare string is a leaf — the simplest form, a single styled run.
+
+```python title="A Leaf" hl_lines="3"
+from xnano.components.text import Text
+
+Text("hello world", color="red", modifiers=("bold",))
+```
+
+<div class="xnano-demo" markdown>
+![text leaf dark](../assets/components/text_leaf-dark.gif){.demo-dark}
+![text leaf light](../assets/components/text_leaf-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Give it a list of leaf `Text` children instead, and they compose into one line, each keeping its own styling.
+
+```python title="A Line" hl_lines="3 4 5 6"
+Text([
+    Text("Hello ", color="cyan"),
+    Text("world", color="red"),
+])
+```
+
+<div class="xnano-demo" markdown>
+![text line dark](../assets/components/text_line-dark.gif){.demo-dark}
+![text line light](../assets/components/text_line-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Nest a list of lines — where at least one child is itself a line — and `Text` becomes a paragraph, stacking each child on its own row.
+
+```python title="A Paragraph" hl_lines="3 4 5"
+Text([
+    Text([Text("Hello ", color="cyan"), Text("world")]),
+    Text("Second line", color="blue"),
+])
+```
+
+<div class="xnano-demo" markdown>
+![text paragraph dark](../assets/components/text_paragraph-dark.gif){.demo-dark}
+![text paragraph light](../assets/components/text_paragraph-light.gif){.demo-light}
+</div>
+
+`Text` figures out which of the three you mean from the shape of `content` alone — there's no separate `Line` or `Paragraph` class to reach for.
+
+## Styling
+
+`color`, `background`, and `modifiers` work the same at every level of nesting — set them on the outer `Text` to style a whole line or paragraph by default, or on individual children to override just that span.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="3 4 5"
+    from xnano import render
+    from xnano.components.text import Text
+
+    render(Text([
+        Text("● ", color="emerald-400"),
+        Text("Done: ", color="white", modifiers=("bold",)),
+        Text("all tests passed", color="slate-300"),
+    ]))
+    ```
+
+```python title="Styling Spans" hl_lines="1 2 3"
+Text([
+    Text("● ", color="emerald-400"), # (1)!
+    Text("Done: ", color="white", modifiers=("bold",)),
+    Text("all tests passed", color="slate-300"),
+])
+```
+
+1. Each child picks its own `color`; a modifier like `"bold"` only has to be set on the span that needs it.
+
+## Alignment
+
+`align` and `wrap` apply at the paragraph level — they control how a `Text`'s lines sit within whatever space its field or `render()` call gives it, not the styling of individual spans.
+
+```python title="Aligning a Paragraph" hl_lines="2"
+Text(
+    "Centered inside its field",
+    align="center",
+)
+```
+
+`align` accepts `"left"` (the default), `"center"`, or `"right"`. `wrap` (default `True`) controls whether a line that's too long for its area breaks onto the next row instead of overflowing.
+
+## Editable Input
+
+Set `input=True` on a leaf `Text` placed in a field, and it becomes a real text box — focusable, part of the tab order, and able to receive keystrokes.
+
+```python title="An Editable Field" hl_lines="3"
+from xnano import BaseGrid, Field
+
+class Form(BaseGrid, direction="vertical"):
+    name: Text = Field(default=Text("", input=True, placeholder="your name"))
+```
+
+<div class="xnano-demo" markdown>
+![text input dark](../assets/components/text_input-dark.gif){.demo-dark}
+![text input light](../assets/components/text_input-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Nothing else is required to make this work. Every `Text(input=True)` field on a live grid is automatically collected into a tab order — the terminal moves focus between them and routes keystrokes to whichever one is focused, without a hook to write.
+
+`placeholder` shows in place of an empty, unfocused input — a plain string renders dim by default, or pass a styled `Text` to keep full control. `cursor` is the caret's index into `content`; leave it `None` and it tracks the end of the string as the user types.
+
+Reacting to focus itself is optional, and uses the same `@on_focus` hook from [events and hooks]{data-preview} — pass the field's name to fire only when that field's focus changes:
+
+```python title="Reacting to Focus" hl_lines="1"
+@on_focus("name", kind="gained")
+def highlight_name_field(self) -> None:
+    ...
+```
+
+The full parameter list — every styling and input option `Text` accepts — lives on the [Text]{data-preview} API reference.
+
+[Text]: ../api/xnano/components/text.md
+[events and hooks]: ../core-concepts/events.md

--- a/docs/core-concepts/actions.md
+++ b/docs/core-concepts/actions.md
@@ -1,0 +1,157 @@
+---
+title: "Actions"
+icon: "lucide/play"
+---
+
+# Actions
+
+An event says what the host observed: a key was pressed, the mouse moved, or the window resized. An [Action]{data-preview} describes the trigger your app cares about — and can produce that same trigger on demand.
+
+That distinction matters once a binding appears in more than one place. Instead of teaching every handler, test, and host that saving means <kbd>Ctrl</kbd>+<kbd>S</kbd>, define the binding once and give it an application-level name.
+
+```python title="Naming a Trigger"
+from xnano import Action
+
+SAVE = Action.keyboard("ctrl+s")
+```
+
+`SAVE` is an immutable value, not a callback. It can be bound to a hook, compared against a real event, or performed against a host as synthetic input.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: a real event or performed action travels through the same action matching and hook dispatch path">
+<svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <marker id="acd-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <!-- Real input -->
+  <rect class="gcd-panel" x="24" y="32" width="176" height="84" rx="12" />
+  <text class="gcd-label" x="112" y="62" text-anchor="middle">real input</text>
+  <text class="gcd-chrome-label" x="112" y="88" text-anchor="middle">Ctrl+S key event</text>
+
+  <!-- Synthetic input -->
+  <rect class="gcd-panel" x="24" y="164" width="176" height="84" rx="12" />
+  <text class="gcd-label" x="112" y="194" text-anchor="middle">perform</text>
+  <text class="gcd-chrome-label" x="112" y="220" text-anchor="middle">host.perform(SAVE)</text>
+
+  <line class="gcd-arrow" x1="200" y1="74" x2="284" y2="124" marker-end="url(#acd-arrow)" />
+  <line class="gcd-arrow" x1="200" y1="206" x2="284" y2="156" marker-end="url(#acd-arrow)" />
+
+  <!-- Shared matcher -->
+  <rect class="gcd-panel gcd-panel-accent" x="296" y="86" width="192" height="108" rx="14" />
+  <text class="gcd-label gcd-label-accent" x="392" y="120" text-anchor="middle">SAVE</text>
+  <text class="gcd-chrome-label" x="392" y="146" text-anchor="middle">Action.keyboard</text>
+  <text class="gcd-z-caption" x="392" y="172" text-anchor="middle">matches ctrl+s</text>
+
+  <line class="gcd-arrow" x1="488" y1="140" x2="548" y2="140" marker-end="url(#acd-arrow)" />
+
+  <!-- Hook -->
+  <rect class="gcd-panel" x="560" y="88" width="136" height="104" rx="14" />
+  <text class="gcd-label" x="628" y="120" text-anchor="middle">hook</text>
+  <text class="gcd-chrome-label" x="628" y="148" text-anchor="middle">@on(SAVE)</text>
+  <text class="gcd-z-label gcd-z-label-on" x="628" y="172" text-anchor="middle">save()</text>
+</svg>
+</div>
+
+## Binding an Action
+
+The general `@on` decorator binds a prebuilt action to a method. When an incoming event satisfies the action's filters, xnano calls the method like any other hook.
+
+```python title="Binding an Action" hl_lines="3 5"
+from xnano import Action, on
+
+SAVE = Action.keyboard("ctrl+s") # (1)!
+
+@on(SAVE) # (2)!
+def save(self) -> None:
+    self.dirty = False
+    self.status = "saved"
+```
+
+1. `Action.keyboard(...)` accepts the same binding grammar as `@on_keyboard`: `"enter"`, `"ctrl+s"`, `"alt+left"`, and so on.
+2. `@on(SAVE)` keeps the method attached to the meaning of the constant. Changing the binding in one place updates every hook that uses it.
+
+<br/>
+
+The specialized decorators are still the clearest choice for one-off bindings. These two hooks behave the same way:
+
+```python title="Actions and Specialized Hooks"
+@on(Action.keyboard("escape"))
+def close_with_action(self) -> None: ...
+
+@on_keyboard("escape")
+def close_with_hook(self) -> None: ...
+```
+
+Reach for an `Action` when a trigger is reused, needs a meaningful name, or will be performed from code. Keep `@on_keyboard`, `@on_click`, and the other specialized hooks for local, one-use reactions.
+
+## Reusing a Binding
+
+A named action can be shared by several grids without either grid owning the physical key choice.
+
+```python title="Reusing a Binding" hl_lines="3 8 13"
+from xnano import Action, BaseGrid, on
+
+SAVE = Action.keyboard("ctrl+s")
+
+class Editor(BaseGrid):
+    @on(SAVE)
+    def save_document(self) -> None:
+        self.status = "saved"
+
+class Settings(BaseGrid):
+    @on(SAVE)
+    def save_preferences(self) -> None:
+        self.status = "preferences saved"
+```
+
+The action does not prescribe what saving does. It only carries the trigger and its filters; each bound hook supplies the reaction appropriate to its grid.
+
+<div class="xnano-demo" markdown>
+![actions binding dark](../assets/concepts/actions_binding-dark.gif){.demo-dark}
+![actions binding light](../assets/concepts/actions_binding-light.gif){.demo-light}
+</div>
+
+## Performing an Action
+
+Every live host can perform an action. The host turns it into an equivalent event and sends it through the same dispatch path as real input, so the existing hooks fire without a second code path.
+
+```python title="Performing an Action" hl_lines="1 5"
+terminal.perform(SAVE) # (1)!
+
+@on_keyboard("f2")
+def save_from_shortcut(self, ctx: Context) -> None:
+    ctx.actions.perform(SAVE) # (2)!
+```
+
+1. `host.perform(...)` is useful in tests, host integrations, and application code that already has the live host.
+2. Inside a hook, `ctx.actions` is the host-bound helper. Performing `SAVE` causes every `@on(SAVE)` hook on the active interface to run.
+
+For common synthetic inputs, the helper also has short methods such as `ctx.actions.press("ctrl+s")`, `click("submit")`, `focus("search")`, `paste("text")`, `resize(...)`, and `tick(...)`.
+
+??? warning "Avoid action loops"
+
+    A performed action can trigger a hook that performs another action. xnano queues that work until the current dispatch finishes, but a hook that performs its own trigger forever is still a loop. Treat `perform()` like emitting input: make sure the reaction eventually stops emitting the same input.
+
+## Action Families
+
+Actions mirror the event families used by the hook decorators:
+
+| Builder | Matches | Specialized hook |
+|---|---|---|
+| `Action.keyboard(*bindings, kind=None)` | key press, release, or repeat | `@on_keyboard` |
+| `Action.mouse(*buttons, kind=None)` | mouse button or movement kind | `@on_mouse` |
+| `Action.click(field=None, button="left")` | click, optionally scoped to a field | `@on_click` |
+| `Action.focus(field=None, kind=None)` | window or field focus change | `@on_focus` |
+| `Action.clipboard(text=None)` | clipboard paste | `@on_clipboard` |
+| `Action.tick(interval_ms=0)` | host clock tick | `@on_tick` |
+| `Action.resize(width=None, height=None)` | host resize | `@on_resize` |
+| `Action.request(method, path)` | web request route | request hooks |
+
+All of them share the same core contract: `matches(event)` checks whether an event satisfies the action, while `to_event()` creates the synthetic event used by `perform()`.
+
+The next concept, [Context]{data-preview}, is where the host, current event, shared state, and the `ctx.actions` helper come together inside a hook.
+
+[Action]: ../api/xnano/core/actions.md
+[Context]: ../api/xnano/context.md

--- a/docs/core-concepts/cli.md
+++ b/docs/core-concepts/cli.md
@@ -1,0 +1,263 @@
+---
+title: "CLI Commands"
+icon: "lucide/terminal"
+---
+
+# CLI Commands
+
+!!! warning "Experimental"
+
+    This feature is not only experimental but meant purely as a prototyping surface. This is in **no way**, and will never be a replacement for frameworks such as [typer](https://typer.tiangolo.com/) or [click](https://click.palletsprojects.com/).
+
+[Command]{data-preview} is xnano's CLI surface — declarative options and subcommands for process arguments, with the same spirit as grids and fields, aimed for creating small command-line tools rather than full terminal applications.
+
+It is not a TUI host. Use it when a tool needs a real command-line entrypoint; pair it with [Terminal]{data-preview} only when the same project also runs an interactive session.
+
+A `Command` can:
+
+- Register a root callback <small>(`@cli` or `register_callback`)</small>
+- Declare options and flags <small>(`@Command.option`)</small>
+- Nest subcommands <small>(`@cli.command()` or `add_subcommand`)</small>
+- Coerce values from type annotations <small>(optionally `strict=True`)</small>
+- Emit help automatically <small>(`--help` / `-h`)</small>
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: argv flows into Command parse, then into a callback or nested subcommand">
+<svg viewBox="0 0 720 220" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <marker id="cli-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <rect class="gcd-panel" x="28" y="60" width="140" height="80" rx="12" />
+  <text class="gcd-label" x="98" y="96" text-anchor="middle">argv</text>
+  <text class="gcd-chrome-label" x="98" y="118" text-anchor="middle">flags · words</text>
+
+  <line class="gcd-arrow" x1="168" y1="100" x2="220" y2="100" marker-end="url(#cli-arrow)" />
+
+  <rect class="gcd-panel gcd-panel-accent" x="232" y="48" width="200" height="104" rx="14" />
+  <text class="gcd-label gcd-label-accent" x="332" y="84" text-anchor="middle">Command</text>
+  <text class="gcd-chrome-label" x="332" y="108" text-anchor="middle">parse · coerce</text>
+  <text class="gcd-chrome-label" x="332" y="128" text-anchor="middle">help · route</text>
+
+  <line class="gcd-arrow" x1="432" y1="80" x2="488" y2="60" marker-end="url(#cli-arrow)" />
+  <line class="gcd-arrow" x1="432" y1="120" x2="488" y2="140" marker-end="url(#cli-arrow)" />
+
+  <rect class="gcd-window" x="500" y="36" width="192" height="56" rx="10" />
+  <text class="gcd-chrome-label" x="596" y="68" text-anchor="middle">root callback</text>
+
+  <rect class="gcd-window" x="500" y="116" width="192" height="56" rx="10" />
+  <text class="gcd-chrome-label" x="596" y="148" text-anchor="middle">subcommand</text>
+</svg>
+</div>
+
+## A Root Command
+
+Construct a `Command`, register a callback with `@cli`, and decorate options with `@Command.option`. Parameter names map from flags (`--name` → `name`).
+
+```python title="A Root Command" hl_lines="3 5 6 7 8"
+from xnano.cli import Command
+
+cli = Command(name="tool", description="A small utility")
+
+@cli # (1)!
+@Command.option("--name", default="world", help="Who to greet")
+def greet(name: str = "world") -> None:
+    print(f"hello, {name}")
+
+if __name__ == "__main__":
+    cli.run() # (2)!
+```
+
+1. `@cli` registers the function as this command's main callback. The same form works as `cli(greet)` after the function is defined, or as `cli.register_callback(greet)`.
+2. `run()` parses `sys.argv[1:]` by default. Pass a list explicitly in tests or demos: `cli.run(["--name", "hammad"])`.
+
+<br/>
+
+```bash title="Usage"
+uv run python tool.py
+# hello, world
+
+uv run python tool.py --name hammad
+# hello, hammad
+
+uv run python tool.py --help
+```
+
+<div class="xnano-demo" markdown>
+![cli root dark](../assets/concepts/cli_root-dark.gif){.demo-dark}
+![cli root light](../assets/concepts/cli_root-light.gif){.demo-light}
+</div>
+
+Types on the signature drive coercion when values are parseable (`int`, `bool`, and so on). Set `Command(strict=True)` to raise on bad values instead of falling back to the raw string.
+
+## Options and Flags
+
+`@Command.option` attaches flags, defaults, and help text. A list of flags gives short aliases. Boolean parameters become flags when annotated `bool` or when `is_flag=True` is set — present on the command line → `True`; absent → the default.
+
+```python title="Options and Flags" hl_lines="6 7 8 9"
+from xnano.cli import Command
+
+cli = Command(name="build", description="Compile the project")
+
+@cli
+@Command.option("--count", default=1, help="How many times")
+@Command.option(["--verbose", "-v"], is_flag=True, help="Verbose output")
+def main(count: int = 1, verbose: bool = False) -> None: # (1)!
+    mode = "verbose" if verbose else "quiet"
+    print(f"building ×{count} ({mode})")
+```
+
+1. `--count` takes a value; `-v` / `--verbose` is a bare flag. Parameter names still match the long flag form (`count`, `verbose`).
+
+<br/>
+
+```bash title="Usage"
+uv run python build.py --count 3 -v
+# building ×3 (verbose)
+```
+
+<div class="xnano-demo" markdown>
+![cli flags dark](../assets/concepts/cli_flags-dark.gif){.demo-dark}
+![cli flags light](../assets/concepts/cli_flags-light.gif){.demo-light}
+</div>
+
+Parameters without an explicit `@Command.option` still appear as `--param-name` flags derived from the signature. A required parameter with no default must be provided or `run()` exits with an error and the help text.
+
+??? note "Flags vs. Values"
+
+    - `is_flag=True` (or a `bool` annotation / default) treats presence as `True`.
+    - Otherwise the next argument is the value (`--count 3` or `--count=3`).
+    - The same validation helpers that power fields also coerce CLI values when types are annotated.
+
+## Subcommands
+
+`@cli.command()` nests another command under a name. Options attach to the subcommand function the same way they do on the root.
+
+```python title="Subcommands" hl_lines="5 6 7 8 10 11 12 13 14"
+from xnano.cli import Command
+
+cli = Command(name="ship", description="Release helpers")
+
+@cli.command(name="greet", description="Print a greeting")
+@Command.option("--name", default="world", help="Who to greet")
+def greet(name: str = "world") -> None:
+    print(f"hello, {name}")
+
+@cli.command(name="bump")
+@Command.option("--major", is_flag=True, help="Bump the major version")
+def bump(major: bool = False) -> None:
+    kind = "major" if major else "patch"
+    print(f"bumping {kind}")
+
+if __name__ == "__main__":
+    cli.run()
+```
+
+<br/>
+
+```bash title="Usage"
+uv run python ship.py greet --name crew
+# hello, crew
+
+uv run python ship.py bump --major
+# bumping major
+
+uv run python ship.py --help
+uv run python ship.py bump --help
+```
+
+<div class="xnano-demo" markdown>
+![cli subcommands dark](../assets/concepts/cli_subcommands-dark.gif){.demo-dark}
+![cli subcommands light](../assets/concepts/cli_subcommands-light.gif){.demo-light}
+</div>
+
+Subcommand names default from the function name with underscores turned into hyphens (`def dry_run` → `dry-run`) when `name=` is omitted. Descriptions fall back to the function docstring.
+
+You can also build a tree programmatically with `add_subcommand(Command(...))` when a subcommand is defined separately.
+
+## Help
+
+With `help=True` (the default), `--help` and `-h` print a generated usage block and exit. The same text is available as a string via `get_help()` without running the process.
+
+```python title="Help Text" hl_lines="8"
+from xnano.cli import Command
+
+cli = Command(name="tool", description="A small utility")
+
+@cli
+@Command.option("--name", default="world", help="Who to greet")
+def greet(name: str = "world") -> None:
+    print(f"hello, {name}")
+
+print(cli.get_help()) # (1)!
+```
+
+1. Useful in docs, tests, or when embedding help in another UI. Requesting help through `parse_arguments(["--help"])` raises `HelpException`; `run()` catches it and prints help for you.
+
+<br/>
+
+```text title="Example help"
+Usage: tool [OPTIONS]
+
+A small utility
+
+Options:
+  --name               Who to greet [default: world]
+  --help, -h           Show this message and exit.
+```
+
+<div class="xnano-demo" markdown>
+![cli help dark](../assets/concepts/cli_help-dark.gif){.demo-dark}
+![cli help light](../assets/concepts/cli_help-light.gif){.demo-light}
+</div>
+
+## Strict Mode
+
+`Command(strict=True)` makes type coercion fail loudly. With `strict=False` (the default), a value that cannot be coerced to the annotation is left as the raw string.
+
+```python title="Strict Mode" hl_lines="3 6"
+from xnano.cli import Command
+
+cli = Command(name="count", strict=True)
+
+@cli
+def main(n: int) -> None:
+    print(n * 2)
+
+cli.run(["--n", "21"])   # prints 42
+# cli.run(["--n", "nope"])  # Error: Invalid value for parameter 'n': ...
+```
+
+<br/>
+
+Reach for `strict=True` when a tool should refuse bad input rather than silently treat `"nope"` as a string.
+
+## Parsing Without Running
+
+`parse_arguments` returns the target `Command` and a dict of validated values without calling the callback — useful for tests and composition.
+
+```python title="Parse Only" hl_lines="8 9"
+from xnano.cli import Command
+
+cli = Command(name="tool")
+
+@cli
+@Command.option("--name", default="world")
+def greet(name: str = "world") -> None:
+    ...
+
+target, values = cli.parse_arguments(["--name", "hammad"])
+assert values["name"] == "hammad"
+assert target is cli
+```
+
+## Next Steps
+
+- Full parameter lists and signatures: the [Command]{data-preview} API reference
+- A shorter recipe-oriented walkthrough: [CLI Commands]{data-preview} in Tutorials
+- Interactive UI surface when you need a live session: [Terminal]{data-preview}
+
+[Command]: ../api/xnano/cli/command.md
+[Terminal]: ../api/xnano/tui/terminal.md
+[CLI Commands]: ../tutorials/cli-commands.md

--- a/docs/core-concepts/components.md
+++ b/docs/core-concepts/components.md
@@ -1,0 +1,69 @@
+---
+title: "Components"
+icon: "lucide/package"
+---
+
+# Components
+
+A component is a piece of pre-built, ready-to-use content — a progress bar, a table, a chart — that behaves like any other value you'd hand to a `Field`.
+
+You've been styling plain strings for every example so far. A component is what you reach for once a string isn't enough to represent what you're showing.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: a Field slot can hold a plain string or a component value such as Progress">
+<svg viewBox="0 0 720 210" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <pattern id="ccd-cell" width="12" height="12" patternUnits="userSpaceOnUse">
+      <path d="M 12 0 L 0 0 0 12" class="gcd-grid-line" />
+    </pattern>
+  </defs>
+
+  <!-- Left: string value -->
+  <g transform="translate(48, 36)">
+    <rect class="gcd-window" x="0" y="0" width="280" height="140" rx="12" />
+    <rect class="gcd-chrome" x="0" y="0" width="280" height="26" rx="12" />
+    <rect class="gcd-chrome" x="0" y="14" width="280" height="12" />
+    <text class="gcd-chrome-label" x="140" y="17" text-anchor="middle">Field value = str</text>
+    <rect class="gcd-grid-fill" x="16" y="42" width="248" height="80" rx="6" />
+    <rect x="16" y="42" width="248" height="80" rx="6" fill="url(#ccd-cell)" />
+    <rect class="gcd-cell-highlight" x="32" y="58" width="216" height="48" rx="4" />
+    <text class="gcd-z-label gcd-z-label-on" x="140" y="86" text-anchor="middle">"Downloading…"</text>
+  </g>
+
+  <!-- Right: component value -->
+  <g transform="translate(392, 36)">
+    <rect class="gcd-window" x="0" y="0" width="280" height="140" rx="12" />
+    <rect class="gcd-chrome" x="0" y="0" width="280" height="26" rx="12" />
+    <rect class="gcd-chrome" x="0" y="14" width="280" height="12" />
+    <text class="gcd-chrome-label" x="140" y="17" text-anchor="middle">Field value = Progress</text>
+    <rect class="gcd-grid-fill" x="16" y="42" width="248" height="80" rx="6" />
+    <rect x="16" y="42" width="248" height="80" rx="6" fill="url(#ccd-cell)" />
+    <rect class="gcd-cell-highlight-strong" x="32" y="72" width="140" height="16" rx="3" />
+    <rect class="gcd-z-base" x="172" y="72" width="76" height="16" rx="3" />
+    <text class="gcd-z-label gcd-z-label-on" x="140" y="112" text-anchor="middle">40%</text>
+  </g>
+</svg>
+</div>
+
+```python title="Using a Component" hl_lines="2 6"
+from xnano import BaseGrid, Field
+from xnano.components.progress import Progress
+
+class Download(BaseGrid, direction="vertical"):
+    status: str = Field(default="Downloading…", height=1)
+    bar: Progress = Field(default_factory=lambda: Progress(value=0.4)) # (1)!
+```
+
+1. `Progress` is a component like any other — assign it as a field's default (or `default_factory`, since it's not a plain immutable value) the same way you would a string.
+
+<div class="xnano-demo" markdown>
+![component progress dark](../assets/concepts/component_progress-dark.gif){.demo-dark}
+![component progress light](../assets/concepts/component_progress-light.gif){.demo-light}
+</div>
+
+<br/>
+
+xnano ships a handful of built-in components — `Text`, `Table`, `Progress`, `Chart`, `Sparkline`, and `Schema` — each covered in its own page in the [Components]{data-preview} section.
+
+You can also write your own. A component is just a small, well-defined contract to implement — covered in full, with a working example, at the start of that same section.
+
+[Components]: ../components/index.md

--- a/docs/core-concepts/context.md
+++ b/docs/core-concepts/context.md
@@ -1,0 +1,134 @@
+---
+title: "Context"
+icon: "lucide/key"
+---
+
+# Context
+
+The second parameter on a hook is always the same object: a [Context]{data-preview} — everything a handler might need to know about the moment it fired, bundled into one argument instead of a dozen.
+
+You've already seen this shape once, on the last page — a hook that takes just `self` gets called with nothing else; add `ctx`, and xnano fills it in.
+
+`Context` is never something you construct yourself. It's built by the host — a [Terminal]{data-preview}, most commonly — and handed to your handler, the same way a request object is handed to a route handler in a web framework.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: the host builds a Context bag of event, terminal, state, and device, then passes it into the hook">
+<svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <marker id="ctx-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <!-- Host -->
+  <rect class="gcd-panel" x="28" y="40" width="168" height="200" rx="14" />
+  <text class="gcd-label" x="112" y="72" text-anchor="middle">host</text>
+  <path class="gcd-line" d="M52 100 h88" stroke-width="3" stroke-linecap="round" />
+  <path class="gcd-line-soft" d="M52 120 h120" stroke-width="3" stroke-linecap="round" />
+  <path class="gcd-line-soft" d="M52 140 h72" stroke-width="3" stroke-linecap="round" />
+  <text class="gcd-chrome-label" x="112" y="190" text-anchor="middle">builds ctx</text>
+  <text class="gcd-chrome-label" x="112" y="210" text-anchor="middle">per hook call</text>
+
+  <line class="gcd-arrow" x1="196" y1="140" x2="248" y2="140" marker-end="url(#ctx-arrow)" />
+
+  <!-- Context bag -->
+  <rect class="gcd-panel gcd-panel-accent" x="260" y="28" width="220" height="224" rx="14" />
+  <text class="gcd-label gcd-label-accent" x="370" y="58" text-anchor="middle">Context</text>
+
+  <rect class="gcd-window" x="284" y="78" width="172" height="32" rx="8" />
+  <text class="gcd-chrome-label" x="370" y="98" text-anchor="middle">event</text>
+
+  <rect class="gcd-window" x="284" y="120" width="172" height="32" rx="8" />
+  <text class="gcd-chrome-label" x="370" y="140" text-anchor="middle">terminal / host</text>
+
+  <rect class="gcd-window" x="284" y="162" width="172" height="32" rx="8" />
+  <text class="gcd-chrome-label" x="370" y="182" text-anchor="middle">state</text>
+
+  <rect class="gcd-window" x="284" y="204" width="172" height="32" rx="8" />
+  <text class="gcd-chrome-label" x="370" y="224" text-anchor="middle">device · cursor</text>
+
+  <line class="gcd-arrow" x1="480" y1="140" x2="532" y2="140" marker-end="url(#ctx-arrow)" />
+
+  <!-- Hook -->
+  <rect class="gcd-panel" x="544" y="88" width="152" height="104" rx="14" />
+  <text class="gcd-label" x="620" y="124" text-anchor="middle">hook</text>
+  <text class="gcd-z-label gcd-z-label-on" x="620" y="150" text-anchor="middle">def on_*(</text>
+  <text class="gcd-z-label gcd-z-label-on" x="620" y="168" text-anchor="middle">self, ctx)</text>
+</svg>
+</div>
+
+## Reading the Event
+
+Whatever triggered the hook is on `ctx` too, already narrowed to the kind of hook it fired from.
+
+```python title="Reading the Event"
+@on_keyboard("enter")
+def submit(self, ctx: Context) -> None:
+    key = ctx.keyboard      # the KeyboardEventData that fired this hook
+    term = ctx.terminal     # the live Terminal instance
+```
+
+<br/>
+
+`ctx.keyboard` and `ctx.mouse` are `None` unless the hook that's running actually fired from that kind of event — a `@on_tick` handler's `ctx.keyboard` is always `None`, for instance.
+
+## Typing Context by State
+
+`Context` is generic over whatever state you pass to `Terminal(state=...)` — a dataclass, a Pydantic model, or nothing at all. Parameterize it the same way you would a typed Pydantic model, and `ctx.get_state()` comes back typed instead of `Any`.
+
+```python title="Typing Context by State" hl_lines="4 9"
+import dataclasses
+from xnano import BaseGrid, Context, Field, Terminal
+from xnano.events import on_keyboard
+
+@dataclasses.dataclass
+class AppState:
+    count: int = 0
+
+class Counter(BaseGrid, direction="vertical"):
+    label: str = Field(default="Count: 0", height=1)
+
+    @on_keyboard("up")
+    def inc(self, ctx: Context[AppState]) -> None: # (1)!
+        state = ctx.get_state() # (2)!
+        state.count += 1
+        self.label = f"Count: {state.count}"
+
+Terminal(state=AppState()).run(Counter())
+```
+
+1. `Context[AppState]` is the same generic pattern as a typed Pydantic model — it doesn't change anything at runtime, but `ctx.get_state()` now returns an `AppState`, not `Any`.
+2. `ctx.get_state()` raises if no `state=` was ever attached to the `Terminal` — reach for a `state=True` field instead when a value only needs to live on one grid, not the whole app.
+
+<div class="xnano-demo" markdown>
+![context state dark](../assets/concepts/context_state-dark.gif){.demo-dark}
+![context state light](../assets/concepts/context_state-light.gif){.demo-light}
+</div>
+
+<br/>
+
+??? note "The State Class"
+
+    Nothing above requires xnano's own `State` class — a plain dataclass or Pydantic model works exactly the same way. `State` exists purely as a convenience for apps that don't want to define a schema up front:
+
+    ```python
+    from xnano import State
+
+    state = State(name="John", count=0)
+    state.count += 1
+    ```
+
+    <br/>
+
+    It's not "the" context state type, just one option among several — reach for a dataclass or Pydantic model instead whenever a fixed schema is worth the extra line.
+
+## Everything Else on Context
+
+A hook rarely needs more than the event, the terminal, and the state — but a few more shortcuts live on `ctx` for when it does:
+
+- `ctx.cursor` / `ctx.device` — the active host's caret and window/tab controls, covered next.
+- `ctx.actions` — perform a synthetic input against the live host, as if it had actually happened.
+- `ctx.stage` — the active host's layout map and cell-level paint, for advanced/manual drawing.
+- `ctx.has_keyboard_event()`, `ctx.has_mouse_event()`, and similar — quick predicates when a hook is bound to more than one kind of event.
+
+[Terminal]: ../api/xnano/tui/terminal.md
+[Context]: ../api/xnano/context.md

--- a/docs/core-concepts/device.md
+++ b/docs/core-concepts/device.md
@@ -1,0 +1,118 @@
+---
+title: "Device & Cursor"
+icon: "lucide/mouse-pointer"
+---
+
+# Device & Cursor
+
+Every host — terminal or browser — exposes two small controls that sit outside the grid entirely: a `device`, for things like the window title, clearing the screen, and the clipboard, and a `cursor`, for the caret itself.
+
+Neither belongs to any grid you build. They belong to the host underneath it, the same way `document.title` belongs to the page, not to any one component on it.
+
+Both are available on [Context]{data-preview}, alongside the event and the terminal — reached the same way from any hook, on any host.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: device title and cursor sit on the host chrome outside the app grid">
+<svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <pattern id="dcd-cell" width="14" height="14" patternUnits="userSpaceOnUse">
+      <path d="M 14 0 L 0 0 0 14" class="gcd-grid-line" />
+    </pattern>
+  </defs>
+
+  <!-- Outer host window -->
+  <rect class="gcd-window" x="80" y="28" width="560" height="200" rx="14" />
+  <!-- Title bar = device -->
+  <rect class="gcd-chrome" x="80" y="28" width="560" height="36" rx="14" />
+  <rect class="gcd-chrome" x="80" y="48" width="560" height="16" />
+  <circle class="gcd-dot" cx="104" cy="46" r="4" />
+  <circle class="gcd-dot" cx="122" cy="46" r="4" />
+  <circle class="gcd-dot" cx="140" cy="46" r="4" />
+  <text class="gcd-chrome-label" x="360" y="50" text-anchor="middle">device.title · clipboard · window</text>
+
+  <!-- Grid body -->
+  <rect class="gcd-grid-fill" x="104" y="80" width="512" height="124" rx="6" />
+  <rect x="104" y="80" width="512" height="124" rx="6" fill="url(#dcd-cell)" />
+  <rect class="gcd-cell-highlight" x="128" y="100" width="200" height="72" rx="4" />
+  <text class="gcd-z-label gcd-z-label-on" x="228" y="140" text-anchor="middle">your grid</text>
+
+  <!-- Cursor caret outside grid ownership -->
+  <rect class="gcd-z-overlay" x="420" y="132" width="3" height="28" rx="1" />
+  <text class="gcd-z-caption gcd-z-caption-on" x="460" y="150">cursor</text>
+
+  <text class="gcd-z-caption" x="360" y="248" text-anchor="middle">host chrome — not a field, not a grid slot</text>
+</svg>
+</div>
+
+## The Device
+
+A device is the one thing every grid on a host shares — its window or tab.
+
+```python title="Setting the Window Title" hl_lines="3"
+@on_state("unread > 0")
+def flash_title(self, ctx: Context) -> None:
+    unread = ctx.get_state().unread
+    ctx.device.title = f"({unread}) inbox" # (1)!
+```
+
+1. `ctx.device.title` sets the terminal window's or browser tab's title — whichever host the app happens to be running on.
+
+<br/>
+
+The clipboard works the same way, from either host:
+
+```python title="Copying to the Clipboard" hl_lines="2"
+@on_keyboard("ctrl+c")
+def copy_selection(self, ctx: Context) -> None:
+    ctx.device.copy_to_clipboard(self.selected_text)
+```
+
+## The Cursor
+
+The cursor isn't part of your grid at all — it's the host's own caret, borrowed for as long as your app is running.
+
+```python title="Hiding the Cursor" hl_lines="2"
+@on_focus("search", kind="gained")
+def hide_caret_while_searching(self, ctx: Context) -> None:
+    ctx.cursor.visible = False # (1)!
+```
+
+1. Most apps never touch `cursor.visible` — it defaults to on. Turn it off for anything that draws its own selection or highlight instead of relying on the caret.
+
+## Terminal vs. Browser
+
+Not every control means the same thing on both hosts. `Device` and `Cursor` share one contract, but a browser has no raw terminal underneath to back some of it.
+
+On the terminal, the cursor is a real, movable caret.
+
+```python title="Moving the Cursor" hl_lines="3"
+@on_tick(500)
+def blink_marker(self, ctx: Context) -> None:
+    ctx.cursor.move_to(4, 2) # (1)!
+    ctx.cursor.style = "blinking_bar"
+```
+
+1. `move_to` — and the rest of the position/movement methods — never errors on a web host, since it's part of the shared contract. It's just a no-op there: a browser has no single caret position to move.
+
+<br/>
+
+The same goes for `device`. Raw mode, the alternate screen buffer, mouse capture, and a handful of other terminal-mode flags only exist on [TerminalDevice]{data-preview} — [WebDevice]{data-preview} has no raw mode to toggle and no alternate screen to swap to.
+
+| | Terminal | Browser |
+|---|---|---|
+| `device` | full control — title, size, clipboard, screen, terminal modes | title, size, clipboard — screen/mode controls are no-ops |
+| `cursor` | a real, movable caret — position, visibility, style | visibility and style only — position is a no-op |
+
+??? abstract "Full Device and Cursor Reference"
+
+    - `device.title`, `device.size`, `device.clear()`, `device.scroll_up()` / `scroll_down()`, `device.copy_to_clipboard()` — the shared [Device]{data-preview} contract, on both hosts.
+    - `device.raw_mode`, `device.alternate_screen`, `device.line_wrap`, `device.mouse_capture`, `device.bracketed_paste`, `device.focus_change`, `device.synchronized_updates` — [TerminalDevice]{data-preview} only.
+    - `cursor.visible`, `cursor.style` — the shared [Cursor]{data-preview} contract, on both hosts.
+    - `cursor.move_to()` and the rest of the position/movement methods, `enable_blinking()` / `disable_blinking()` — [TerminalCursor]{data-preview} only.
+    - [WebDevice]{data-preview} implements the same `Device`/`Cursor` contract for the browser host, with terminal-only members reduced to safe no-ops.
+
+[Context]: ../api/xnano/context.md
+[Device]: ../api/xnano/core/device.md
+[Cursor]: ../api/xnano/core/device.md
+[TerminalDevice]: ../api/xnano/tui/device.md
+[TerminalCursor]: ../api/xnano/tui/cursor.md
+[WebDevice]: ../api/xnano/webui/device.md

--- a/docs/core-concepts/events.md
+++ b/docs/core-concepts/events.md
@@ -1,0 +1,157 @@
+---
+title: "Events & Hooks"
+icon: "lucide/zap"
+---
+
+# Events & Hooks
+
+A grid isn't just laid out once. A method wrapped in one of xnano's `@on_*` decorators turns into a hook — fired whenever something happens to it, whether that's a key press, a click, or a tick of the clock.
+
+Hooks live directly on the grid they affect, the same way a Pydantic validator lives on the model it validates.
+
+There's no central event bus to register with, and no dispatch table to maintain. Decorate a method, and xnano wires it up the moment the grid is live.
+
+A hook can react to:
+
+- Keyboard presses <small>(`@on_keyboard`)</small>
+- Mouse clicks and movement <small>(`@on_mouse`, `@on_click`)</small>
+- The clock <small>(`@on_tick`)</small>
+- Focus, resize, clipboard, and state changes <small>(`@on_focus`, `@on_resize`, `@on_clipboard`, `@on_state`)</small>
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: host events wire straight into decorated methods on the grid — no central event bus">
+<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <marker id="ecd-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <!-- Host -->
+  <rect class="gcd-panel" x="24" y="36" width="200" height="180" rx="14" />
+  <text class="gcd-label" x="124" y="64" text-anchor="middle">host</text>
+
+  <rect class="gcd-window" x="48" y="84" width="152" height="36" rx="8" />
+  <text class="gcd-chrome-label" x="124" y="106" text-anchor="middle">key · click · tick</text>
+
+  <rect class="gcd-window" x="48" y="132" width="152" height="36" rx="8" />
+  <text class="gcd-chrome-label" x="124" y="154" text-anchor="middle">focus · resize · paste</text>
+
+  <text class="gcd-z-caption" x="124" y="196" text-anchor="middle">what happened</text>
+
+  <line class="gcd-arrow" x1="224" y1="126" x2="300" y2="126" marker-end="url(#ecd-arrow)" />
+  <text class="gcd-z-caption" x="262" y="114" text-anchor="middle">match</text>
+
+  <!-- Grid with hooks on methods -->
+  <rect class="gcd-panel gcd-panel-accent" x="312" y="36" width="384" height="180" rx="14" />
+  <text class="gcd-label gcd-label-accent" x="504" y="64" text-anchor="middle">grid</text>
+
+  <rect class="gcd-window" x="340" y="86" width="152" height="48" rx="8" />
+  <text class="gcd-chrome-label" x="416" y="106" text-anchor="middle">@on_keyboard</text>
+  <text class="gcd-z-label gcd-z-label-on" x="416" y="124" text-anchor="middle">def inc(self)</text>
+
+  <rect class="gcd-window" x="512" y="86" width="152" height="48" rx="8" />
+  <text class="gcd-chrome-label" x="588" y="106" text-anchor="middle">@on_tick</text>
+  <text class="gcd-z-label gcd-z-label-on" x="588" y="124" text-anchor="middle">def pulse(self)</text>
+
+  <rect class="gcd-window" x="340" y="150" width="324" height="40" rx="8" />
+  <text class="gcd-chrome-label" x="502" y="174" text-anchor="middle">hooks live on the grid — not a global bus</text>
+</svg>
+</div>
+
+## Responding to Keys
+
+`@on_keyboard` fires the decorated method whenever a matching key is pressed. Combine it with a `state=True` field from the last page, and a handler becomes a plain, live counter.
+
+```python title="Responding to Keys" hl_lines="8 10 14"
+from xnano import BaseGrid, Field, Terminal
+from xnano.events import on_keyboard
+
+class Counter(BaseGrid, direction="vertical", gap=1):
+    label: str = Field(default="Count: 0", height=1)
+    hint:  str = Field(default="↑ / ↓ to count", height=1, color="slate-500")
+
+    count: int = Field(default=0, state=True) # (1)!
+
+    @on_keyboard("up")
+    def inc(self) -> None: # (2)!
+        self.count += 1
+        self.label = f"Count: {self.count}"
+
+    @on_keyboard("down")
+    def dec(self) -> None:
+        self.count -= 1
+        self.label = f"Count: {self.count}"
+
+Terminal().run(Counter())
+```
+
+1. Nothing new here — `count` is the same `state=True` field from the last page: live data, never painted directly.
+2. A hook that takes just `self` is called with no extra arguments. Add a second parameter (covered next) when a handler needs more than the grid itself.
+
+<div class="xnano-demo" markdown>
+![counter dark](../assets/concepts/hooks_keyboard-dark.gif){.demo-dark}
+![counter light](../assets/concepts/hooks_keyboard-light.gif){.demo-light}
+</div>
+
+## The Context Object
+
+Add a second parameter to any hook, and xnano fills it with a [Context]{data-preview} — the event that fired, the live [Terminal]{data-preview}, and whatever application state you're tracking.
+
+```python title="The Context Object" hl_lines="1 4 5"
+from xnano import Context
+from xnano.events import on_keyboard
+
+@on_keyboard("q")
+def quit(self, ctx: Context) -> None: # (1)!
+    ctx.terminal.request_exit() # (2)!
+```
+
+1. Typing `ctx` as `Context` isn't required — xnano dispatches on the handler's *arity*, not its annotations — but it's what gets you autocomplete on `ctx.terminal`, `ctx.keyboard`, and everything else it carries.
+2. `ctx.terminal` is the live `Terminal` running this grid; `request_exit()` ends its session.
+
+<br/>
+
+`Context` deserves its own page — its concept page covers what else it carries, and how to type it against your own application state.
+
+## Reacting to the Clock
+
+`@on_tick` fires on a repeating interval instead of a discrete event — useful for clocks, animations, or polling something in the background.
+
+```python title="Reacting to the Clock" hl_lines="6"
+import time
+from xnano import BaseGrid, Field, Terminal
+from xnano.events import on_tick
+
+class Clock(BaseGrid, direction="vertical"):
+    display: str = Field(default="", height=3, border="rounded", title=" Time ")
+
+    @on_tick(1000) # (1)!
+    def update(self) -> None:
+        self.display = time.strftime("  %H:%M:%S")
+
+Terminal().run(Clock())
+```
+
+1. The number is an interval in milliseconds. A bare `@on_tick` fires on every frame instead — pass a short interval (`16`, for roughly 60fps) for animation.
+
+<div class="xnano-demo" markdown>
+![clock dark](../assets/concepts/hooks_tick-dark.gif){.demo-dark}
+![clock light](../assets/concepts/hooks_tick-light.gif){.demo-light}
+</div>
+
+??? abstract "More Ways to Bind"
+
+    A few more hooks round out the set — each documented in full on the [events]{data-preview} API reference.
+
+    - `@on_click("field_name")` — a click on a specific field's area.
+    - `@on_focus` / `@on_focus("field_name")` — terminal window focus, or a field gaining/losing input focus.
+    - `@on_resize` — the terminal was resized.
+    - `@on_clipboard` — a paste event.
+    - `@on_state("expression")` / `@on_field("expression")` — fires each tick when a Python expression evaluated against shared state (or the grid's own fields) comes out truthy.
+    - `@on_poll` — fires on idle waits or every frame, for background work.
+    - `@on(SAVE)` — bind a reusable [Action]{data-preview} (e.g. `Action.keyboard("ctrl+s")`) instead of repeating the same binding across handlers.
+
+[Context]: ../api/xnano/context.md
+[Terminal]: ../api/xnano/tui/terminal.md
+[Action]: ../api/xnano/core/actions.md
+[events]: ../api/xnano/events.md

--- a/docs/core-concepts/fields.md
+++ b/docs/core-concepts/fields.md
@@ -1,0 +1,141 @@
+---
+title: "Fields"
+icon: "lucide/list"
+---
+
+# Fields
+
+Every attribute you declare with `Field()` on a grid is doing two jobs at once.
+
+It's a typed piece of data, the same way a Pydantic `Field()` is. And it's a slot — a rectangular region of the grid this data occupies, sized and styled on its own terms.
+
+If you've used Pydantic, `Field(default=...)` already feels familiar. xnano's `Field` starts there and keeps going — the same call that sets a default also decides where this field's slot sits, how big it is, and how it looks once painted.
+
+Declaring a field gives that attribute:
+
+- A size <small>(`width` / `height` — in cells, a percentage, a fraction, or `"fit"`)</small>
+- An appearance <small>(`color`, `border`, `padding`, and more)</small>
+- A say in whether it renders at all <small>(`state=True` fields hold data but never paint)</small>
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: a Field splits into typed data and a painted slot on the grid; state=True fields have data but no slot">
+<svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <pattern id="fcd-cell" width="14" height="14" patternUnits="userSpaceOnUse">
+      <path d="M 14 0 L 0 0 0 14" class="gcd-grid-line" />
+    </pattern>
+    <marker id="fcd-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <!-- Source: Field() call -->
+  <rect class="gcd-panel gcd-panel-accent" x="40" y="90" width="160" height="72" rx="12" />
+  <text class="gcd-label gcd-label-accent" x="120" y="122" text-anchor="middle">Field()</text>
+  <text class="gcd-chrome-label" x="120" y="146" text-anchor="middle">one declaration</text>
+
+  <line class="gcd-arrow" x1="200" y1="126" x2="248" y2="126" marker-end="url(#fcd-arrow)" />
+
+  <!-- Split node -->
+  <circle cx="268" cy="126" r="8" class="gcd-arrow-fill" />
+  <line class="gcd-arrow" x1="276" y1="110" x2="330" y2="70" marker-end="url(#fcd-arrow)" />
+  <line class="gcd-arrow" x1="276" y1="142" x2="330" y2="182" marker-end="url(#fcd-arrow)" />
+
+  <!-- Data branch -->
+  <rect class="gcd-panel" x="340" y="36" width="200" height="72" rx="12" />
+  <text class="gcd-label" x="440" y="68" text-anchor="middle">data</text>
+  <text class="gcd-chrome-label" x="440" y="90" text-anchor="middle">typed · validated · live</text>
+
+  <!-- Slot branch -->
+  <rect class="gcd-panel" x="340" y="148" width="200" height="72" rx="12" />
+  <text class="gcd-label" x="440" y="180" text-anchor="middle">slot</text>
+  <text class="gcd-chrome-label" x="440" y="202" text-anchor="middle">size · style · paint</text>
+
+  <!-- Grid preview -->
+  <g transform="translate(560, 70)">
+    <rect class="gcd-window" x="0" y="0" width="140" height="120" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="140" height="22" rx="10" />
+    <rect class="gcd-chrome" x="0" y="12" width="140" height="10" />
+    <circle class="gcd-dot" cx="14" cy="11" r="3" />
+    <circle class="gcd-dot" cx="26" cy="11" r="3" />
+    <circle class="gcd-dot" cx="38" cy="11" r="3" />
+    <rect class="gcd-grid-fill" x="10" y="30" width="120" height="80" rx="4" />
+    <rect x="10" y="30" width="120" height="80" rx="4" fill="url(#fcd-cell)" />
+    <rect class="gcd-cell-highlight-strong" x="18" y="38" width="104" height="28" rx="3" />
+    <text class="gcd-chrome-label" x="70" y="56" text-anchor="middle">painted</text>
+    <rect class="gcd-z-base" x="18" y="76" width="104" height="24" rx="3" />
+    <text class="gcd-z-label gcd-z-label-muted" x="70" y="92" text-anchor="middle">state only</text>
+  </g>
+</svg>
+</div>
+
+## Declaring a Field
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4"
+    from xnano import BaseGrid, Field, Terminal
+
+    class Card(BaseGrid, direction="vertical"):
+        heading: str = Field(default="Reminder", color="violet", border="rounded", width="fit")
+        body: str = Field(default="Water the plants.")
+
+    Terminal(height=5).render(Card())
+    ```
+
+```python title="Declaring a Field" hl_lines="4"
+from xnano import BaseGrid, Field
+
+class Card(BaseGrid, direction="vertical"):
+    heading: str = Field(default="Reminder", color="violet", border="rounded", width="fit") # (1)!
+    body: str = Field(default="Water the plants.") # (2)!
+```
+
+1. `default` and the styling keywords (`color`, `border`, `width`, ...) are all just keyword arguments to the same <code>Field()</code> call — there's no separate styling API to learn.
+2. A field with none of the styling arguments set still renders — it just takes on the grid's plain look and whatever space is left over.
+
+<div class="xnano-demo" markdown>
+![fields card dark](../assets/concepts/fields_card-dark.gif){.demo-dark}
+![fields card light](../assets/concepts/fields_card-light.gif){.demo-light}
+</div>
+
+<br/>
+
+The full list of what a field can carry — sizing, layout, color, borders, padding, and more — lives on the [Field]{data-preview} API reference. This page is about the shape of the idea, not every knob on it.
+
+## Fields vs. Plain Attributes
+
+Not every attribute needs a `Field()`. A plain, un-decorated annotation is still a normal typed attribute — it's just never painted, and never occupies a slot.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4"
+    from xnano import BaseGrid, Field, Terminal
+
+    class Card(BaseGrid, direction="vertical"):
+        heading: str = Field(default="Reminder")
+        tags: list[str] = ["home", "chores"]
+
+    Terminal(height=1).render(Card())
+    ```
+
+```python title="Fields vs. Plain Attributes" hl_lines="5"
+from xnano import BaseGrid, Field
+
+class Card(BaseGrid, direction="vertical"):
+    heading: str = Field(default="Reminder")
+    tags: list[str] = ["home", "chores"] # (1)!
+```
+
+1. `tags` is a normal instance attribute — live, readable, writable — but it never shows up on the grid, because it was never given a slot.
+
+<br/>
+
+`tags` behaves a lot like a `state=True` field: live data with no rendering behavior.
+
+The difference is that `state=True` opts a field back into `Field()`'s validation and metadata, while a plain attribute is just Python. Reach for `state=True` when you want that; reach for a plain attribute for everything else.
+
+[Field]: ../api/xnano/fields.md

--- a/docs/core-concepts/getting-started.md
+++ b/docs/core-concepts/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: "Getting Started"
-icon: "lucide/play"
+icon: "lucide/book-open"
 ---
 
 # Getting Started
@@ -23,13 +23,13 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "pip"
 
     ```bash
-    pip install "xnano>=1.0.10"
+    pip install "xnano>=1.0.8"
     ```
 
 === "uv"
 
     ```bash
-    uv pip install "xnano>=1.0.10"
+    uv pip install "xnano>=1.0.8"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -38,7 +38,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "poetry"
 
     ```bash
-    poetry install "xnano>=1.0.10"
+    poetry install "xnano>=1.0.8"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -47,7 +47,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "conda"
 
     ```bash
-    conda install "xnano>=1.0.10"
+    conda install "xnano>=1.0.8"
     ```
 
 ## What is xnano?
@@ -58,6 +58,38 @@ built of two rust-based dependencies:
 - [xnano-core]{data-preview} - Low level terminal rendering engine built on top of [ratatui](https://ratatui.rs) and [tachyonfx](https://github.com/ratatui/tachyonfx) specifically for xnano.
 - [pydantic-core](https://github.com/pydantic/pydantic-core) - The core of the [Pydantic](https://pydantic.dev/docs/validation/latest/get-started) library used for runtime type validation.
 
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: app grid sits on xnano DSL over xnano-core, targeting terminal or browser">
+<svg viewBox="0 0 720 240" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <marker id="gsd-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <rect class="gcd-panel gcd-panel-accent" x="200" y="20" width="320" height="48" rx="12" />
+  <text class="gcd-label gcd-label-accent" x="360" y="50" text-anchor="middle">your App · grids · fields · hooks</text>
+
+  <line class="gcd-arrow" x1="360" y1="68" x2="360" y2="92" marker-end="url(#gsd-arrow)" />
+
+  <rect class="gcd-panel" x="200" y="96" width="320" height="48" rx="12" />
+  <text class="gcd-label" x="360" y="126" text-anchor="middle">xnano · public DSL</text>
+
+  <line class="gcd-arrow" x1="360" y1="144" x2="360" y2="168" marker-end="url(#gsd-arrow)" />
+
+  <rect class="gcd-panel" x="200" y="172" width="320" height="48" rx="12" />
+  <text class="gcd-label" x="360" y="202" text-anchor="middle">xnano-core · ratatui · paint</text>
+
+  <!-- Side hosts -->
+  <rect class="gcd-window" x="40" y="100" width="120" height="56" rx="10" />
+  <text class="gcd-chrome-label" x="100" y="132" text-anchor="middle">terminal</text>
+  <line class="gcd-arrow" x1="160" y1="128" x2="196" y2="128" marker-end="url(#gsd-arrow)" />
+
+  <rect class="gcd-window" x="560" y="100" width="120" height="56" rx="10" />
+  <text class="gcd-chrome-label" x="620" y="132" text-anchor="middle">browser</text>
+  <line class="gcd-arrow" x1="560" y1="128" x2="524" y2="128" marker-end="url(#gsd-arrow)" />
+</svg>
+</div>
+
 ## Supported Interfaces
 
 The core idea of xnano is to provide a unified language that can be re-used across multiple user interfaces with no extra effort. Currently, xnano supports
@@ -67,51 +99,55 @@ the following interfaces.
 
 The main featureset of the library revolves around it's rust-based terminal rendering engine, [xnano-core]{data-preview}.
 
-!!! example "Interactive Example"
+??? example "Interactive Example"
 
     The following example is interactive and can be run directly in the browser by hitting the <kbd>Run</kbd> button.
 
-```pyodide install="xnano>=1.0.10"
+    ```pyodide install="xnano>=1.0.9" exec="no"
+    import xnano
+
+    xnano.render("hello, terminal!", color="blue")
+    ```
+
+```python title="Rendering to the Terminal"
 import xnano
 
-xnano.render("hello, terminal!", color="blue")
+xnano.render("Hello from xnano!", color="pink", modifiers=["bold"])
 ```
+
+<div class="xnano-demo" markdown>
+![hello render dark](../assets/concepts/hello_render-dark.gif){.demo-dark}
+![hello render light](../assets/concepts/hello_render-light.gif){.demo-light}
+</div>
 
 ### Web
 
 Rendered content is __orthogonal__ to the host interface it is displayed on, which means everything you build and render onto the terminal within xnano can also be rendered onto a webpage with no extra effort.
 
-!!! abstract "Web Dependencies"
+??? abstract "Web Dependencies"
 
     The entire layout and component system for the WebUI engine is built on top of raw [HTMX](https://htmx.org/) and [TailwindCSS](https://tailwindcss.com/), and requires no additional dependencies aside from [starlette](https://www.starlette.io/) and [uvicorn](https://www.uvicorn.org/) to serve the application.
 
     You can use WebUI based components by installing the following extra:
 
-    ```bash
+    ```bash title="Install Web Dependencies"
     pip install "xnano[web]"
     ```
 
-```python
+```python title="Launching a Web Application"
 from xnano import Field, BaseGrid
 from xnano.webui import Web
 
 class App(BaseGrid):
     body: str = Field(default="hello, web!")
 
-Web().run(App())
-```
-
-```bash title="Output"
-INFO:     Started server process [23935]
-INFO:     Waiting for application startup.
-INFO:     Application startup complete.
-INFO:     Uvicorn running on http://127.0.0.1:3000 (Press CTRL+C to quit)
+Web().run(App(), port=8000)
 ```
 
 ## Next Steps
 
 Currently this site is still a work in progress. Complete walkthroughs and documentation for both <code>xnano</code> and <code>xnano-core</code> are coming soon.
 
-[xnano]: ./getting-started.md
+[xnano]: getting-started.md
 [xnano-core]: ../architecture/xnano-core.md
 *[pydantic-core]: Data validation library written in rust.

--- a/docs/core-concepts/grids.md
+++ b/docs/core-concepts/grids.md
@@ -1,0 +1,369 @@
+---
+title: "Grids"
+icon: "lucide/grid"
+---
+
+# Grids
+
+Whether it's within the terminal or web browser, everything in xnano revolves around the concept of transforming a "host interface" into a 2D grid of
+cells.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: terminal and browser hosts become the same surfaces with a grid overlay">
+<svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <pattern id="gcd-cell-grid" width="14" height="14" patternUnits="userSpaceOnUse">
+      <path d="M 14 0 L 0 0 0 14" class="gcd-grid-line" />
+    </pattern>
+    <marker id="gcd-arrowhead" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <!-- Left panel -->
+  <rect class="gcd-panel" x="16" y="28" width="280" height="244" rx="16" />
+  <text class="gcd-label" x="156" y="54" text-anchor="middle">hosts</text>
+
+  <!-- Terminal (left) -->
+  <g transform="translate(40, 70)">
+    <rect class="gcd-window" x="0" y="0" width="232" height="88" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="232" height="22" rx="10" />
+    <rect class="gcd-chrome" x="0" y="12" width="232" height="10" />
+    <circle class="gcd-dot" cx="14" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="26" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="38" cy="11" r="3.5" />
+    <text class="gcd-chrome-label" x="116" y="15" text-anchor="middle">terminal</text>
+    <path class="gcd-line" d="M16 38 h48" stroke-width="3" stroke-linecap="round" />
+    <path class="gcd-line-soft" d="M16 52 h96" stroke-width="3" stroke-linecap="round" />
+    <path class="gcd-line-soft" d="M16 66 h72" stroke-width="3" stroke-linecap="round" />
+  </g>
+
+  <!-- Browser (left) -->
+  <g transform="translate(40, 172)">
+    <rect class="gcd-window" x="0" y="0" width="232" height="80" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="232" height="28" rx="10" />
+    <rect class="gcd-chrome" x="0" y="18" width="232" height="10" />
+    <circle class="gcd-dot" cx="14" cy="14" r="3.5" />
+    <circle class="gcd-dot" cx="26" cy="14" r="3.5" />
+    <circle class="gcd-dot" cx="38" cy="14" r="3.5" />
+    <rect class="gcd-urlbar" x="54" y="8" width="160" height="12" rx="6" />
+    <text class="gcd-chrome-label" x="134" y="17" text-anchor="middle">browser</text>
+    <path class="gcd-line" d="M16 46 h80" stroke-width="3" stroke-linecap="round" />
+    <path class="gcd-line-soft" d="M16 60 h120" stroke-width="3" stroke-linecap="round" />
+  </g>
+
+  <!-- Arrow -->
+  <line class="gcd-arrow" x1="320" y1="150" x2="392" y2="150" marker-end="url(#gcd-arrowhead)" />
+
+  <!-- Right panel -->
+  <rect class="gcd-panel gcd-panel-accent" x="424" y="28" width="280" height="244" rx="16" />
+  <text class="gcd-label gcd-label-accent" x="564" y="54" text-anchor="middle">grid</text>
+
+  <!-- Terminal (right) with grid -->
+  <g transform="translate(448, 70)">
+    <rect class="gcd-window" x="0" y="0" width="232" height="88" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="232" height="22" rx="10" />
+    <rect class="gcd-chrome" x="0" y="12" width="232" height="10" />
+    <circle class="gcd-dot" cx="14" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="26" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="38" cy="11" r="3.5" />
+    <text class="gcd-chrome-label" x="116" y="15" text-anchor="middle">terminal</text>
+    <rect class="gcd-grid-fill" x="8" y="28" width="216" height="52" rx="6" />
+    <rect x="8" y="28" width="216" height="52" rx="6" fill="url(#gcd-cell-grid)" />
+  </g>
+
+  <!-- Browser (right) with grid -->
+  <g transform="translate(448, 172)">
+    <rect class="gcd-window" x="0" y="0" width="232" height="80" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="232" height="28" rx="10" />
+    <rect class="gcd-chrome" x="0" y="18" width="232" height="10" />
+    <circle class="gcd-dot" cx="14" cy="14" r="3.5" />
+    <circle class="gcd-dot" cx="26" cy="14" r="3.5" />
+    <circle class="gcd-dot" cx="38" cy="14" r="3.5" />
+    <rect class="gcd-urlbar" x="54" y="8" width="160" height="12" rx="6" />
+    <text class="gcd-chrome-label" x="134" y="17" text-anchor="middle">browser</text>
+    <rect class="gcd-grid-fill" x="8" y="34" width="216" height="38" rx="6" />
+    <rect x="8" y="34" width="216" height="38" rx="6" fill="url(#gcd-cell-grid)" />
+  </g>
+</svg>
+</div>
+
+Within these grids, we can select smaller areas to render content or create components from. By doing this, we automatically
+give that area the ability to:
+
+- Render it's own content <small>(text, characters, images, etc.)</small>
+- Hold it's own state <small>(typed & validated!)</small>
+- Handle user input and external events <small>(is this in focus?, was this clicked?, etc.)</small>
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: a terminal grid with a smaller focused region of cells highlighted">
+<svg viewBox="0 0 720 264" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <pattern id="gcd-cell-grid-lg" width="18" height="18" patternUnits="userSpaceOnUse">
+      <path d="M 18 0 L 0 0 0 18" class="gcd-grid-line" />
+    </pattern>
+    <!-- Diagonal hatch for focused / clicked cell region -->
+    <pattern id="gcd-focus-stripes" width="8" height="8" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <rect width="8" height="8" class="gcd-stripe-bg" />
+      <rect width="3.5" height="8" class="gcd-stripe-fg" />
+    </pattern>
+    <clipPath id="gcd-term-clip">
+      <rect x="40" y="72" width="640" height="152" rx="8" />
+    </clipPath>
+  </defs>
+
+  <!-- Full-area terminal (two cells shorter than the first diagram) -->
+  <rect class="gcd-window" x="24" y="28" width="672" height="208" rx="16" />
+  <rect class="gcd-chrome" x="24" y="28" width="672" height="32" rx="16" />
+  <rect class="gcd-chrome" x="24" y="44" width="672" height="16" />
+  <circle class="gcd-dot" cx="48" cy="44" r="5" />
+  <circle class="gcd-dot" cx="66" cy="44" r="5" />
+  <circle class="gcd-dot" cx="84" cy="44" r="5" />
+  <text class="gcd-chrome-label" x="360" y="49" text-anchor="middle">terminal</text>
+
+  <!-- Grid body -->
+  <g clip-path="url(#gcd-term-clip)">
+    <rect class="gcd-grid-fill" x="40" y="72" width="640" height="152" />
+    <rect x="40" y="72" width="640" height="152" fill="url(#gcd-cell-grid-lg)" />
+
+    <!-- Selected region: a contiguous block of cells -->
+    <rect class="gcd-cell-highlight" x="76" y="90" width="126" height="72" rx="3" />
+    <!-- Nested focused / clicked cell — striped fill -->
+    <rect class="gcd-cell-focus" x="94" y="108" width="54" height="36" rx="2" fill="url(#gcd-focus-stripes)" />
+    <rect class="gcd-cell-focus-ring" x="94" y="108" width="54" height="36" rx="2" />
+  </g>
+</svg>
+</div>
+
+??? abstract "The '<code>z</code>' Axis"
+
+    Along with the standard x & y coordinate system, xnano also introduces a third "z" dimension.
+
+    As [xnano-core]{data-preview} controls the complete rendering lifecycle within the terminal at every
+    frame, it is able to render the component or content with the highest "z-index" for every cell within
+    the grid. This allows you to create things such as overlays & breadcrumbs with ease.
+
+    <div class="grid-concept-diagram grid-concept-diagram--compact" role="img" aria-label="Diagram: lower z selection is not rendered; higher z overlay is rendered">
+    <svg viewBox="0 0 460 220" xmlns="http://www.w3.org/2000/svg" fill="none">
+      <defs>
+        <pattern id="gcd-z-cell-grid" width="14" height="14" patternUnits="userSpaceOnUse">
+          <path d="M 14 0 L 0 0 0 14" class="gcd-grid-line" />
+        </pattern>
+        <filter id="gcd-z-soft-shadow" x="-20%" y="-20%" width="140%" height="140%">
+          <feDropShadow dx="0" dy="3" stdDeviation="3.5" flood-opacity="0.28" />
+        </filter>
+      </defs>
+      <!-- Base terminal -->
+      <g transform="translate(24, 48)">
+        <rect class="gcd-window" x="0" y="0" width="300" height="148" rx="12" />
+        <rect class="gcd-chrome" x="0" y="0" width="300" height="24" rx="12" />
+        <rect class="gcd-chrome" x="0" y="14" width="300" height="10" />
+        <circle class="gcd-dot" cx="14" cy="12" r="3.5" />
+        <circle class="gcd-dot" cx="26" cy="12" r="3.5" />
+        <circle class="gcd-dot" cx="38" cy="12" r="3.5" />
+        <text class="gcd-chrome-label" x="150" y="16" text-anchor="middle">terminal</text>
+        <rect class="gcd-grid-fill" x="10" y="32" width="280" height="106" rx="6" />
+        <rect x="10" y="32" width="280" height="106" rx="6" fill="url(#gcd-z-cell-grid)" />
+        <!-- Base-layer selection (z = 0) — muted: not rendered -->
+        <rect class="gcd-z-base" x="28" y="48" width="96" height="54" rx="3" />
+        <text class="gcd-z-label gcd-z-label-muted" x="76" y="79" text-anchor="middle">z = 0</text>
+        <text class="gcd-z-caption gcd-z-caption-muted" x="134" y="78">this isn't rendered</text>
+        <!-- Depth connectors (base → floating overlay) -->
+        <path class="gcd-z-connector" d="M28 48 L52 18" />
+        <path class="gcd-z-connector" d="M124 48 L148 18" />
+        <path class="gcd-z-connector" d="M28 102 L52 72" />
+        <path class="gcd-z-connector" d="M124 102 L148 72" />
+      </g>
+      <!-- Same shape hovering above (higher z) — rendered -->
+      <g transform="translate(48, 18)" filter="url(#gcd-z-soft-shadow)">
+        <rect class="gcd-z-overlay" x="0" y="0" width="96" height="54" rx="3" />
+        <rect class="gcd-z-overlay-inner" x="6" y="6" width="84" height="42" rx="2" />
+        <text class="gcd-z-label gcd-z-label-on" x="48" y="32" text-anchor="middle">z = 1</text>
+        <text class="gcd-z-caption gcd-z-caption-on" x="106" y="32">this is rendered</text>
+      </g>
+    </svg>
+    </div>
+
+
+
+## Creating a Grid
+
+Let's start by creating a simple grid. You'll notice very quickly that the API design for grids is heavily inspired by the [BaseModel]{data-preview} class from the
+[Pydantic]{data-preview} library.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4 5 6 7 8 9 10" exec="no"
+    from xnano import BaseGrid, Field, Terminal
+
+    class App(BaseGrid, direction="vertical"):
+        title: str = Field(default="My App", border="rounded")
+        body: str = Field()
+        name: str = Field(default="Hammad", state=True)
+
+        def __post_init__(self):
+            self.body = f"Hello, {self.name}!"
+
+    Terminal(height=4).render(App())
+    ```
+
+```python title="Creating a Grid" hl_lines="4 5 6 7 8 9 10"
+from xnano import BaseGrid, Field
+
+class App(BaseGrid, direction="vertical"): # (1)!
+    title: str = Field(default="My App", border="rounded") # (2)!
+    body: str = Field()
+    name: str = Field(default="Hammad", state=True) # (3)!
+
+    def __post_init__(self):
+        self.body = f"Hello, {self.name}!" # (4)!
+```
+
+1. Define a grid component the same way you would a Pydantic model. <br/><br/>You modify set the grid's behavior directly within the class constructor, or by configuring the <code>grid_settings</code> class attribute.
+2. The "Field" constructor helps you style, validate, and configure how that field is rendered within the grid.
+3. Setting <code>state=True</code> onto a field lets it act purely as state, and is never rendered onto the grid directly.
+4. Attributes on a grid are <strong>live</strong>, meaning any changes to attributes are immediately reflected onto your host display or browser.
+5. The easiest way to print to the terminal with xnano is to use the <code>render()</code> function.
+
+<div class="xnano-demo" markdown>
+![grid basic dark](../assets/concepts/grid_basic-dark.gif){.demo-dark}
+![grid basic light](../assets/concepts/grid_basic-light.gif){.demo-light}
+</div>
+
+## Grid Settings
+
+Some settings describe the grid as a whole rather than any single field — its layout direction, the gap between fields, and the frame drawn around the whole thing. These live apart from field declarations, the same way Pydantic keeps `model_config` separate from the fields it configures.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="3"
+    from xnano import BaseGrid, Field, Terminal
+
+    class Dashboard(BaseGrid, direction="horizontal", gap=1, border="rounded", title=" Dashboard "):
+        left: str = Field(default="Left", width="1fr")
+        right: str = Field(default="Right", width="1fr")
+
+    Terminal(height=5).render(Dashboard())
+    ```
+
+```python title="Grid Settings" hl_lines="3"
+from xnano import BaseGrid, Field
+
+class Dashboard(BaseGrid, direction="horizontal", gap=1, border="rounded", title=" Dashboard "): # (1)!
+    left: str = Field(default="Left", width="1fr")
+    right: str = Field(default="Right", width="1fr")
+```
+
+1. Everything after <code>BaseGrid</code> in the class header is a grid setting — here, laying <code>left</code> and <code>right</code> out side by side, spacing them a cell apart, and framing the whole grid in a rounded, titled border.
+
+<div class="xnano-demo" markdown>
+![grid settings dark](../assets/concepts/grid_settings-dark.gif){.demo-dark}
+![grid settings light](../assets/concepts/grid_settings-light.gif){.demo-light}
+</div>
+
+<br/>
+
+The same settings can also be declared on a <code>grid_settings</code> class attribute — useful once a grid has enough settings that the class header starts to run long, or when a base grid needs to hand settings down to a subclass.
+
+=== "Class header"
+
+    ```python
+    class Dashboard(BaseGrid, direction="horizontal", gap=1, border="rounded"):
+        ...
+    ```
+
+=== "<code>grid_settings</code> attribute"
+
+    ```python
+    from xnano import GridSettings
+
+    class Dashboard(BaseGrid):
+        grid_settings = GridSettings(
+            direction="horizontal",
+            gap=1,
+            border="rounded",
+        )
+        ...
+    ```
+
+<br/>
+
+Both forms merge together if used at the same time — a subclass's <code>grid_settings</code> wins over anything set in its own or an inherited class header.
+
+`direction` and `gap` are the two you'll reach for the most. Everything else — color, borders, padding, title, character modifiers — is the same styling vocabulary a [Field]{data-preview} accepts, just applied to the grid's outer frame instead of one slot. The full list lives on the [GridSettings]{data-preview} API reference.
+
+## Displaying Content
+
+Now that we've defined a simple grid component, let's display it on an interface.
+
+Grids are **orthogonal** to the host they're rendered on. This means you can render the same grid on both the terminal and web browser
+without any additional effort.
+
+### Rendering in the Terminal
+
+The primary way to render or display content using xnano is through the terminal. To do this, we can either create a new session of a [Terminal]{data-preview} class, or use the
+[render]{data-preview} function directly.
+
+=== "Using the <code>render()</code> function"
+
+    ```python title="render()" hl_lines="3"
+    from xnano import render
+
+    render(App()) # (1)!
+    ```
+
+    1. The <code>render()</code> function acts as a drop in replacement for the stdlib <code>print()</code> function with all of xnano's layout and styling capabilities.
+
+=== "Running a <code>Terminal</code> session"
+
+    ```python title="Terminal" hl_lines="3 4"
+    from xnano.tui import Terminal
+
+    terminal = Terminal()
+    terminal.run(App()) # (1)!
+    ```
+
+    1. Unlike <code>render()</code>, <code>Terminal</code> sessions are persistent and will remain active unless explicitly exited by the framework or user.
+
+### Running a Web Application
+
+??? abstract "Web Dependencies"
+
+    Although the rendering engine for web applications requires no additional dependencies, xnano requires
+    the [starlette](https://www.starlette.io/) and [uvicorn](https://www.uvicorn.org/) python packages
+    to bootstrap and launch the web app itself.
+
+    You can install these dependencies by installing the <code>xnano[web]</code> extra.
+
+    ```bash
+    pip install 'xnano[web]'
+    ```
+
+<br/>
+
+We can run our web application the exact same way we did with the terminal! Simple create a new "live session" using
+the [Web]{data-preview} class, and pass the grid component to it.
+
+```python title="Web" hl_lines="3"
+from xnano.webui import Web
+
+Web().run(App())
+```
+
+```bash title="Output"
+INFO:     Started server process [79107]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+[xnano-core]: ../architecture/xnano-core.md
+[Pydantic]: https://pydantic.dev/docs/validation/dev/api/pydantic/
+[BaseModel]: https://pydantic.dev/docs/validation/dev/api/pydantic/base_model/
+[Terminal]: ../api/xnano/tui/terminal.md
+[render]: ../api/xnano/_renderable.md
+[Field]: fields.md
+[GridSettings]: ../api/xnano/grid.md
+[Web]: ../api/xnano/webui/web.md

--- a/docs/core-concepts/styling.md
+++ b/docs/core-concepts/styling.md
@@ -1,0 +1,93 @@
+---
+title: "Styling"
+icon: "lucide/palette"
+---
+
+# Styling
+
+Every color, border, and modifier you've seen so far — `color="violet"`, `border="rounded"` — comes from one shared vocabulary. It doesn't matter whether you're styling a [Field]{data-preview}, a `GridSettings` frame, or one of the built-in components covered next: the same keywords mean the same thing everywhere.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: Field, GridSettings, and components share one Style vocabulary">
+<svg viewBox="0 0 720 200" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <marker id="scd-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <rect class="gcd-panel" x="40" y="48" width="140" height="64" rx="12" />
+  <text class="gcd-label" x="110" y="86" text-anchor="middle">Field</text>
+
+  <rect class="gcd-panel" x="210" y="48" width="160" height="64" rx="12" />
+  <text class="gcd-label" x="290" y="86" text-anchor="middle">GridSettings</text>
+
+  <rect class="gcd-panel" x="400" y="48" width="160" height="64" rx="12" />
+  <text class="gcd-label" x="480" y="86" text-anchor="middle">components</text>
+
+  <line class="gcd-arrow" x1="110" y1="112" x2="110" y2="140" marker-end="url(#scd-arrow)" />
+  <line class="gcd-arrow" x1="290" y1="112" x2="290" y2="140" marker-end="url(#scd-arrow)" />
+  <line class="gcd-arrow" x1="480" y1="112" x2="480" y2="140" marker-end="url(#scd-arrow)" />
+
+  <path class="gcd-arrow" d="M110 148 H 580" fill="none" />
+  <rect class="gcd-panel gcd-panel-accent" x="200" y="148" width="320" height="40" rx="10" />
+  <text class="gcd-label gcd-label-accent" x="360" y="174" text-anchor="middle">Style · color · border · modifiers</text>
+</svg>
+</div>
+
+## Color
+
+A color can be a plain name, a hex string, an RGB(A) tuple, or a Tailwind shade.
+
+```python title="Color Inputs"
+Field(color="violet")          # a named color
+Field(color="#a78bfa")         # hex
+Field(color=(167, 139, 250))   # RGB tuple
+Field(color="violet-400")      # a Tailwind shade
+```
+
+<br/>
+
+Tailwind shades are the one worth knowing well — every color in the default Tailwind palette (`slate`, `violet`, `emerald`, `amber`, ...) is available at every weight from `50` to `950`, so `"violet-400"` and `"violet-600"` are both valid without reaching for a hex code.
+
+## Borders and Modifiers
+
+A `border` draws a frame around a field's slot; `modifiers` change how its text renders.
+
+```python title="Borders and Modifiers" hl_lines="2 3"
+Field(
+    border="rounded",
+    modifiers=["bold", "italic"],
+)
+```
+
+<div class="xnano-demo" markdown>
+![styled field dark](../assets/concepts/styled_field-dark.gif){.demo-dark}
+![styled field light](../assets/concepts/styled_field-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Six border styles are available — `"plain"`, `"rounded"`, `"double"`, `"thick"`, `"quadrant_inside"`, `"quadrant_outside"` — and seven modifiers: `"bold"`, `"dim"`, `"italic"`, `"underline"`, `"slow_blink"`, `"rapid_blink"`, `"reversed"`. All seven are real terminal attributes, not an approximation — `"slow_blink"` really blinks.
+
+## Tailwind Classes
+
+Anywhere a field accepts `class_name`, you can reach for a Tailwind utility string instead of the individual keyword arguments.
+
+```python title="Tailwind Classes"
+Field(class_name="text-violet-400 bg-slate-900 p-2 rounded-lg")
+```
+
+<div class="xnano-demo" markdown>
+![styled tailwind dark](../assets/concepts/styled_tailwind-dark.gif){.demo-dark}
+![styled tailwind light](../assets/concepts/styled_tailwind-light.gif){.demo-light}
+</div>
+
+<br/>
+
+The terminal and the browser don't treat this the same way. Classes with a cell-level meaning — color, padding, margin, border — get lowered into the exact same styling a `Field(color=..., padding=...)` call would produce, so they render identically on both hosts. Everything else (`flex-*`, `shadow-*`, `transition-*`, ...) only makes sense in a browser, and passes straight through to the rendered HTML untouched — the terminal host just ignores it.
+
+??? note "Why Both APIs Exist"
+
+    Keyword arguments and `class_name` aren't two competing systems — they're the same `Style` underneath, built two different ways. Reach for keywords when a value is dynamic or computed; reach for `class_name` when you're pasting in something that already looks like Tailwind, or want the browser-only utilities keywords don't cover.
+
+[Field]: fields.md

--- a/docs/core-concepts/terminal.md
+++ b/docs/core-concepts/terminal.md
@@ -1,0 +1,131 @@
+---
+title: "Terminal"
+icon: "lucide/monitor"
+---
+
+# Terminal
+
+A [Terminal]{data-preview} is a live session on top of a real terminal window — the thing that owns the screen, reads keys and mouse movement off it, and keeps both alive for as long as your app runs.
+
+Nothing in xnano renders on its own. Whatever you build needs somewhere to actually run, and a `Terminal` is that somewhere: the stage the rest of the framework performs on.
+
+Think of it the way a web framework thinks of a server process. The routes, models, and handlers you write don't listen on a socket by themselves — something has to bind the port, accept connections, and keep looping. `Terminal` is that piece, except the "socket" is your actual terminal emulator, and the "requests" are key presses, mouse events, and clock ticks.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: Terminal owns the session loop around a root grid — open, run events and frames, exit">
+<svg viewBox="0 0 720 240" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <pattern id="tcd-cell" width="12" height="12" patternUnits="userSpaceOnUse">
+      <path d="M 12 0 L 0 0 0 12" class="gcd-grid-line" />
+    </pattern>
+    <marker id="tcd-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <rect class="gcd-panel" x="40" y="28" width="640" height="184" rx="16" />
+  <text class="gcd-label" x="360" y="56" text-anchor="middle">Terminal session</text>
+
+  <!-- Loop stages -->
+  <rect class="gcd-window" x="72" y="80" width="100" height="48" rx="10" />
+  <text class="gcd-chrome-label" x="122" y="108" text-anchor="middle">open</text>
+
+  <line class="gcd-arrow" x1="172" y1="104" x2="208" y2="104" marker-end="url(#tcd-arrow)" />
+
+  <!-- Root grid -->
+  <g transform="translate(220, 72)">
+    <rect class="gcd-window" x="0" y="0" width="200" height="100" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="200" height="22" rx="10" />
+    <rect class="gcd-chrome" x="0" y="12" width="200" height="10" />
+    <circle class="gcd-dot" cx="12" cy="11" r="3" />
+    <circle class="gcd-dot" cx="24" cy="11" r="3" />
+    <circle class="gcd-dot" cx="36" cy="11" r="3" />
+    <text class="gcd-chrome-label" x="100" y="15" text-anchor="middle">root grid</text>
+    <rect class="gcd-grid-fill" x="12" y="32" width="176" height="56" rx="4" />
+    <rect x="12" y="32" width="176" height="56" rx="4" fill="url(#tcd-cell)" />
+  </g>
+
+  <path class="gcd-z-connector" d="M320 172 C 320 200, 122 200, 122 128" marker-end="url(#tcd-arrow)" fill="none" />
+  <text class="gcd-z-caption" x="230" y="196" text-anchor="middle">events · frames</text>
+
+  <line class="gcd-arrow" x1="420" y1="122" x2="470" y2="122" marker-end="url(#tcd-arrow)" />
+
+  <rect class="gcd-panel gcd-panel-accent" x="484" y="80" width="160" height="80" rx="12" />
+  <text class="gcd-label gcd-label-accent" x="564" y="116" text-anchor="middle">exit</text>
+  <text class="gcd-chrome-label" x="564" y="138" text-anchor="middle">request_exit()</text>
+</svg>
+</div>
+
+## A Minimal Session
+
+The smallest possible use of a `Terminal` is a single function call — nothing to define, nothing to lay out first.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" exec="no"
+    import xnano
+
+    xnano.render("hello, terminal!", color="blue")
+    ```
+
+```python title="A Minimal Session" hl_lines="3"
+import xnano
+
+xnano.render("hello, terminal!", color="blue") # (1)!
+```
+
+1. [render]{data-preview} is a one-shot: it opens a `Terminal` session just long enough to paint this one call, then hands the screen back.
+
+<div class="xnano-demo" markdown>
+![terminal session dark](../assets/concepts/terminal_session-dark.gif){.demo-dark}
+![terminal session light](../assets/concepts/terminal_session-light.gif){.demo-light}
+</div>
+
+<br/>
+
+`render()` is convenient for a single frame, but most apps want to stay open — reading input, updating state, redrawing — until the user quits. That's what a `Terminal` session gives you directly:
+
+```python title="A Persistent Session" hl_lines="3 4"
+from xnano.tui import Terminal
+
+terminal = Terminal()
+terminal.run("hello, terminal!") # (1)!
+```
+
+1. Unlike `render()`, a session started with `.run()` stays open — it keeps drawing frames and dispatching events until the app exits, the same way a web server keeps accepting connections until it's stopped.
+
+## Terminal Grids
+
+A `Terminal` doesn't know anything about layout or state on its own — pass it a plain string, as above, and it just paints that string.
+
+Give it a `BaseGrid` instead, and the terminal treats it as the root of the whole screen: the grid's fields become the regions of the display, and the terminal starts dispatching keyboard, mouse, and tick events into whatever hooks that grid defines.
+
+```python title="Running a Grid" hl_lines="8"
+from xnano import BaseGrid, Field, Terminal
+
+class App(BaseGrid, direction="vertical"):
+    title: str = Field(default="My App", border="rounded")
+    name: str = Field(default="Hammad", state=True)
+
+terminal = Terminal()
+terminal.run(App()) # (1)!
+```
+
+1. Don't worry about the `Field()` and `BaseGrid` syntax yet — that's exactly what the next couple of pages are for. For now, the only thing to take away is that a `Terminal` is what actually puts this grid on screen and keeps it alive.
+
+??? note "State Threaded Through the Session"
+
+    A `Terminal` can also carry application-wide state, passed once at construction and handed to every hook as part of its [Context]{data-preview} — `Terminal(state=AppState())`. That's covered properly once hooks are introduced; for now, just know the session is also where that state lives.
+
+## Next Steps
+
+Everything from here — [grids]{data-preview}, [fields]{data-preview}, [events and hooks]{data-preview}, and the [device and cursor]{data-preview} a session exposes — describes what happens *inside* a `Terminal`. Start with grids to see what actually gets drawn onto it.
+
+[Terminal]: ../api/xnano/tui/terminal.md
+[render]: ../api/xnano/_renderable.md
+[Context]: ../api/xnano/context.md
+[grids]: grids.md
+[fields]: fields.md
+[events and hooks]: events.md
+[device and cursor]: device.md

--- a/docs/core-concepts/web.md
+++ b/docs/core-concepts/web.md
@@ -1,0 +1,140 @@
+---
+title: "Web Applications"
+icon: "lucide/globe"
+---
+
+# Web Applications
+
+!!! warning "Experimental"
+
+    This feature is experimental and is subject to frequent changes.
+
+A [Web]{data-preview} host is the browser counterpart to [Terminal]{data-preview} — instead of owning a terminal window, it owns a live web server, and instead of painting cells to a screen, it serves your app as an actual page over HTTP.
+
+Whatever you hand a `Terminal` to run, you can hand a `Web` host too — the same class, unchanged. It doesn't know or care which host is running it: `Web` just answers keyboard events, clicks, and ticks from a browser tab instead of a terminal window, and paints HTML instead of cells.
+
+That's the idea behind calling rendered content **orthogonal** to its host: the same `App()` you'd hand to a `Terminal` is exactly what you hand to a `Web` host too.
+
+<div class="grid-concept-diagram" role="img" aria-label="Diagram: one App grid class handed to either Terminal or Web without changes">
+<svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <pattern id="wcd-cell" width="12" height="12" patternUnits="userSpaceOnUse">
+      <path d="M 12 0 L 0 0 0 12" class="gcd-grid-line" />
+    </pattern>
+    <marker id="wcd-arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" class="gcd-arrow-fill" />
+    </marker>
+  </defs>
+
+  <!-- Shared App -->
+  <rect class="gcd-panel gcd-panel-accent" x="260" y="24" width="200" height="72" rx="12" />
+  <text class="gcd-label gcd-label-accent" x="360" y="56" text-anchor="middle">App()</text>
+  <text class="gcd-chrome-label" x="360" y="78" text-anchor="middle">same grid · same hooks</text>
+
+  <line class="gcd-arrow" x1="300" y1="96" x2="180" y2="140" marker-end="url(#wcd-arrow)" />
+  <line class="gcd-arrow" x1="420" y1="96" x2="540" y2="140" marker-end="url(#wcd-arrow)" />
+
+  <!-- Terminal host -->
+  <g transform="translate(48, 148)">
+    <rect class="gcd-window" x="0" y="0" width="240" height="88" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="240" height="22" rx="10" />
+    <rect class="gcd-chrome" x="0" y="12" width="240" height="10" />
+    <circle class="gcd-dot" cx="14" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="26" cy="11" r="3.5" />
+    <circle class="gcd-dot" cx="38" cy="11" r="3.5" />
+    <text class="gcd-chrome-label" x="120" y="15" text-anchor="middle">Terminal</text>
+    <rect class="gcd-grid-fill" x="12" y="32" width="216" height="44" rx="4" />
+    <rect x="12" y="32" width="216" height="44" rx="4" fill="url(#wcd-cell)" />
+  </g>
+
+  <!-- Web host -->
+  <g transform="translate(432, 148)">
+    <rect class="gcd-window" x="0" y="0" width="240" height="88" rx="10" />
+    <rect class="gcd-chrome" x="0" y="0" width="240" height="28" rx="10" />
+    <rect class="gcd-chrome" x="0" y="18" width="240" height="10" />
+    <circle class="gcd-dot" cx="14" cy="14" r="3.5" />
+    <circle class="gcd-dot" cx="26" cy="14" r="3.5" />
+    <circle class="gcd-dot" cx="38" cy="14" r="3.5" />
+    <rect class="gcd-urlbar" x="54" y="8" width="168" height="12" rx="6" />
+    <text class="gcd-chrome-label" x="138" y="17" text-anchor="middle">Web</text>
+    <rect class="gcd-grid-fill" x="12" y="40" width="216" height="36" rx="4" />
+    <rect x="12" y="40" width="216" height="36" rx="4" fill="url(#wcd-cell)" />
+  </g>
+</svg>
+</div>
+
+## A Minimal Session
+
+Where `Terminal().run(...)` keeps a terminal window alive, `Web().run(...)` starts an actual server process and keeps *that* alive.
+
+```python title="Running a Web App" hl_lines="7"
+from xnano import BaseGrid, Field
+from xnano.webui import Web
+
+class App(BaseGrid):
+    body: str = Field(default="hello, web!")
+
+Web().run(App(), port=8000) # (1)!
+```
+
+1. Don't worry about `Field()` and `BaseGrid` yet — [grids]{data-preview} and [fields]{data-preview} cover that in depth. The only new idea here is `Web` itself: the thing that takes this same grid and serves it as a page instead of a terminal frame.
+
+```bash title="Output"
+INFO:     Started server process [79107]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+Visiting that address renders the grid as HTML, wired up with [HTMX](https://htmx.org/) so that hooks — the same `@on_keyboard`, `@on_click`, and `@on_tick` decorators a terminal app uses — fire from real browser events: a keydown in the page, a click on an element, a poll on an interval.
+
+??? abstract "Web Dependencies"
+
+    `Web` needs no extra dependencies to build its HTML/HTMX layout, but running a real server does — [starlette](https://www.starlette.io/) to route requests and [uvicorn](https://www.uvicorn.org/) to serve them. Both come with the `web` extra:
+
+    ```bash
+    pip install "xnano[web]"
+    ```
+
+## One Grid, Two Hosts
+
+Because a grid never references `Terminal` or `Web` directly, the exact same class can be handed to either one.
+
+```python title="Same Grid, Either Host"
+from xnano import BaseGrid, Field, Terminal
+from xnano.webui import Web
+
+class App(BaseGrid):
+    body: str = Field(default="hello!")
+
+Terminal().run(App())   # a terminal window
+Web().run(App())        # a browser tab
+```
+
+Only one of these runs at a time in a given process, but nothing about `App` itself changes between them — the grid, its fields, and its hooks are the host-agnostic part; `Terminal` and `Web` are just two different stages willing to run it.
+
+??? note "Shared vs. Per-Visitor Sessions"
+
+    Passing a `BaseGrid` *instance* to `Web().run(...)` gives every visitor the same live grid — one shared state, seen by everyone connected. Passing the *class* itself instead creates a fresh grid per browser session, the same way each terminal run starts from scratch.
+
+    ```python
+    Web().run(Dashboard())   # shared across all visitors
+    Web().run(Dashboard)     # a new session per visitor
+    ```
+
+## What Doesn't Carry Over
+
+Not everything a terminal session offers has a browser equivalent. A few [device and cursor]{data-preview} controls — raw mode, the alternate screen buffer, moving the caret to a specific cell — only make sense where there's a real terminal underneath, and reduce to harmless no-ops on `Web`. Native effects and some terminal-only sizing behavior are similarly TUI-specific.
+
+None of that affects the core model, though: grids, fields, and hooks all mean the same thing on both hosts.
+
+## Next Steps
+
+With both hosts in view, the rest of `core-concepts` — [grids]{data-preview}, [fields]{data-preview}, [events and hooks]{data-preview}, and [device and cursor]{data-preview} — applies equally whether the app ends up running in a `Terminal` or served with `Web`.
+
+[Terminal]: ../api/xnano/tui/terminal.md
+[Web]: ../api/xnano/webui/web.md
+[grids]: grids.md
+[fields]: fields.md
+[events and hooks]: events.md
+[device and cursor]: device.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
-icon: lucide/smile
 title: " "
+icon: "lucide/smile"
 ---
 
 <span class="page-index"></span>
@@ -35,13 +35,6 @@ Fast and flexible, xnano gives you a simple [Pydantic](https://github.com/pydant
 </div>
 
 <div class="xnano-showcase" markdown>
-![kanban monotone dark](./assets/examples/kanban-dark-mono.gif){.showcase-mono .demo-dark}
-![kanban color dark](./assets/examples/kanban-dark.gif){.showcase-color .demo-dark}
-![kanban monotone light](./assets/examples/kanban-light-mono.gif){.showcase-mono .demo-light}
-![kanban color light](./assets/examples/kanban-light.gif){.showcase-color .demo-light}
-</div>
-
-<div class="xnano-showcase" markdown>
 ![agent chat monotone dark](./assets/examples/agent_chat-dark-mono.gif){.showcase-mono .demo-dark}
 ![agent chat color dark](./assets/examples/agent_chat-dark.gif){.showcase-color .demo-dark}
 ![agent chat monotone light](./assets/examples/agent_chat-light-mono.gif){.showcase-mono .demo-light}
@@ -56,13 +49,13 @@ You can install xnano with your favorite package manager on python 3.10+.
 
 === "pip"
 
-    ```bash
+    ```bash title="Install with pip"
     pip install "xnano"
     ```
 
 === "uv"
 
-    ```bash
+    ```bash title="Install with uv"
     uv pip install "xnano"
 
     # or add to your project's dependencies
@@ -71,7 +64,7 @@ You can install xnano with your favorite package manager on python 3.10+.
 
 === "poetry"
 
-    ```bash
+    ```bash title="Install with poetry"
     poetry install "xnano"
 
     # or add to your project's dependencies
@@ -80,233 +73,109 @@ You can install xnano with your favorite package manager on python 3.10+.
 
 === "conda"
 
-    ```bash
+    ```bash title="Install with conda"
     conda install "xnano"
     ```
 
 ---
 
-## Your first render
+## Hello World
 
-The easiest way to get started is the print-like `render()` helper — no
-session, no event loop. It writes styled content to the terminal and returns.
+A grid, a couple of fields, a hook, and a `Terminal` to run it — that's the whole shape of an xnano app.
 
-```python
-from xnano import render
-from xnano.components.text import Text
+??? example "Interactive Example"
 
-render(
-    Text("Hello from xnano!", color="violet", modifiers=["bold"])
-)
-```
+    The following code block is interactive and can be run directly in the browser.
 
-<div class="xnano-demo" markdown>
-![render text dark](./assets/concepts/render_text-dark.gif){.demo-dark}
-![render text light](./assets/concepts/render_text-light.gif){.demo-light}
-</div>
+    ```pyodide install="xnano>=1.0.9" hl_lines="4 5"
+    from xnano import BaseGrid, Field, Terminal
 
-You can pass multiple renderables too — they'll stack vertically:
+    class Hello(BaseGrid, direction="vertical"):
+        message: str = Field(default="Hello, xnano!", color="violet", modifiers=["bold"], height=1)
+        hint: str = Field(default="press q to quit", height=1, color="slate-500")
 
-```python
-from xnano import render
-from xnano.components.text import Text
+    Terminal(height=2).render(Hello())
+    ```
 
-render(
-    Text("Success!", color="emerald-400", modifiers=["bold"]),
-    Text("All 12 checks passed.", color="slate-400"),
-)
-```
-
-<div class="xnano-demo" markdown>
-![render multiple dark](./assets/concepts/render_multiple-dark.gif){.demo-dark}
-![render multiple light](./assets/concepts/render_multiple-light.gif){.demo-light}
-</div>
-
----
-
-## Building a layout
-
-Layouts work like Pydantic models. Inherit from `BaseGrid`, add typed fields, and xnano handles the rest. Field order is layout order. (`Grid` remains available as an alias of `BaseGrid`.)
-
-```python
-from xnano import Field, BaseGrid, Terminal
-
-class App(BaseGrid, direction="vertical"):
-    header: str = Field(default="My App", height=1, color="white", background="violet")
-    body:   str = Field(default="Content goes here.")
-    footer: str = Field(default="[q] quit", height=1, color="slate-500")
-
-Terminal().run(App())
-```
-
-<div class="xnano-demo" markdown>
-![grid basic dark](./assets/concepts/grid_basic-dark.gif){.demo-dark}
-![grid basic light](./assets/concepts/grid_basic-light.gif){.demo-light}
-</div>
-
-Nest grids to build more complex layouts:
-
-```python
-class Sidebar(BaseGrid, direction="vertical"):
-    nav:    str = Field(default="- Home\n- Settings", width="20%", border="rounded")
-    detail: str = Field(default="Select an item", width="1fr")
-
-class App(BaseGrid, direction="horizontal"):
-    sidebar: Sidebar = Field(default_factory=Sidebar, width="25%")
-    main:    str     = Field(default="Main area", width="1fr", border="rounded")
-
-Terminal().run(App())
-```
-
-<div class="xnano-demo" markdown>
-![grid nested dark](./assets/concepts/grid_nested-dark.gif){.demo-dark}
-![grid nested light](./assets/concepts/grid_nested-light.gif){.demo-light}
-</div>
-
----
-
-## Responding to keys
-
-Decorate a method with `@on_keyboard` and it fires when that key is pressed. Fields marked `state=True` trigger a re-render whenever they change.
-
-```python
-from xnano import Field, BaseGrid, Terminal
+```python title="Hello, xnano" hl_lines="5 6 9 10 13"
+from xnano import BaseGrid, Field, Terminal
+from xnano.context import Context
 from xnano.events import on_keyboard
 
-class Counter(BaseGrid, direction="vertical", gap=1):
-    label: str = Field(default="Count: 0", height=1)
-    hint:  str = Field(default="↑ / ↓ to count  ·  q to quit", height=1, color="slate-500")
+class Hello(BaseGrid, direction="vertical"):
+    message: str = Field(default="Hello, xnano!", color="violet", modifiers=["bold"], height=1) # (1)!
+    hint: str = Field(default="press q to quit", height=1, color="slate-500")
 
-    count: int = Field(default=0, state=True)
-
-    @on_keyboard("up")
-    def inc(self) -> None:
-        self.count += 1
-        self.label = f"Count: {self.count}"
-
-    @on_keyboard("down")
-    def dec(self) -> None:
-        self.count -= 1
-        self.label = f"Count: {self.count}"
-
-    @on_keyboard("q")
-    def quit(self, ctx) -> None:
+    @on_keyboard("q") # (2)!
+    def quit(self, ctx: Context) -> None:
         ctx.terminal.request_exit()
 
-Terminal().run(Counter())
+Terminal().run(Hello()) # (3)!
 ```
+
+1. A grid is a class; a field is a typed, styled attribute on it — this one's violet and bold.
+2. A method wrapped in `@on_keyboard` becomes a hook, fired whenever that key is pressed.
+3. `Terminal().run(...)` keeps the app alive, reading input and repainting until it exits.
 
 <div class="xnano-demo" markdown>
-![counter dark](./assets/concepts/hooks_keyboard-dark.gif){.demo-dark}
-![counter light](./assets/concepts/hooks_keyboard-light.gif){.demo-light}
+![hello dark](./assets/concepts/hello_render-dark.gif){.demo-dark}
+![hello light](./assets/concepts/hello_render-light.gif){.demo-light}
 </div>
 
-You can also pass a `Context` object to get access to the terminal, keyboard event details, and more:
 
-```python
-@on_keyboard("enter")
-def submit(self, ctx) -> None:
-    key = ctx.keyboard      # crossterm KeyEvent
-    term = ctx.terminal     # Terminal instance
-```
+## Next Steps
 
----
+Once you're ready to get started, try clicking on one of the following cards to explore the documentation & examples.
 
-## Tick-driven updates
+<br/>
 
-Use `@on_tick` to run something on a repeating interval. Pass a number of milliseconds to `@on_tick` to override the default, or set `tick_interval` on `Terminal`.
+<div class="grid cards" markdown>
 
-```python
-import time
-from xnano import Field, BaseGrid, Terminal
-from xnano.events import on_tick
+-   :material-view-grid:{ .lg .middle } **Core Concepts**
 
-class Clock(BaseGrid, direction="vertical"):
-    display: str = Field(default="", height=3, border="rounded", title=" Time ")
+    ---
 
-    @on_tick(1000)
-    def update(self) -> None:
-        self.display = time.strftime("  %H:%M:%S")
+    Start with the core concepts and components that make up the xnano, along with interactive examples to get you off the ground running.
 
-Terminal().run(Clock())
-```
+    [Core Concepts | Grids]{.xnano-card-link data-preview}
 
-<div class="xnano-demo" markdown>
-![clock dark](./assets/concepts/hooks_tick-dark.gif){.demo-dark}
-![clock light](./assets/concepts/hooks_tick-light.gif){.demo-light}
+-   :material-puzzle:{ .lg .middle } **Components**
+
+    ---
+
+    Explore xnano's component API, along with built-in components and how to easily define your own.
+
+    [Components | Components]{.xnano-card-link data-preview}
+
+-   :material-school:{ .lg .middle } **Tutorials**
+
+    ---
+
+    Simple step-by-step tutorials for a variety of common use cases and patterns that can be implemented with xnano.
+
+    [Tutorials | Overview]{.xnano-card-link data-preview}
+
+-   :material-chip:{ .lg .middle } **Core Architecture**
+
+    ---
+
+    For _advanced_ developers, who want a deeper undertanding of the underlying rust-based <code>xnano-core</code> library along with xnano's core architecture and event/rendering lifecycle.
+
+    [Core Architecture | xnano-core]{.xnano-card-link data-preview}
+
+-   :material-book-open-page-variant:{ .lg .middle } **API Reference**
+
+    ---
+
+    Complete API reference for the public classes, methods and other objects within the <code>xnano</code> and <code>xnano-core</code> packages.
+
+    [API Reference | xnano]{.xnano-card-link data-preview}
+
 </div>
 
-For 60 fps animations, pass a short interval:
-
-```python
-Terminal(tick_interval=16).run(MyAnimatedApp())
-```
-
----
-
-## Sizing fields
-
-Every field accepts `width=` and `height=` to control how much space it takes. You can use plain integers (cells), percentages, or fraction strings.
-
-```python
-class Layout(BaseGrid, direction="horizontal", gap=1):
-    sidebar: str = Field(default="Sidebar", width="25%",  border="rounded")
-    main:    str = Field(default="Content", width="1fr",  border="rounded")
-    aside:   str = Field(default="Aside",   width="20%",  border="rounded")
-```
-
-| Value | Description |
-|---|---|
-| `3` | Fixed 3 cells |
-| `"25%"` | 25% of the available space |
-| `"1fr"` / `"2fr"` | A fractional share of what's left — `"2fr"` takes twice as much as `"1fr"` |
-| `"fit"` | Shrink-wrap to content size |
-
-Mix and match freely — xnano resolves everything in one pass:
-
-```python
-class App(BaseGrid, direction="vertical"):
-    header: str = Field(default="Header", height=1)     # always 1 row
-    body:   str = Field(default="Body",   height="1fr") # fills remaining space
-    footer: str = Field(default="Footer", height=3)     # always 3 rows
-
-Terminal().run(App())
-```
-
-<div class="xnano-demo" markdown>
-![sizing dark](./assets/concepts/sizing_mix-dark.gif){.demo-dark}
-![sizing light](./assets/concepts/sizing_mix-light.gif){.demo-light}
-</div>
-
----
-
-## Styled text
-
-Use `Text` to compose rich inline content with colors, modifiers, and nesting:
-
-```python
-from xnano import render
-from xnano.components.text import Text
-
-message = Text([
-    Text("● ", color="emerald-400"),
-    Text("Done: ", color="white", modifiers=["bold"]),
-    Text("all tests passed\n", color="slate-300"),
-])
-
-render(message)
-```
-
-<div class="xnano-demo" markdown>
-![styled text dark](./assets/concepts/styled_text-dark.gif){.demo-dark}
-![styled text light](./assets/concepts/styled_text-light.gif){.demo-light}
-</div>
-
-Colors accept Tailwind names (`"violet-500"`), hex strings (`"#a78bfa"`), or plain names (`"white"`, `"red"`).
-
----
-
-## Next steps
-
-As of v1.0.4, the documentation for xnano is still a heavy work in progress. Complete
-guides and tutorials will be available very soon.
+[Core Concepts]: core-concepts/grids.md
+[Core Concepts | Grids]: core-concepts/grids.md
+[Components | Components]: components/index.md
+[Tutorials | Overview]: tutorials/index.md
+[Core Architecture | xnano-core]: architecture/xnano-core.md
+[API Reference | xnano]: api/xnano/xnano.md

--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -136,26 +136,35 @@ function openLinksInNewTab() {
     });
 }
 
-// Picks two random colors from the current theme's aurora palette (shared
-// with hero.js) once per page load and hands them to nav.css as CSS vars.
+// Picks two neighboring colors from a restrained pastel palette once per
+// page load and hands them to nav.css as CSS vars. This intentionally stays
+// independent from the brighter hero palette.
 // This is a single synchronous pick — no animation loop, no per-frame cost.
 function setupNavAccent() {
-    const palettes = window.__xnanoAuroraPalettes;
-    if (!palettes) return;
-
-    // Lighten by mixing toward white — keeps the same hue, just a lighter
-    // tint of it, rather than jumping to an unrelated color in the palette.
-    function lighten([r, g, b], amount) {
-        return [r, g, b].map(v => Math.round(v + (255 - v) * amount));
-    }
+    const palettes = {
+        default: [
+            [100, 117, 160], // dusty cornflower
+            [111, 133, 174], // powder blue
+            [98, 137, 158],  // blue mist
+            [121, 125, 166], // muted periwinkle
+        ],
+        slate: [
+            [178, 192, 223], // moonlit blue
+            [184, 202, 228], // powder blue
+            [165, 202, 210], // blue mist
+            [190, 194, 225], // pale periwinkle
+        ],
+    };
 
     function pickColors() {
         const scheme = document.body.getAttribute("data-md-color-scheme");
         const palette = palettes[scheme] || palettes.slate;
-        const base = palette[Math.floor(Math.random() * palette.length)];
+        const index = Math.floor(Math.random() * palette.length);
+        const base = palette[index];
+        const companion = palette[(index + 1) % palette.length];
         const toRgb = ([r, g, b]) => `rgb(${r}, ${g}, ${b})`;
         document.documentElement.style.setProperty("--xnano-nav-c1", toRgb(base));
-        document.documentElement.style.setProperty("--xnano-nav-c2", toRgb(lighten(base, 0.45)));
+        document.documentElement.style.setProperty("--xnano-nav-c2", toRgb(companion));
     }
 
     pickColors();
@@ -165,10 +174,27 @@ function setupNavAccent() {
     });
 }
 
+function setupCollapsibleNavigation() {
+    document.querySelectorAll("li.md-nav__item--section").forEach(li => {
+        const label = li.querySelector("label.md-nav__link .md-ellipsis");
+        if (label) {
+            const text = label.textContent.trim();
+            if (
+                text === "Tutorials" ||
+                text === "Core Architecture" ||
+                text === "API Reference"
+            ) {
+                li.classList.remove("md-nav__item--section");
+            }
+        }
+    });
+}
+
 async function main() {
     setupTermynal();
     openLinksInNewTab();
     setupNavAccent();
+    setupCollapsibleNavigation();
 }
 
 document$.subscribe(() => {

--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -5,7 +5,6 @@
   </div>
   {% endif %}
   {% if not config.extra.generator == false %}
-  Docs made with <a href="https://zensical.org/" target="_blank" rel="noopener">Zensical</a> & Theme Inspired By <a
-    href="https://zed.dev" target="_blank" rel="noopener">Zed</a>
+  Docs made with <a href="https://zensical.org/" target="_blank" rel="noopener">Zensical</a>
   {% endif %}
 </div>

--- a/docs/stylesheets/code-theme.css
+++ b/docs/stylesheets/code-theme.css
@@ -14,12 +14,12 @@
     --xn-code-line-highlight: #e4e2d4;
 
     --xn-code-comment: #6b7280;
-    --xn-code-keyword: #a626a4;
-    --xn-code-decorator: rgb#597fa1;
+    --xn-code-keyword: #756d93;
+    --xn-code-decorator: #6879a0;
     --xn-code-namespace: #383a42;
     --xn-code-class: #c18401;
-    --xn-code-builtin: #0184bc;
-    --xn-code-function: #4078a8;
+    --xn-code-builtin: #537f88;
+    --xn-code-function: #62769e;
     --xn-code-string: #50a14f;
     --xn-code-number: #986801;
     --xn-code-constant: #986801;
@@ -34,12 +34,12 @@
     --xn-code-line-highlight: #262a33;
 
     --xn-code-comment: #5c6370;
-    --xn-code-keyword: #c678dd;
-    --xn-code-decorator: #80bbeb;
+    --xn-code-keyword: #c4badb;
+    --xn-code-decorator: #b4c2df;
     --xn-code-namespace: #abb2bf;
     --xn-code-class: #e5c07b;
-    --xn-code-builtin: #56b6c2;
-    --xn-code-function: #61afef;
+    --xn-code-builtin: #91c0c5;
+    --xn-code-function: #afc2e3;
     --xn-code-string: #98c379;
     --xn-code-number: #d19a66;
     --xn-code-constant: #d19a66;

--- a/docs/stylesheets/components.css
+++ b/docs/stylesheets/components.css
@@ -3,12 +3,14 @@
 .grid-concept-diagram {
     margin-left: 1.5rem;
     margin-right: 1.5rem;
-    max-width: 40rem;
+    max-width: min(40rem, 100%);
+    box-sizing: border-box;
 }
 
 .grid-concept-diagram svg {
     display: block;
     width: 100%;
+    max-width: 100%;
     height: auto;
     font-family: "Geist Pixel", "Iosevka Web", monospace;
 }
@@ -19,77 +21,92 @@
     margin-right: auto;
     margin-top: 0.75rem;
     margin-bottom: 0.25rem;
-    max-width: 22rem;
+    max-width: min(22rem, 100%);
+    box-sizing: border-box;
+}
+
+/* Medium / small viewports: drop side indent so the figure matches text width. */
+@media screen and (max-width: 76.1875em) {
+    .grid-concept-diagram {
+        margin-left: 0;
+        margin-right: 0;
+        max-width: 100%;
+    }
+
+    .grid-concept-diagram--compact {
+        margin-left: 0;
+        max-width: 100%;
+    }
 }
 
 /* Light */
 [data-md-color-scheme="default"] .grid-concept-diagram {
     --gcd-panel-bg: #eeecdf;
     --gcd-panel-border: #c8c4b4;
-    --gcd-panel-accent-bg: #e4ebf8;
-    --gcd-panel-accent-border: #124ecf;
+    --gcd-panel-accent-bg: var(--xnano-accent-soft);
+    --gcd-panel-accent-border: var(--xnano-accent-border);
     --gcd-window-bg: #f4f4ed;
     --gcd-chrome-bg: #e4e2d4;
     --gcd-dot: #b8b4a4;
     --gcd-urlbar: #f4f4ed;
-    --gcd-text: #102044;
+    --gcd-text: var(--xnano-accent-ink);
     --gcd-text-soft: #5a6478;
-    --gcd-line: #124ecf;
-    --gcd-line-soft: #a8b4c8;
-    --gcd-grid: #124ecf33;
-    --gcd-grid-fill: #124ecf0a;
-    --gcd-arrow: #124ecf;
-    --gcd-label-accent: #124ecf;
-    --gcd-cell-highlight: #124ecf28;
-    --gcd-cell-highlight-strong: #124ecf55;
-    --gcd-cell-highlight-border: #124ecf;
-    --gcd-stripe-bg: #124ecf22;
-    --gcd-stripe-fg: #124ecf66;
+    --gcd-line: var(--xnano-accent);
+    --gcd-line-soft: #aaa8c4;
+    --gcd-grid: color-mix(in srgb, var(--xnano-accent) 20%, transparent);
+    --gcd-grid-fill: color-mix(in srgb, var(--xnano-accent) 5%, transparent);
+    --gcd-arrow: var(--xnano-accent);
+    --gcd-label-accent: var(--xnano-accent);
+    --gcd-cell-highlight: color-mix(in srgb, var(--xnano-accent) 16%, transparent);
+    --gcd-cell-highlight-strong: color-mix(in srgb, var(--xnano-accent) 33%, transparent);
+    --gcd-cell-highlight-border: var(--xnano-accent-border);
+    --gcd-stripe-bg: color-mix(in srgb, var(--xnano-accent) 13%, transparent);
+    --gcd-stripe-fg: color-mix(in srgb, var(--xnano-accent) 40%, transparent);
     --gcd-z-base: #9a958833;
     --gcd-z-base-border: #9a9588;
-    --gcd-z-overlay: #124ecfcc;
-    --gcd-z-overlay-inner: #e4ebf8ee;
-    --gcd-z-connector: #124ecf55;
-    --gcd-z-label: #102044;
-    --gcd-z-label-on: #102044;
+    --gcd-z-overlay: color-mix(in srgb, var(--xnano-accent-bright) 80%, transparent);
+    --gcd-z-overlay-inner: color-mix(in srgb, var(--xnano-accent-soft) 93%, transparent);
+    --gcd-z-connector: color-mix(in srgb, var(--xnano-accent) 33%, transparent);
+    --gcd-z-label: var(--xnano-accent-ink);
+    --gcd-z-label-on: var(--xnano-accent-ink);
     --gcd-z-label-muted: #7a766c;
     --gcd-z-caption: #5a6478;
-    --gcd-z-caption-on: #124ecf;
+    --gcd-z-caption-on: var(--xnano-accent);
 }
 
 /* Dark */
 [data-md-color-scheme="slate"] .grid-concept-diagram {
     --gcd-panel-bg: #1a1c22;
-    --gcd-panel-border: #2a3856;
-    --gcd-panel-accent-bg: #161c2a;
-    --gcd-panel-accent-border: #85acfa;
+    --gcd-panel-border: var(--xnano-accent-border);
+    --gcd-panel-accent-bg: var(--xnano-accent-soft);
+    --gcd-panel-accent-border: var(--xnano-accent);
     --gcd-window-bg: #141519;
     --gcd-chrome-bg: #0e1014;
     --gcd-dot: #3a4256;
     --gcd-urlbar: #1e2028;
     --gcd-text: #dedcd1;
     --gcd-text-soft: #8b909a;
-    --gcd-line: #85acfa;
-    --gcd-line-soft: #3a4a66;
-    --gcd-grid: #85acfa44;
-    --gcd-grid-fill: #85acfa0f;
-    --gcd-arrow: #85acfa;
-    --gcd-label-accent: #8ec6ff;
-    --gcd-cell-highlight: #85acfa33;
-    --gcd-cell-highlight-strong: #85acfa66;
-    --gcd-cell-highlight-border: #85acfa;
-    --gcd-stripe-bg: #85acfa28;
-    --gcd-stripe-fg: #85acfa77;
+    --gcd-line: var(--xnano-accent);
+    --gcd-line-soft: #555272;
+    --gcd-grid: color-mix(in srgb, var(--xnano-accent) 27%, transparent);
+    --gcd-grid-fill: color-mix(in srgb, var(--xnano-accent) 6%, transparent);
+    --gcd-arrow: var(--xnano-accent);
+    --gcd-label-accent: var(--xnano-accent-bright);
+    --gcd-cell-highlight: color-mix(in srgb, var(--xnano-accent) 20%, transparent);
+    --gcd-cell-highlight-strong: color-mix(in srgb, var(--xnano-accent) 40%, transparent);
+    --gcd-cell-highlight-border: var(--xnano-accent);
+    --gcd-stripe-bg: color-mix(in srgb, var(--xnano-accent) 16%, transparent);
+    --gcd-stripe-fg: color-mix(in srgb, var(--xnano-accent) 47%, transparent);
     --gcd-z-base: #5c637033;
     --gcd-z-base-border: #5c6370;
-    --gcd-z-overlay: #85acfacf;
-    --gcd-z-overlay-inner: #1a2438ee;
-    --gcd-z-connector: #85acfa66;
+    --gcd-z-overlay: color-mix(in srgb, var(--xnano-accent) 81%, transparent);
+    --gcd-z-overlay-inner: color-mix(in srgb, var(--xnano-accent-soft) 93%, transparent);
+    --gcd-z-connector: color-mix(in srgb, var(--xnano-accent) 40%, transparent);
     --gcd-z-label: #dedcd1;
     --gcd-z-label-on: #dedcd1;
     --gcd-z-label-muted: #8b909a;
     --gcd-z-caption: #8b909a;
-    --gcd-z-caption-on: #85acfa;
+    --gcd-z-caption-on: var(--xnano-accent);
 }
 
 .grid-concept-diagram .gcd-panel {

--- a/docs/stylesheets/extras.css
+++ b/docs/stylesheets/extras.css
@@ -138,8 +138,15 @@
     --md-default-bg-color: #f4f4ed;
     --md-primary-bg-color: #f4f4ed;
 
-    --md-accent-fg-color: #102044;
-    --md-accent-bg-color: #124ecf;
+    --xnano-accent: #5e6f96;
+    --xnano-accent-bright: #7588b6;
+    --xnano-accent-soft: #e1e5ef;
+    --xnano-accent-border: #8995b2;
+    --xnano-accent-ink: #343b50;
+    --xnano-accent-shadow: #5e6f9633;
+
+    --md-accent-fg-color: var(--xnano-accent);
+    --md-accent-bg-color: var(--xnano-accent-soft);
 
     --md-footer-bg-color: #f3f1eb;
     --md-footer-bg-color--dark: #f3f1eb;
@@ -158,7 +165,7 @@
 
 /* H1 Coloring */
 [data-md-color-scheme="default"] .md-typeset h1 {
-    color: #124ecf;
+    color: var(--xnano-accent);
 }
 
 /* Banner Announcement over Header */
@@ -169,8 +176,8 @@
 /* Code Blocks Override */
 [data-md-color-scheme="default"] .highlight {
     border-radius: var(--radius-2);
-    border: var(--border-size-1) solid #124ecf;
-    box-shadow: #124ecf33 4px 4px 0px 0px;
+    border: var(--border-size-1) solid var(--xnano-accent-border);
+    box-shadow: var(--xnano-accent-shadow) 4px 4px 0px 0px;
     position: relative;
     /* Annotation tooltips are positioned outside the code box. Clipping this
        wrapper cuts their text off at the rounded edge. */
@@ -181,13 +188,20 @@
   !!! DARK THEME COLORS !!!
 */
 [data-md-color-scheme="slate"] {
-    --md-default-bg-color: #141519;
-    --md-primary-bg-color: #141519;
+    --md-default-bg-color: #141414;
+    --md-primary-bg-color: #141414;
 
     --md-primary-fg-color: #dedcd1;
 
-    --md-accent-bg-color: #102044;
-    --md-accent-fg-color: #85acfa;
+    --xnano-accent: #b2c0df;
+    --xnano-accent-bright: #c6d0e9;
+    --xnano-accent-soft: #1B1B1B;
+    --xnano-accent-border: #212121;
+    --xnano-accent-ink: #e0e5f0;
+    --xnano-accent-shadow: #8295bd33;
+
+    --md-accent-bg-color: var(--xnano-accent-soft);
+    --md-accent-fg-color: var(--xnano-accent);
 
     --md-footer-bg-color: #0e1014;
     --md-footer-bg-color--dark: #0e1014;
@@ -197,16 +211,16 @@
   !!! DARK THEME COLOR OVERRIDES !!!
 */
 [data-md-color-scheme="slate"] .md-header {
-    background-color: #141519;
+    background-color: #141414;
 }
 
 [data-md-color-scheme="slate"] .md-footer-meta {
-    background-color: #141519;
+    background-color: #141414;
 }
 
 /* H1 Coloring */
 [data-md-color-scheme="slate"] .md-typeset h1 {
-    color: #8ec6ff;
+    color: var(--xnano-accent-bright);
 }
 
 /* Banner Announcement over Header */
@@ -217,8 +231,8 @@
 /* Code Blocks Override */
 [data-md-color-scheme="slate"] .highlight {
     border-radius: var(--radius-2);
-    border: var(--border-size-1) solid #2a3856;
-    box-shadow: #2a385633 4px 4px 0px 0px;
+    border: var(--border-size-1) solid var(--xnano-accent-border);
+    box-shadow: var(--xnano-accent-shadow) 4px 4px 0px 0px;
     position: relative;
     overflow: visible;
 }
@@ -262,40 +276,74 @@
 
 [data-md-color-scheme="default"] .highlight > span.filename {
     background-color: #e9e7dc;
-    color: #102044;
-    border-color: #85acfa;
+    color: var(--xnano-accent-ink);
+    border-color: var(--xnano-accent-border);
 }
 
 [data-md-color-scheme="default"] .highlight > span.filename .code-lang {
-    color: #124ecf;
+    color: var(--xnano-accent);
     opacity: 0.85;
 }
 
 [data-md-color-scheme="slate"] .highlight > span.filename {
     background-color: #0e1014;
     color: #dedcd1;
-    border-color: #2a3856;
+    border-color: var(--xnano-accent-border);
 }
 
 [data-md-color-scheme="slate"] .highlight > span.filename .code-lang {
-    color: #85acfa;
+    color: var(--xnano-accent);
     opacity: 0.85;
+}
+
+/*
+  Content media must stay within the typeset column — same usable width as
+  text and code blocks. Paragraphs use scaleX(1.03) for body copy, which
+  otherwise pushes images/GIFs past the right edge (clipped on medium and
+  smaller layouts, and anywhere the column is tight).
+*/
+.md-typeset img,
+.md-typeset video,
+.md-typeset picture {
+    max-width: 100%;
+    height: auto;
+    box-sizing: border-box;
+}
+
+/* Image-only (or link-wrapped image) paragraphs: no optical widen. */
+.md-typeset p:has(> img:only-child),
+.md-typeset p:has(> a:only-child > img:only-child),
+.md-typeset p:has(> picture:only-child),
+.md-typeset p:has(> a:only-child > picture:only-child) {
+    transform: none;
 }
 
 /* ── Theme-aware demo GIFs ─────────────────────────────────────────────── */
 .xnano-demo {
     margin: 1.25rem 0;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
     border-radius: 12px;
     overflow: hidden;
     line-height: 0;
 }
 
+/* MkDocs wraps images in <p>; that p inherits scaleX and clips the right edge. */
+.xnano-demo > p {
+    display: contents;
+    margin: 0;
+    transform: none;
+}
+
 .xnano-demo img {
-    width: auto;
+    width: 100%;
     max-width: 100%;
     height: auto;
     display: block;
     border-radius: 12px;
+    box-sizing: border-box;
+    object-fit: contain;
 }
 
 /* Paired captures opt into theme switching. A single unclassified image is

--- a/docs/stylesheets/nav.css
+++ b/docs/stylesheets/nav.css
@@ -1,20 +1,36 @@
 /* ── Navbar / TOC active + inactive link styling ──────────────────────────
-   Active link gets a slow two-tone shimmer, colors picked at random once
-   per page load from the same aurora palette as hero.js (see custom.js
+   Active link in the primary sidebar nav gets a "> " marker whose color
+   shimmers slowly between two tones, picked at random once per page load
+   from a small pastel palette (see custom.js
    `setupNavAccent`) — a single synchronous pick, not a per-frame cost.
    The shimmer itself is a compositor-only `background-position` animation
-   (no layout/paint per frame). Inactive links get a plain color
-   transition on hover. */
+   (no layout/paint per frame). The TOC (secondary sidebar) gets no
+   animation at all. Inactive links get a plain color transition on
+   hover. */
 
 .md-nav__link {
     transition: color 0.2s var(--ease-out-3);
+    /* Material ships leaf links at 700 and active at 500, so "bold" on
+       active is invisible. Keep leaves regular; bold only the selection. */
+    font-weight: 400;
+    font-synthesis: weight;
 }
 
 .md-nav__link:not(.md-nav__link--active):hover {
     color: var(--md-accent-fg-color);
 }
 
-.md-nav__link--active .md-ellipsis {
+/* Section toggles / dropdowns — the labels that expand or collapse a
+   nested nav list — get bolded so they read as controls distinct from
+   plain leaf links. */
+.md-nav__item--nested > label.md-nav__link {
+    font-weight: 700;
+}
+
+/* "> " marker before the active page's title in the primary sidebar nav
+   only — the shimmer animates the marker's color, not the link text. */
+.md-sidebar--primary .md-nav__link--active .md-ellipsis::before {
+    content: "> ";
     background-image: linear-gradient(
         90deg,
         var(--xnano-nav-c1, var(--md-accent-fg-color)),
@@ -29,6 +45,21 @@
     will-change: background-position;
 }
 
+/* Current page title — link, TOC toggle label, and the ellipsis span
+   Material wraps the title in (weight must hit the span, not only the
+   anchor, or a single-weight body font can look unchanged). */
+.md-sidebar--primary .md-nav__item--active > .md-nav__link,
+.md-sidebar--primary .md-nav__link--active,
+.md-sidebar--primary .md-nav__link--active .md-ellipsis {
+    font-weight: 700 !important;
+}
+
+/* TOC (secondary): same bold active heading, no shimmer. */
+.md-sidebar--secondary .md-nav__link--active,
+.md-sidebar--secondary .md-nav__link--active .md-ellipsis {
+    font-weight: 700 !important;
+}
+
 @keyframes xnano-nav-shimmer {
     50% {
         background-position: -100% 0;
@@ -36,15 +67,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .md-nav__link--active .md-ellipsis {
+    .md-sidebar--primary .md-nav__link--active .md-ellipsis::before {
         animation: none;
     }
-}
-
-/* "> " marker before the active page's title in the primary sidebar nav.
-   `color` is set explicitly since it would otherwise inherit `transparent`
-   from the gradient-clipped `.md-ellipsis` text above it. */
-.md-sidebar--primary .md-nav__link--active .md-ellipsis::before {
-    content: "> ";
-    color: var(--md-accent-fg-color);
 }

--- a/docs/stylesheets/showcase-hover.css
+++ b/docs/stylesheets/showcase-hover.css
@@ -3,6 +3,9 @@
 .xnano-showcase {
     position: relative;
     margin: 1.25rem 0;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
     border-radius: 12px;
     overflow: hidden;
     line-height: 0;
@@ -10,18 +13,24 @@
     display: grid;
 }
 
-/* MkDocs wraps images in <p>; let children share one grid cell. */
+/* MkDocs wraps images in <p>; let children share one grid cell.
+   Also drop scaleX so media doesn't spill past the content column. */
 .xnano-showcase > p {
     display: contents;
     margin: 0;
+    transform: none;
 }
 
 .xnano-showcase img {
     grid-area: 1 / 1;
     width: 100%;
+    max-width: 100%;
+    height: auto;
+    box-sizing: border-box;
     border-radius: 12px;
     display: none;
     transition: opacity 0.45s ease;
+    object-fit: contain;
 }
 
 /* Theme-aware visibility (mono + color pairs). */

--- a/docs/stylesheets/termynal.css
+++ b/docs/stylesheets/termynal.css
@@ -58,7 +58,7 @@
 a[data-terminal-control] {
     text-align: right;
     display: block;
-    color: #aebbff;
+    color: #bdc9e4;
 }
 
 [data-ty] {

--- a/docs/stylesheets/watercolor.css
+++ b/docs/stylesheets/watercolor.css
@@ -1,0 +1,179 @@
+/* ── Small hand-painted details ──────────────────────────────────────────
+   Color stays on the small marks, not behind the interface. Typography,
+   theme behavior, and runnable examples stay untouched.
+
+   Grain is the same pre-baked static texture hero.js uses for the hero
+   image (a 128x128 tile of per-pixel random noise, `mix-blend-mode:
+   overlay` at 0.40 opacity) — a plain cached raster image here, so there's
+   no canvas, no JS, and no per-frame cost at all: one paint, ever. */
+
+/* One warm sunset gradient (coral -> orange -> gold -> cream), not a
+   mixed palette — cool tones (blue/green) desaturated into flat gray
+   once the grain's overlay blend landed on them. */
+[data-md-color-scheme="default"] {
+    --xnano-wash-1: #e2685c;
+    --xnano-wash-2: #ea8f4f;
+    --xnano-wash-3: #eeb057;
+    --xnano-wash-4: #f0c96e;
+    --xnano-wash-5: #f2dfa6;
+}
+
+[data-md-color-scheme="slate"] {
+    --xnano-wash-1: #b8564c;
+    --xnano-wash-2: #c07a45;
+    --xnano-wash-3: #c79650;
+    --xnano-wash-4: #c9a95f;
+    --xnano-wash-5: #cbb98a;
+}
+
+/* Homepage paths stay familiar documentation cards. On hover, the card
+   fills with its wash color and the grain tile shows through it — text
+   inverts so it stays legible against the now-solid fill. */
+.md-content__inner:has(.page-index) .grid.cards > ul > li {
+    --xnano-card-wash-a: var(--xnano-wash-1);
+    position: relative;
+    overflow: hidden;
+    background-color: transparent;
+    background-image: none;
+    border: 0.05rem solid color-mix(
+        in srgb,
+        var(--xnano-card-wash-a) 16%,
+        var(--md-default-fg-color--lightest)
+    );
+    border-radius: 0.3rem;
+    box-shadow: none;
+    padding: 0.85rem;
+    transition: background-color 200ms ease, border-color 200ms ease;
+}
+
+.md-content__inner .grid.cards > ul > li:has(.xnano-card-link) {
+    position: relative;
+}
+
+.md-content__inner .grid.cards .xnano-card-link {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    border-radius: 0.3rem;
+    font-size: 0;
+}
+
+.md-content__inner
+    .grid.cards
+    > ul
+    > li
+    > p:has(> .xnano-card-link:only-child) {
+    display: contents;
+}
+
+.md-content__inner .grid.cards .xnano-card-link:focus-visible {
+    outline: 0.1rem solid var(--md-accent-fg-color);
+    outline-offset: -0.15rem;
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background-image: url("../assets/grain.png");
+    background-repeat: repeat;
+    background-size: 128px 128px;
+    mix-blend-mode: overlay;
+    opacity: 0;
+    transition: opacity 200ms ease;
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li:hover::before,
+.md-content__inner:has(.page-index) .grid.cards > ul > li:focus-within::before {
+    opacity: 0.4;
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li > * {
+    position: relative;
+    z-index: 1;
+    transition: color 200ms ease;
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li:hover,
+.md-content__inner:has(.page-index) .grid.cards > ul > li:focus-within {
+    background-color: var(--xnano-card-wash-a);
+    border-color: var(--xnano-card-wash-a);
+    box-shadow: none;
+}
+
+/* Explicit near-black, not filter: invert() — the theme's default text
+   color is semi-transparent, so inverting it washes out to a low-contrast
+   gray against a mid-toned wash fill instead of real contrast. */
+.md-content__inner:has(.page-index) .grid.cards > ul > li:hover > *,
+.md-content__inner:has(.page-index) .grid.cards > ul > li:focus-within > *,
+.md-content__inner:has(.page-index) .grid.cards > ul > li:hover .twemoji,
+.md-content__inner:has(.page-index) .grid.cards > ul > li:focus-within .twemoji {
+    color: #14120f;
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li:hover hr,
+.md-content__inner:has(.page-index) .grid.cards > ul > li:focus-within hr {
+    border-bottom-color: rgba(20, 18, 15, 0.4);
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li:hover a,
+.md-content__inner:has(.page-index) .grid.cards > ul > li:focus-within a {
+    color: #14120f;
+    text-decoration-color: rgba(20, 18, 15, 0.5);
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li:nth-child(2) {
+    --xnano-card-wash-a: var(--xnano-wash-2);
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li:nth-child(3) {
+    --xnano-card-wash-a: var(--xnano-wash-3);
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li:nth-child(4) {
+    --xnano-card-wash-a: var(--xnano-wash-4);
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li:nth-child(5) {
+    --xnano-card-wash-a: var(--xnano-wash-5);
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li .twemoji {
+    color: color-mix(
+        in srgb,
+        var(--xnano-card-wash-a) 78%,
+        var(--md-default-fg-color)
+    );
+    font-size: 1.15em;
+    transform: rotate(-1.5deg);
+    transform-origin: center;
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li:nth-child(even) .twemoji {
+    transform: rotate(1.25deg);
+}
+
+.md-content__inner:has(.page-index) .grid.cards > ul > li > hr {
+    width: 2.4rem;
+    margin: 0.7rem 0 0.9rem;
+    border-bottom: 0.1rem solid color-mix(
+        in srgb,
+        var(--xnano-card-wash-a) 52%,
+        transparent
+    );
+    transform: rotate(-0.7deg);
+    transform-origin: left center;
+}
+
+@media print {
+    .md-content__inner:has(.page-index) .grid.cards > ul > li .twemoji,
+    .md-content__inner:has(.page-index) .grid.cards > ul > li > hr {
+        transform: none;
+    }
+
+    .md-content__inner:has(.page-index) .grid.cards > ul > li::before {
+        display: none;
+    }
+}

--- a/docs/tutorials/action-bindings.md
+++ b/docs/tutorials/action-bindings.md
@@ -1,0 +1,101 @@
+---
+title: "Action Bindings"
+icon: "lucide/link"
+---
+
+# Action Bindings
+
+`@on_keyboard("ctrl+s")` binds a key directly on one handler. [Action]{data-preview} names that binding once so you can reuse it across handlers, tests, and `perform()` calls.
+
+Events are what the host observed (a key press, a click). Actions are the named intents your app attaches to those inputs — save, quit, next-tab — so the chord and the handler stay decoupled.
+
+## Define an Action
+
+```python title="Define an Action" hl_lines="3 4"
+from xnano import Action
+
+SAVE = Action.keyboard("ctrl+s") # (1)!
+QUIT = Action.keyboard("q")
+```
+
+1. `Action.keyboard(...)` takes the same binding strings as `@on_keyboard` — `"ctrl+s"`, `"q"`, `"enter"`, and so on.
+
+## Bind With `@on`
+
+```python title="Bind With @on" hl_lines="3 4 5 6"
+from xnano import on
+
+@on(SAVE)
+def save(self) -> None: # (1)!
+    self.dirty = False
+    self.status = "saved"
+```
+
+1. `@on(SAVE)` fires when that action matches the live event.
+
+## Mix With `@on_keyboard`
+
+One-off keys can stay on `@on_keyboard`. Use `Action` + `@on` when the same binding is shared, tested, or performed synthetically.
+
+```python title="Mix With @on_keyboard" hl_lines="3 4 5 6"
+from xnano import on_keyboard
+
+@on_keyboard("e")
+def edit(self) -> None:
+    self.dirty = True
+    self.status = "unsaved"
+```
+
+## A Small Editor
+
+```python title="A Small Editor"
+from xnano import BaseGrid, Field, Terminal, Context, Action, on, on_keyboard
+
+SAVE = Action.keyboard("ctrl+s")
+QUIT = Action.keyboard("q")
+
+class Editor(BaseGrid, direction="vertical", gap=1):
+    status: str = Field(default="unsaved", height=1)
+    body: str = Field(default="draft notes…", height=3, border="rounded")
+    dirty: bool = Field(default=True, state=True)
+
+    @on(SAVE)
+    def save(self) -> None:
+        self.dirty = False
+        self.status = "saved"
+
+    @on(QUIT)
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+    @on_keyboard("e")
+    def edit(self) -> None:
+        self.dirty = True
+        self.status = "unsaved"
+
+Terminal().run(Editor())
+```
+
+<div class="xnano-demo" markdown>
+![action bindings dark](../assets/tutorials/action_bindings-dark.gif){.demo-dark}
+![action bindings light](../assets/tutorials/action_bindings-light.gif){.demo-light}
+</div>
+
+## Performing an Action
+
+From tests or another handler, with a live terminal:
+
+```python title="Performing an Action" hl_lines="2"
+terminal.perform(SAVE) # (1)!
+```
+
+1. `perform` injects the action as if the user had triggered its binding. The same `@on(SAVE)` handlers fire.
+
+<br/>
+
+??? abstract "More Action Kinds"
+
+    `Action.keyboard` is the common case. The hierarchy also covers mouse, click, tick, focus, resize, and clipboard — see the [Action]{data-preview} API reference. For the broader hook set, see [events & hooks]{data-preview}.
+
+[Action]: ../api/xnano/core/actions.md
+[events & hooks]: ../core-concepts/events.md

--- a/docs/tutorials/cli-commands.md
+++ b/docs/tutorials/cli-commands.md
@@ -1,0 +1,99 @@
+---
+title: "CLI Commands"
+icon: "lucide/terminal"
+---
+
+# CLI Commands
+
+[Command]{data-preview} declares options and subcommands for process arguments. Decorate a callback, declare options, call `run()`.
+
+It is not a TUI host — pair it with [Terminal]{data-preview} only when a tool needs both a CLI entry and an interactive session.
+
+## A Root Command
+
+Construct a `Command`, register a callback with `@cli`, and decorate options with `@Command.option`. Parameter names map from flags (`--name` → `name`).
+
+```python title="A Root Command" hl_lines="3 5 6 7 8"
+from xnano.cli import Command
+
+cli = Command(name="tool", description="A small utility")
+
+@cli # (1)!
+@Command.option("--name", default="world", help="Who to greet")
+def greet(name: str = "world") -> None:
+    print(f"hello, {name}")
+
+if __name__ == "__main__":
+    cli.run() # (2)!
+```
+
+1. `@cli` registers the function as this command's main callback. The same form works as `cli(greet)` after the function is defined.
+2. `run()` parses `sys.argv[1:]` by default. Pass a list explicitly in tests: `cli.run(["--name", "hammad"])`.
+
+<br/>
+
+```bash title="Usage"
+uv run python tool.py
+# hello, world
+
+uv run python tool.py --name hammad
+# hello, hammad
+
+uv run python tool.py --help
+```
+
+Types on the signature drive coercion when values are parseable (`int`, `bool`, and so on). Set `Command(strict=True)` to raise on bad values instead of falling back to the raw string.
+
+## Subcommands
+
+`@cli.command()` nests another command under a name. Options attach to the subcommand function the same way.
+
+```python title="Subcommands" hl_lines="5 6 7 8 10 11 12 13 14"
+from xnano.cli import Command
+
+cli = Command(name="ship", description="Release helpers")
+
+@cli.command(name="greet", description="Print a greeting")
+@Command.option("--name", default="world", help="Who to greet")
+def greet(name: str = "world") -> None:
+    print(f"hello, {name}")
+
+@cli.command(name="bump")
+@Command.option("--major", is_flag=True, help="Bump the major version")
+def bump(major: bool = False) -> None: # (1)!
+    kind = "major" if major else "patch"
+    print(f"bumping {kind}")
+
+if __name__ == "__main__":
+    cli.run()
+```
+
+1. Boolean options become flags when annotated `bool` or when `is_flag=True` is set. Present on the command line → `True`; absent → the default.
+
+<br/>
+
+```bash title="Usage"
+uv run python ship.py greet --name crew
+uv run python ship.py bump --major
+uv run python ship.py --help
+uv run python ship.py bump --help
+```
+
+Subcommand names default from the function name with underscores turned into hyphens (`def dry_run` → `dry-run`) when `name=` is omitted. Descriptions fall back to the function docstring.
+
+## Options and Positionals
+
+Flags use `@Command.option`; parameters without an explicit option still appear as `--param-name` style flags derived from the signature. Short aliases take a list of flags:
+
+```python title="Short Flags"
+@Command.option(["--verbose", "-v"], is_flag=True, help="Verbose output")
+def build(verbose: bool = False) -> None:
+    ...
+```
+
+<br/>
+
+The same validation helpers used for fields also coerce CLI values when types are annotated.
+
+[Command]: ../api/xnano/cli/command.md
+[Terminal]: ../api/xnano/tui/terminal.md

--- a/docs/tutorials/composed-text.md
+++ b/docs/tutorials/composed-text.md
@@ -1,0 +1,193 @@
+---
+title: "Composed Text"
+icon: "lucide/pencil"
+---
+
+# Composed Text
+
+[Text]{data-preview} covers a single styled span, a line of spans, or a multi-line paragraph. Nested children keep their own colors and modifiers — no ANSI string-building required.
+
+Shape comes from `content` alone: a string is a leaf, a list of leaves is a line, and a list that contains lines becomes a paragraph.
+
+## A Leaf
+
+One run of text with one style.
+
+```python title="A Leaf"
+from xnano.components.text import Text
+
+Text("ready", color="emerald-400", modifiers=("bold",))
+```
+
+## A Line
+
+A list of leaf children becomes one line, each span independent.
+
+```python title="A Line"
+from xnano.components.text import Text
+
+Text([
+    Text("● ", color="emerald-400"),
+    Text("ok", color="white", modifiers=("bold",)),
+    Text(" — all checks passed", color="slate-400"),
+])
+```
+
+## Rendering a Line
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4 5 6 7"
+    from xnano import render
+    from xnano.components.text import Text
+
+    render(Text([
+        Text("● ", color="emerald-400"),
+        Text("welcome", color="white", modifiers=("bold",)),
+        Text(" — xnano is ready", color="slate-400"),
+    ]))
+    ```
+
+```python title="Rendering a Line" hl_lines="4 5 6 7"
+from xnano import render
+from xnano.components.text import Text
+
+render(Text([
+    Text("● ", color="emerald-400"), # (1)!
+    Text("welcome", color="white", modifiers=("bold",)),
+    Text(" — xnano is ready", color="slate-400"),
+]))
+```
+
+1. Each child owns its own `color` and modifiers. The outer `Text` is just the line that holds them.
+
+## A Paragraph
+
+Nest at least one line inside another list and you get a paragraph — each child on its own row.
+
+```python title="A Paragraph"
+Text([
+    Text([Text("Hello ", color="cyan"), Text("world")]),
+    Text("Second line", color="blue"),
+])
+```
+
+## On a Grid Field
+
+```python title="On a Grid Field" hl_lines="6"
+from xnano import BaseGrid, Field
+from xnano.components.text import Text
+
+class StatusBar(BaseGrid, direction="vertical"):
+    line: Text = Field(
+        default_factory=lambda: Text([
+            Text("● ", color="emerald-400"),
+            Text("ok", color="white", modifiers=("bold",)),
+        ]),
+        height=1,
+    )
+```
+
+## Rebuilding When State Changes
+
+Store the level as `state=True` data, rebuild the composed `Text` when it changes, and reassign the field.
+
+```python title="Builder Helper" hl_lines="8 9 10 11 12 13"
+_COLORS = {
+    "ok": "emerald-400",
+    "warn": "amber-400",
+    "err": "red-400",
+}
+_LABELS = {"ok": "healthy", "warn": "degraded", "err": "down"}
+
+def status_line(level: str) -> Text:
+    color = _COLORS[level]
+    return Text([
+        Text("● ", color=color),
+        Text(level.upper(), color=color, modifiers=("bold",)),
+        Text(f" — {_LABELS[level]}", color="slate-400"),
+    ])
+```
+
+```python title="Updating From Keys" hl_lines="3 4 5 6 9 10 11 12"
+from xnano import on_keyboard
+
+@on_keyboard("1")
+def set_ok(self) -> None:
+    self.level = "ok"
+    self.line = status_line(self.level) # (1)!
+
+@on_keyboard("2")
+def set_warn(self) -> None:
+    self.level = "warn"
+    self.line = status_line(self.level)
+```
+
+1. Reassign the whole `Text` when the level changes — same as updating a [Progress]{data-preview} field.
+
+## Putting It Together
+
+```python title="Full Example"
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+from xnano.components.text import Text
+
+_COLORS = {
+    "ok": "emerald-400",
+    "warn": "amber-400",
+    "err": "red-400",
+}
+_LABELS = {"ok": "healthy", "warn": "degraded", "err": "down"}
+
+def status_line(level: str) -> Text:
+    color = _COLORS[level]
+    return Text([
+        Text("● ", color=color),
+        Text(level.upper(), color=color, modifiers=("bold",)),
+        Text(f" — {_LABELS[level]}", color="slate-400"),
+    ])
+
+class StatusBar(BaseGrid, direction="vertical", gap=1):
+    line: Text = Field(default_factory=lambda: status_line("ok"), height=1)
+    hint: str = Field(
+        default="1 ok · 2 warn · 3 err · q quit",
+        height=1,
+        color="slate-500",
+    )
+    level: str = Field(default="ok", state=True)
+
+    @on_keyboard("1")
+    def set_ok(self) -> None:
+        self.level = "ok"
+        self.line = status_line(self.level)
+
+    @on_keyboard("2")
+    def set_warn(self) -> None:
+        self.level = "warn"
+        self.line = status_line(self.level)
+
+    @on_keyboard("3")
+    def set_err(self) -> None:
+        self.level = "err"
+        self.line = status_line(self.level)
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal().run(StatusBar())
+```
+
+<div class="xnano-demo" markdown>
+![composed text dark](../assets/tutorials/composed_text-dark.gif){.demo-dark}
+![composed text light](../assets/tutorials/composed_text-light.gif){.demo-light}
+</div>
+
+<br/>
+
+For editable inputs (`Text(input=True)`, focus, submit), see [text inputs]{data-preview}.
+
+[Text]: ../components/text.md
+[Progress]: ../api/xnano/components/progress.md
+[text inputs]: text-inputs.md

--- a/docs/tutorials/confirm-dialog.md
+++ b/docs/tutorials/confirm-dialog.md
@@ -1,0 +1,170 @@
+---
+title: "Confirm Dialogs"
+icon: "lucide/alert-triangle"
+---
+
+# Confirm Dialogs
+
+A confirm step is a nullable overlay field: `None` means hidden, a [Text]{data-preview} (or string) means shown. Assign the prompt when you need confirmation; set it back to `None` to dismiss.
+
+## Nullable Overlay Field
+
+Fields typed as `T | None` with `default=None` occupy no cells until a value is set. Borders and titles on the field apply when the overlay is present.
+
+```python title="Nullable Overlay Field" hl_lines="8 9 10 11 12"
+from xnano import BaseGrid, Field
+from xnano.components.text import Text
+
+class Trash(BaseGrid, direction="vertical", gap=1):
+    body: str = Field(
+        default="Draft report.md is ready.",
+        border="rounded",
+        title=" File ",
+    )
+    overlay: Text | None = Field(
+        default=None,
+        border="rounded",
+        title=" Confirm ",
+    ) # (1)!
+    pending: bool = Field(default=False, state=True)
+```
+
+1. Hidden while `None`. `border` and `title` only frame the overlay when a value is assigned.
+
+## Showing the Dialog
+
+Showing the dialog is an assignment. The rest of the grid keeps painting underneath.
+
+```python title="Showing the Dialog" hl_lines="3 4 5 6 7 8 9"
+from xnano import on_keyboard
+
+@on_keyboard("d")
+def request_delete(self) -> None:
+    if self.pending:
+        return
+    self.pending = True
+    self.overlay = Text(
+        "Delete draft report.md?\n\n  y · confirm    n / esc · cancel",
+        color="amber-200",
+    )
+```
+
+## Confirm and Cancel
+
+Do the destructive work only on confirm. Open and cancel just toggle the overlay. A `pending` flag keeps `y` / `n` as no-ops when the dialog isn't open.
+
+```python title="Confirm and Cancel" hl_lines="3 4 5 6 7 10 11 12 13 16 17 18 19"
+@on_keyboard("y")
+def confirm(self) -> None:
+    if not self.pending:
+        return
+    self.body = "(empty — file deleted)"
+    self._dismiss()
+
+@on_keyboard("n")
+def cancel(self) -> None:
+    if not self.pending:
+        return
+    self._dismiss()
+
+@on_keyboard("esc")
+def cancel_escape(self) -> None:
+    if not self.pending:
+        return
+    self._dismiss()
+
+def _dismiss(self) -> None:
+    self.pending = False
+    self.overlay = None # (1)!
+```
+
+1. Dismiss by setting `overlay` back to `None`.
+
+## Putting It Together
+
+```python title="Full Example"
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+from xnano.components.text import Text
+
+class Trash(BaseGrid, direction="vertical", gap=1):
+    body: str = Field(
+        default="Draft report.md is ready.",
+        border="rounded",
+        title=" File ",
+    )
+    status: str = Field(default="Press d to delete.", height=1, color="slate-400")
+    hint: str = Field(default="d · delete   q · quit", height=1, color="slate-500")
+
+    overlay: Text | None = Field(
+        default=None,
+        border="rounded",
+        title=" Confirm ",
+    )
+    pending: bool = Field(default=False, state=True)
+
+    @on_keyboard("d")
+    def request_delete(self) -> None:
+        if self.pending:
+            return
+        self.pending = True
+        self.overlay = Text(
+            "Delete draft report.md?\n\n  y · confirm    n / esc · cancel",
+            color="amber-200",
+        )
+        self.status = "Waiting for confirmation…"
+        self.hint = "y · confirm   n / esc · cancel"
+
+    @on_keyboard("y")
+    def confirm(self) -> None:
+        if not self.pending:
+            return
+        self.body = "(empty — file deleted)"
+        self.status = "Deleted."
+        self._dismiss()
+
+    @on_keyboard("n")
+    def cancel(self) -> None:
+        if not self.pending:
+            return
+        self.status = "Delete cancelled."
+        self._dismiss()
+
+    @on_keyboard("esc")
+    def cancel_escape(self) -> None:
+        if not self.pending:
+            return
+        self.status = "Delete cancelled."
+        self._dismiss()
+
+    def _dismiss(self) -> None:
+        self.pending = False
+        self.overlay = None
+        self.hint = "d · delete   q · quit"
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal().run(Trash())
+```
+
+<div class="xnano-demo" markdown>
+![confirm dialog dark](../assets/tutorials/confirm_dialog-dark.gif){.demo-dark}
+![confirm dialog light](../assets/tutorials/confirm_dialog-light.gif){.demo-light}
+</div>
+
+<br/>
+
+??? note "Z-Axis and Overlays"
+
+    Higher-z content paints over lower cells each frame — see the z-axis section in [grids]{data-preview}. A nullable field is the simplest way to mount an overlay.
+
+    For stacked panels that stay mounted (sidebar | main), use nested grids instead — see [nested panels]{data-preview}.
+
+[BaseGrid]: ../api/xnano/grid.md
+[Field]: ../api/xnano/fields.md
+[Terminal]: ../api/xnano/tui/terminal.md
+[Context]: ../api/xnano/context.md
+[Text]: ../api/xnano/components/text.md
+[grids]: ../core-concepts/grids.md
+[nested panels]: nested-panels.md

--- a/docs/tutorials/custom-component.md
+++ b/docs/tutorials/custom-component.md
@@ -1,0 +1,144 @@
+---
+title: "Custom Components"
+icon: "lucide/wrench"
+---
+
+# Custom Components
+
+Subclass [AbstractComponent]{data-preview}, implement `get_size()` and `compose()`, and you get a widget you can drop into a [Field]{data-preview} or pass to [render]{data-preview}. Built-ins follow the same contract.
+
+## The Class Shell
+
+```python title="The Class Shell" hl_lines="6 7 8"
+import dataclasses
+from xnano.components.abstract import AbstractComponent
+
+@dataclasses.dataclass
+class Badge(AbstractComponent):
+    text: str = ""
+    color: str = "white"
+```
+
+## Measure
+
+`get_size()` returns preferred cell size. Skip it and the field's own sizing wins.
+
+```python title="Measure" hl_lines="3 4"
+from xnano._types import Size
+
+def get_size(self, ctx):
+    return Size(width=len(self.text) + 4, height=3) # (1)!
+```
+
+1. Wide enough for the label plus a border, three rows tall for the frame.
+
+## Compose
+
+`compose()` returns host-agnostic content — not a terminal node. Controllers lower that tree into cells or HTML depending on the host.
+
+```python title="Compose" hl_lines="3 4 5 6 7 8"
+from xnano.core.content import Panel, TextBlock
+
+def compose(self, ctx):
+    return Panel(
+        child=TextBlock.from_plain(self.text, color=self.color),
+        border="rounded",
+    )
+```
+
+## Render Standalone
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="5 6 9 10"
+    from xnano import render
+    from xnano._types import Size
+    from xnano.components.abstract import AbstractComponent
+    from xnano.core.content import Panel, TextBlock
+    import dataclasses
+
+    @dataclasses.dataclass
+    class Badge(AbstractComponent):
+        text: str = ""
+        color: str = "white"
+
+        def get_size(self, ctx):
+            return Size(width=len(self.text) + 4, height=3)
+
+        def compose(self, ctx):
+            return Panel(
+                child=TextBlock.from_plain(self.text, color=self.color),
+                border="rounded",
+            )
+
+    render(Badge(text="NEW", color="emerald-400"))
+    ```
+
+```python title="Render Standalone"
+import dataclasses
+from xnano import render
+from xnano._types import Size
+from xnano.components.abstract import AbstractComponent
+from xnano.core.content import Panel, TextBlock
+
+@dataclasses.dataclass
+class Badge(AbstractComponent):
+    text: str = ""
+    color: str = "white"
+
+    def get_size(self, ctx):
+        return Size(width=len(self.text) + 4, height=3)
+
+    def compose(self, ctx):
+        return Panel(
+            child=TextBlock.from_plain(self.text, color=self.color),
+            border="rounded",
+        )
+
+render(Badge(text="NEW", color="emerald-400"))
+```
+
+<div class="xnano-demo" markdown>
+![custom component dark](../assets/tutorials/custom_component-dark.gif){.demo-dark}
+![custom component light](../assets/tutorials/custom_component-light.gif){.demo-light}
+</div>
+
+## As a Field Value
+
+A component is a field value like any other. Use `default_factory` when the instance is mutable or takes constructor arguments.
+
+```python title="As a Field Value" hl_lines="6 7 8"
+from xnano import BaseGrid, Field
+
+class Header(BaseGrid, direction="horizontal", gap=1):
+    title: str = Field(default="Deploy", height=1)
+    badge: Badge = Field(
+        default_factory=lambda: Badge(text="LIVE", color="red"), # (1)!
+        width="fit",
+        height=3,
+    )
+```
+
+1. Same as putting a `Progress` or `Table` on a field — `default_factory` builds a fresh instance per grid.
+
+<br/>
+
+Reassign the field when the badge should change:
+
+```python title="Updating a Badge"
+self.badge = Badge(text="DONE", color="emerald-400")
+```
+
+<br/>
+
+Built-ins — [Text]{data-preview}, [Table]{data-preview}, [Progress]{data-preview}, and the rest — are the same shape. See [Components]{data-preview} for the full set.
+
+[AbstractComponent]: ../api/xnano/components/abstract.md
+[Field]: ../api/xnano/fields.md
+[render]: ../api/xnano/_renderable.md
+[Components]: ../components/index.md
+[Text]: ../api/xnano/components/text.md
+[Table]: ../api/xnano/components/table.md
+[Progress]: ../api/xnano/components/progress.md

--- a/docs/tutorials/dual-host.md
+++ b/docs/tutorials/dual-host.md
@@ -1,0 +1,101 @@
+---
+title: "Dual Host"
+icon: "lucide/repeat"
+---
+
+# Dual Host
+
+Hand the same [BaseGrid]{data-preview} class to either [Terminal]{data-preview} or [Web]{data-preview} without changing fields or hooks. Only the entrypoint chooses the host.
+
+## One Grid
+
+Nothing in the class imports `Terminal` or `Web`.
+
+```python title="One Grid" hl_lines="7 8 10 11 12 13 15 16 17"
+from xnano import BaseGrid, Field, on_keyboard, on_tick
+
+class Counter(BaseGrid, direction="vertical", gap=1):
+    label: str = Field(default="Count: 0", height=1)
+    clock: str = Field(default="uptime: 0s", height=1, color="slate-500")
+    hint: str = Field(default="↑ to count · works in terminal or browser", height=1)
+
+    count: int = Field(default=0, state=True)
+    seconds: int = Field(default=0, state=True)
+
+    @on_keyboard("up")
+    def bump(self) -> None:
+        self.count += 1
+        self.label = f"Count: {self.count}"
+
+    @on_tick(1000)
+    def tick(self) -> None:
+        self.seconds += 1
+        self.clock = f"uptime: {self.seconds}s"
+```
+
+<br/>
+
+## Choosing a Host
+
+A thin `main()` reads a flag and constructs one host. Terminal mode runs an instance; web mode can pass the class itself so each browser session gets a fresh grid.
+
+```python title="Choosing a Host" hl_lines="3 6 7 8 11 12"
+import sys
+
+def main() -> None:
+    use_web = "--web" in sys.argv
+
+    if use_web:
+        from xnano.webui import Web
+
+        Web(title="counter").run(Counter) # (1)!
+    else:
+        from xnano import Terminal
+
+        Terminal().run(Counter())
+
+if __name__ == "__main__":
+    main()
+```
+
+1. Pass the **class** (`Counter`) for a new grid per browser session. Pass an **instance** (`Counter()`) to share one live grid across every visitor.
+
+<div class="xnano-demo" markdown>
+![dual host terminal dark](../assets/tutorials/dual_host_terminal-dark.gif){.demo-dark}
+![dual host terminal light](../assets/tutorials/dual_host_terminal-light.gif){.demo-light}
+</div>
+
+<br/>
+
+```bash title="Run"
+uv run python app.py          # terminal
+uv run python app.py --web    # http://127.0.0.1:8000
+```
+
+??? abstract "Web Dependencies"
+
+    Building HTML/HTMX needs no extra packages, but serving a real process does — install the `web` extra for starlette and uvicorn:
+
+    ```bash
+    pip install "xnano[web]"
+    ```
+
+??? note "Shared vs. Per-Visitor Sessions"
+
+    ```python
+    Web().run(Counter())   # one shared instance for every visitor
+    Web().run(Counter)     # a fresh grid per browser session
+    ```
+
+    Use the class when each visitor should get their own state. Use an instance when the app is a shared board.
+
+## What Carries Over
+
+Keyboard hooks, ticks, clicks, fields, and components mean the same thing on both hosts. A few [device]{data-preview} and cursor controls only apply in a real terminal and become no-ops on `Web`.
+
+For a fuller sample (text input, click target, and clock together), see `examples/web_counter.py`.
+
+[BaseGrid]: ../api/xnano/grid.md
+[Terminal]: ../api/xnano/tui/terminal.md
+[Web]: ../api/xnano/webui/web.md
+[device]: ../core-concepts/device.md

--- a/docs/tutorials/grid-render.md
+++ b/docs/tutorials/grid-render.md
@@ -1,0 +1,96 @@
+---
+title: "grid_render"
+icon: "lucide/layout-grid"
+---
+
+# grid_render
+
+`grid_render()` runs once per frame, before layout, so painted fields can be recomputed from live state. Use it when the display is derived — clocks, tab bodies, headers that read shared state — not when a single key press is enough to rewrite one field.
+
+## Override the Method
+
+Assign field values as usual; do not return a tree.
+
+```python title="Override the Method" hl_lines="8 9"
+import time
+from xnano import BaseGrid, Field, Terminal
+
+class Clock(BaseGrid, direction="vertical"):
+    display: str = Field(default="", height=3, border="rounded", title=" time ")
+
+    def grid_render(self) -> None: # (1)!
+        self.display = time.strftime("  %H:%M:%S")
+
+Terminal(tick_interval=200).run(Clock())
+```
+
+1. Called every frame after event dispatch and before layout. Initial defaults still come from `Field(default=...)` or `__post_init__`; this method refreshes what changes over time.
+
+<br/>
+
+A short `tick_interval` keeps time-based UIs redrawing. Without ticks, the host still frames on input — clocks need a timer when nothing else is happening.
+
+## Derived From State
+
+When a header depends on app-wide state (or several fields that other hooks mutate), recompute it in `grid_render` instead of repeating the same assignment in every handler.
+
+```python title="Derived From State" hl_lines="14 15 16 17 18 19"
+import dataclasses
+from xnano import BaseGrid, Context, Field, Terminal, on_keyboard
+
+@dataclasses.dataclass
+class AppState:
+    username: str = "guest"
+    tab: int = 0
+
+class Shell(BaseGrid, direction="vertical", gap=1):
+    header: str = Field(
+        default="", height=1, color="white", background="violet-900"
+    )
+    body: str = Field(default="← / → switch tabs · q quit")
+
+    def grid_render(self) -> None:
+        state = self.state # (1)!
+        tabs = ["Overview", "Config", "Logs"]
+        label = tabs[state.tab % len(tabs)]
+        self.header = f"  {state.username} · {label}"
+        self.body = f"  Active tab: {label}"
+
+    @on_keyboard("left")
+    def prev(self, ctx: Context[AppState]) -> None:
+        ctx.get_state().tab = (ctx.get_state().tab - 1) % 3
+
+    @on_keyboard("right")
+    def next(self, ctx: Context[AppState]) -> None:
+        ctx.get_state().tab = (ctx.get_state().tab + 1) % 3
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal(state=AppState(username="hammad")).run(Shell())
+```
+
+1. `self.state` is whatever was passed to `Terminal(state=...)`. Reading it here keeps the paint path in one place; hooks only mutate the underlying numbers.
+
+<div class="xnano-demo" markdown>
+![grid render dark](../assets/tutorials/grid_render-dark.gif){.demo-dark}
+![grid render light](../assets/tutorials/grid_render-light.gif){.demo-light}
+</div>
+
+<br/>
+
+`examples/tabs_nav.py` and `examples/dashboard.py` do the same thing at larger scale: hooks change indices and histories, `grid_render` rebuilds the widgets.
+
+## When Hooks Are Enough
+
+Update fields directly in hooks when a change is event-driven and local — increment a counter, flip a boolean, rewrite one label. Use `grid_render` when:
+
+- Values depend on wall-clock time or external state that moves without a key press.
+- Several fields must stay consistent with one shared index (tabs, selected row + detail pane).
+- Components are rebuilt as values each frame (`self.table = Services(...)`, sparkline windows, and similar).
+
+Mixing both is normal: hooks mutate state; `grid_render` projects that state onto fields.
+
+[BaseGrid]: ../api/xnano/grid.md
+[Context]: ../api/xnano/context.md

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,71 @@
+---
+title: "Overview"
+icon: "lucide/graduation-cap"
+---
+
+# Overview
+
+Working examples of common xnano patterns — streaming text, forms, lists, tabs, shared state, dual hosts, and more. Most pages are small and self-contained; a few put several ideas together.
+
+These assume you've already read [Core Concepts]{data-preview} — especially [grids]{data-preview}, [fields]{data-preview}, [events & hooks]{data-preview}, and [context]{data-preview}.
+
+## Interaction
+
+| Tutorial | What it shows |
+|---|---|
+| [Streaming Content](streaming-content.md) | Live field streaming and `render(..., stream=...)` |
+| [Text Inputs](text-inputs.md) | Editable `Text(input=True)` fields, focus, and submit |
+| [Selection Lists](selection-list.md) | Keyboard-navigable lists with a live selection highlight |
+| [Tabs](tabs.md) | Multi-screen layouts switched from one keybinding |
+| [Confirm Dialogs](confirm-dialog.md) | A nullable overlay field as a modal confirm step |
+
+## Layout & Display
+
+| Tutorial | What it shows |
+|---|---|
+| [Nested Panels](nested-panels.md) | Grids inside grids — sidebars, headers, content regions |
+| [Composed Text](composed-text.md) | Multi-span status lines and mixed styling with `Text` |
+| [grid_render](grid-render.md) | Recomputing display every frame with `grid_render()` |
+| [Scrollable Logs](scrollable-log.md) | A windowed, scrollable log feed from a longer buffer |
+
+## Live Data
+
+| Tutorial | What it shows |
+|---|---|
+| [Live Progress](live-progress.md) | Animating a `Progress` bar from `@on_tick` |
+| [Live Sparklines](live-sparklines.md) | Rolling metric history with `Sparkline` |
+| [Table Browser](table-browser.md) | Selecting rows in a declarative `Table` |
+
+## State, Actions & Hosts
+
+| Tutorial | What it shows |
+|---|---|
+| [Shared State](shared-state.md) | App-wide state on `Terminal(state=...)` typed through `Context` |
+| [Action Bindings](action-bindings.md) | Reusable `Action` constants bound with `@on` |
+| [Title & Clipboard](title-and-clipboard.md) | Window titles and clipboard from `ctx.device` |
+| [Dual Host](dual-host.md) | The same grid on `Terminal` and `Web` |
+| [CLI Commands](cli-commands.md) | Options and subcommands with `xnano.cli.Command` |
+
+## Reuse
+
+| Tutorial | What it shows |
+|---|---|
+| [Custom Components](custom-component.md) | A small reusable widget via `AbstractComponent` |
+
+## Running the Examples
+
+One-shot `render()` examples may be interactive in the browser. Anything that needs a live event loop (`.run()`, key presses, ticks) is plain Python you run locally:
+
+```bash
+uv run python your_snippet.py
+```
+
+<br/>
+
+Larger demos that combine several of these live under `examples/` — `agent_chat.py`, `dashboard.py`, `tabs_nav.py`, and the rest.
+
+[Core Concepts]: ../core-concepts/grids.md
+[grids]: ../core-concepts/grids.md
+[fields]: ../core-concepts/fields.md
+[events & hooks]: ../core-concepts/events.md
+[context]: ../core-concepts/context.md

--- a/docs/tutorials/live-progress.md
+++ b/docs/tutorials/live-progress.md
@@ -1,0 +1,182 @@
+---
+title: "Live Progress"
+icon: "lucide/loader"
+---
+
+# Live Progress
+
+[Progress]{data-preview} paints a ratio (or value out of a total) as a bar. Update it from `@on_tick` for downloads, tasks, or anything that advances over time.
+
+## Ratio Bar
+
+No `total` means `value` is already the ratio.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4"
+    from xnano import render
+    from xnano.components.progress import Progress
+
+    render(Progress(value=0.6, color="emerald-400"))
+    ```
+
+```python title="Ratio Bar" hl_lines="4"
+from xnano import render
+from xnano.components.progress import Progress
+
+render(Progress(value=0.6, color="emerald-400")) # (1)!
+```
+
+1. `0.6` paints as a 60% filled bar labeled `"60%"`.
+
+## Value Over Total
+
+Pass `total` when the raw numbers are more natural than a ratio. The percentage label is still derived unless you set `label` or `label=False`.
+
+```python title="Value Over Total" hl_lines="4"
+from xnano import render
+from xnano.components.progress import Progress
+
+render(Progress(value=340, total=500, color="sky-400"))
+```
+
+## Line Style
+
+`style="line"` is the thinner gauge — same ratio math, different paint.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4"
+    from xnano import render
+    from xnano.components.progress import Progress
+
+    render(Progress(value=0.4, style="line", label="cpu", color="sky-400"))
+    ```
+
+```python title="Line Style" hl_lines="4"
+from xnano import render
+from xnano.components.progress import Progress
+
+render(Progress(value=0.4, style="line", label="cpu", color="sky-400"))
+```
+
+## On a Grid Field
+
+Use `default_factory` — `Progress` is a component instance, not a plain immutable default.
+
+```python title="On a Grid Field" hl_lines="5 6"
+from xnano import BaseGrid, Field
+from xnano.components.progress import Progress
+
+class Download(BaseGrid, direction="vertical", gap=1):
+    bar: Progress = Field(
+        default_factory=lambda: Progress(value=0.0, color="emerald-400"),
+        height=1,
+    )
+```
+
+## Advancing From a Tick
+
+Keep raw counters as `state=True` fields. Rebuild a fresh `Progress` each tick and reassign the field.
+
+```python title="Advancing From a Tick" hl_lines="12 13 14 15 16 17"
+from xnano import on_tick
+from xnano.components.progress import Progress
+
+@on_tick(80) # (1)!
+def advance(self) -> None:
+    if self.paused or self.done >= self.total:
+        return
+    self.done += 1
+    ratio = self.done / self.total
+    self.bar = Progress(value=ratio, color="emerald-400") # (2)!
+    self.status = (
+        "Done." if self.done >= self.total
+        else f"Downloading… {self.done}/{self.total}"
+    )
+```
+
+1. `@on_tick(80)` fires every 80ms. A bare `@on_tick` fires every frame.
+2. Reassign a new `Progress` each update. The field paints whatever instance it currently holds.
+
+## Pause Toggle
+
+```python title="Pause Toggle" hl_lines="3 4 5 6"
+from xnano import on_keyboard
+
+@on_keyboard("space")
+def toggle(self) -> None:
+    self.paused = not self.paused
+    if self.done < self.total:
+        self.status = "Paused." if self.paused else "Downloading…"
+```
+
+## Putting It Together
+
+```python title="Full Example"
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard, on_tick
+from xnano.components.progress import Progress
+
+class Download(BaseGrid, direction="vertical", gap=1):
+    status: str = Field(default="Downloading…", height=1)
+    bar: Progress = Field(
+        default_factory=lambda: Progress(value=0.0, color="emerald-400"),
+        height=1,
+    )
+    gauge: Progress = Field(
+        default_factory=lambda: Progress(
+            value=0.0, style="line", label="bytes", color="sky-400"
+        ),
+        height=1,
+    )
+    done: int = Field(default=0, state=True)
+    total: int = Field(default=100, state=True)
+    paused: bool = Field(default=False, state=True)
+
+    @on_tick(80)
+    def advance(self) -> None:
+        if self.paused or self.done >= self.total:
+            return
+        self.done += 1
+        ratio = self.done / self.total
+        self.bar = Progress(value=ratio, color="emerald-400")
+        self.gauge = Progress(
+            value=self.done,
+            total=self.total,
+            style="line",
+            label="bytes",
+            color="sky-400",
+        )
+        self.status = (
+            "Done." if self.done >= self.total
+            else f"Downloading… {self.done}/{self.total}"
+        )
+
+    @on_keyboard("space")
+    def toggle(self) -> None:
+        self.paused = not self.paused
+        if self.done < self.total:
+            self.status = "Paused." if self.paused else "Downloading…"
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal().run(Download())
+```
+
+<div class="xnano-demo" markdown>
+![live progress dark](../assets/tutorials/live_progress-dark.gif){.demo-dark}
+![live progress light](../assets/tutorials/live_progress-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Full parameters: [Progress]{data-preview}. Tick and keyboard hooks: [events & hooks]{data-preview}.
+
+[Progress]: ../api/xnano/components/progress.md
+[events & hooks]: ../core-concepts/events.md

--- a/docs/tutorials/live-sparklines.md
+++ b/docs/tutorials/live-sparklines.md
@@ -1,0 +1,147 @@
+---
+title: "Live Sparklines"
+icon: "lucide/trending-up"
+---
+
+# Live Sparklines
+
+[Sparkline]{data-preview} paints a sequence of samples as a compact inline chart. Keep a rolling history in state, append on `@on_tick`, trim to a fixed window, and reassign the field.
+
+## A Static Sparkline
+
+Bar heights scale to the tallest sample unless you set `max_value`.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4"
+    from xnano import Terminal
+    from xnano.components.sparkline import Sparkline
+
+    Terminal(height=4).render(
+        Sparkline(data=[1, 4, 2, 8, 5, 9, 3, 7], color="sky-400")
+    )
+    ```
+
+```python title="A Static Sparkline" hl_lines="4"
+from xnano import Terminal
+from xnano.components.sparkline import Sparkline
+
+Terminal(height=4).render(
+    Sparkline(data=[1, 4, 2, 8, 5, 9, 3, 7], color="sky-400")
+) # (1)!
+```
+
+1. Pass `max_value` when auto-scaling would make quiet series look noisy — or when comparing several sparklines side by side.
+
+## On a Grid Field
+
+```python title="On a Grid Field" hl_lines="6 7 8 9"
+from xnano import BaseGrid, Field
+from xnano.components.sparkline import Sparkline
+
+class MetricStrip(BaseGrid, direction="vertical", gap=1):
+    chart: Sparkline = Field(
+        default_factory=lambda: Sparkline(
+            data=[0] * 24, max_value=100, color="emerald-400"
+        ),
+        height=4,
+    )
+```
+
+## History in State
+
+The list never paints on its own — `state=True` holds history; `chart` is the painted field.
+
+```python title="History in State" hl_lines="2"
+samples: list[int] = Field(
+    default_factory=lambda: [0] * 24, state=True
+)
+```
+
+## Append on Tick
+
+Each tick appends a sample, trims the window, and rebuilds the sparkline.
+
+```python title="Append on Tick" hl_lines="3 4 5 6 7 8 9 10 11"
+import random
+from xnano import on_tick
+from xnano.components.sparkline import Sparkline
+
+_HISTORY = 24
+
+@on_tick(120)
+def sample(self) -> None:
+    next_value = max(0, min(100, self.samples[-1] + random.randint(-12, 14)))
+    self.samples.append(next_value)
+    if len(self.samples) > _HISTORY:
+        self.samples = self.samples[-_HISTORY:] # (1)!
+    self.chart = Sparkline(
+        data=list(self.samples),
+        max_value=100,
+        color="emerald-400",
+    )
+    self.readout = f"now {next_value:>3}"
+```
+
+1. Trim after append so the window stays fixed. Reassign a new `Sparkline` each tick rather than mutating the previous instance in place.
+
+## Putting It Together
+
+```python title="Full Example"
+import random
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard, on_tick
+from xnano.components.sparkline import Sparkline
+
+_HISTORY = 24
+
+class MetricStrip(BaseGrid, direction="vertical", gap=1):
+    heading: str = Field(default="cpu · simulated", height=1, color="slate-400")
+    chart: Sparkline = Field(
+        default_factory=lambda: Sparkline(
+            data=[0] * _HISTORY, max_value=100, color="emerald-400"
+        ),
+        height=4,
+    )
+    readout: str = Field(default="—", height=1)
+    samples: list[int] = Field(
+        default_factory=lambda: [0] * _HISTORY, state=True
+    )
+
+    @on_tick(120)
+    def sample(self) -> None:
+        next_value = max(
+            0, min(100, self.samples[-1] + random.randint(-12, 14))
+        )
+        self.samples.append(next_value)
+        if len(self.samples) > _HISTORY:
+            self.samples = self.samples[-_HISTORY:]
+        self.chart = Sparkline(
+            data=list(self.samples),
+            max_value=100,
+            color="emerald-400",
+        )
+        self.readout = (
+            f"now {next_value:>3}  "
+            f"avg {sum(self.samples) // len(self.samples):>3}"
+        )
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal().run(MetricStrip())
+```
+
+<div class="xnano-demo" markdown>
+![live sparklines dark](../assets/tutorials/live_sparklines-dark.gif){.demo-dark}
+![live sparklines light](../assets/tutorials/live_sparklines-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Optional `colors=` takes one color per sample for a gradient across the window — see [Sparkline]{data-preview}. `examples/dashboard.py` and `examples/feed.py` combine sparklines with tables and gauges.
+
+[Sparkline]: ../api/xnano/components/sparkline.md
+[BaseGrid]: ../api/xnano/grid.md

--- a/docs/tutorials/nested-panels.md
+++ b/docs/tutorials/nested-panels.md
@@ -1,0 +1,172 @@
+---
+title: "Nested Panels"
+icon: "lucide/layout"
+---
+
+# Nested Panels
+
+Nest grids by putting child [BaseGrid]{data-preview} instances on parent fields with `default_factory`. Each child keeps its own fields, sizing, and hooks.
+
+## Child Grids
+
+Define regions as their own grid classes first.
+
+```python title="Child Grids"
+from xnano import BaseGrid, Field
+
+class Sidebar(BaseGrid, direction="vertical"):
+    nav: str = Field(
+        default="  — Home\n  — About\n  — Settings",
+        border="rounded",
+        border_color="slate-600",
+        title=" Nav ",
+    )
+    status: str = Field(default="  Ready", height=1, color="slate-500")
+
+class Main(BaseGrid, direction="vertical", gap=1):
+    title: str = Field(default="  Workspace", height=1, color="violet-300")
+    body: str = Field(
+        default="Main content area.",
+        border="rounded",
+        border_color="violet-500",
+        title=" Content ",
+    )
+```
+
+## Parent Layout
+
+A nested grid is still a field value. It occupies a slot on the parent the same way a string would — the content of that slot is a full sub-layout.
+
+```python title="Parent Layout" hl_lines="2 3"
+class App(BaseGrid, direction="horizontal", gap=1):
+    sidebar: Sidebar = Field(default_factory=Sidebar, width="25%") # (1)!
+    main: Main = Field(default_factory=Main, width="1fr")
+```
+
+1. `default_factory=Sidebar` builds a fresh child per parent instance. `width="25%"` sizes the child's slot; the child's own fields lay out inside it.
+
+<br/>
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="14 15"
+    from xnano import BaseGrid, Field, Terminal
+
+    class Sidebar(BaseGrid, direction="vertical"):
+        nav: str = Field(
+            default="  — Home\n  — About\n  — Settings",
+            border="rounded",
+            border_color="slate-600",
+            title=" Nav ",
+        )
+        status: str = Field(default="  Ready", height=1, color="slate-500")
+
+    class Main(BaseGrid, direction="vertical", gap=1):
+        title: str = Field(default="  Workspace", height=1, color="violet-300")
+        body: str = Field(
+            default="Main content area.",
+            border="rounded",
+            border_color="violet-500",
+            title=" Content ",
+        )
+
+    class App(BaseGrid, direction="horizontal", gap=1):
+        sidebar: Sidebar = Field(default_factory=Sidebar, width="25%")
+        main: Main = Field(default_factory=Main, width="1fr")
+
+    Terminal(height=10).render(App())
+    ```
+
+## Parent Hooks
+
+Parent hooks can reach into children by attribute. Child classes can declare their own `@on_*` hooks too.
+
+```python title="Parent Hooks" hl_lines="4 5 9 10"
+from xnano import Context, on_keyboard
+
+@on_keyboard("1")
+def show_home(self) -> None:
+    self.main.body = "Home — overview of the workspace."
+    self.sidebar.status = "  Home"
+
+@on_keyboard("2")
+def show_about(self) -> None:
+    self.main.body = "About — what this panel stack is for."
+    self.sidebar.status = "  About"
+
+@on_keyboard("q")
+def quit(self, ctx: Context) -> None:
+    ctx.terminal.request_exit()
+```
+
+## Putting It Together
+
+```python title="Full Example"
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+
+class Sidebar(BaseGrid, direction="vertical"):
+    nav: str = Field(
+        default="  — Home\n  — About\n  — Settings",
+        border="rounded",
+        border_color="slate-600",
+        title=" Nav ",
+    )
+    status: str = Field(default="  Ready", height=1, color="slate-500")
+
+class Main(BaseGrid, direction="vertical", gap=1):
+    title: str = Field(default="  Workspace", height=1, color="violet-300")
+    body: str = Field(
+        default="Main content area.\nNested grids keep layout regions separate.",
+        border="rounded",
+        border_color="violet-500",
+        title=" Content ",
+    )
+
+class App(BaseGrid, direction="horizontal", gap=1):
+    sidebar: Sidebar = Field(default_factory=Sidebar, width="25%")
+    main: Main = Field(default_factory=Main, width="1fr")
+
+    @on_keyboard("1")
+    def show_home(self) -> None:
+        self.main.body = "Home — overview of the workspace."
+        self.sidebar.status = "  Home"
+
+    @on_keyboard("2")
+    def show_about(self) -> None:
+        self.main.body = "About — what this panel stack is for."
+        self.sidebar.status = "  About"
+
+    @on_keyboard("3")
+    def show_settings(self) -> None:
+        self.main.body = "Settings — theme, density, and keys."
+        self.sidebar.status = "  Settings"
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal().run(App())
+```
+
+<div class="xnano-demo" markdown>
+![nested panels dark](../assets/tutorials/nested_panels-dark.gif){.demo-dark}
+![nested panels light](../assets/tutorials/nested_panels-light.gif){.demo-light}
+</div>
+
+<br/>
+
+??? abstract "Composition Notes"
+
+    - Use nested `BaseGrid` subclasses for stable regions; use plain strings or components when a slot is just content.
+    - Sizing on the parent (`width`, `height`, `fr`, `%`) controls the child's outer slot.
+    - Deeper trees (header + body + footer) are the same idea stacked.
+    - Overlays and confirms: [confirm dialogs]{data-preview}.
+
+[BaseGrid]: ../api/xnano/grid.md
+[Field]: ../api/xnano/fields.md
+[Terminal]: ../api/xnano/tui/terminal.md
+[Context]: ../api/xnano/context.md
+[Text]: ../api/xnano/components/text.md
+[confirm dialogs]: confirm-dialog.md

--- a/docs/tutorials/scrollable-log.md
+++ b/docs/tutorials/scrollable-log.md
@@ -1,0 +1,134 @@
+---
+title: "Scrollable Logs"
+icon: "lucide/scroll"
+---
+
+# Scrollable Logs
+
+Keep a longer buffer in state and paint only a window of lines. Keyboard handlers move a `scroll_offset`; new lines can stick to the bottom when the view is already at the end.
+
+Useful for build output, tool traces, and any feed that outgrows the terminal height.
+
+## Buffer and Window
+
+Store every line in a list. Derive the visible window from `scroll_offset` and a fixed viewport height. Only the joined window becomes a field value.
+
+```python title="Buffer and Window" hl_lines="8 9 11 12 13 14 15 16"
+from xnano import BaseGrid, Field
+
+VIEW_HEIGHT = 8
+
+class LogView(BaseGrid, direction="vertical", gap=1):
+    body: str = Field(default="", border="rounded", title=" log ")
+    hint: str = Field(default="j/k or ↓/↑ to scroll", height=1, color="slate-500")
+
+    buffer: list[str] = Field(default_factory=list, state=True)
+    scroll_offset: int = Field(default=0, state=True) # (1)!
+
+    def _window(self) -> list[str]:
+        start = self.scroll_offset
+        return self.buffer[start : start + VIEW_HEIGHT]
+
+    def _paint(self) -> None:
+        lines = self._window()
+        self.body = "\n".join(lines) if lines else "  (empty)"
+```
+
+1. `scroll_offset` is the index of the first visible line. It never paints; only `body` does.
+
+<br/>
+
+Clamp the offset whenever the buffer shrinks or the window would slide past the end: `max(0, min(scroll_offset, max(0, len(buffer) - VIEW_HEIGHT)))`.
+
+## Keyboard Scroll
+
+Bind up/down (or `j`/`k`) to nudge the offset one line at a time, then repaint. Pass multiple keys to one decorator.
+
+```python title="Keyboard Scroll" hl_lines="3 4 5 6 8 9 10 11"
+from xnano import on_keyboard
+
+@on_keyboard("up", "k") # (1)!
+def scroll_up(self) -> None:
+    self.scroll_offset = max(0, self.scroll_offset - 1)
+    self._paint()
+
+@on_keyboard("down", "j")
+def scroll_down(self) -> None:
+    max_offset = max(0, len(self.buffer) - VIEW_HEIGHT)
+    self.scroll_offset = min(max_offset, self.scroll_offset + 1)
+    self._paint()
+```
+
+1. Extra positional keys are OR'd into the same filter — arrow up and `k` both call `scroll_up`.
+
+## Append and Auto-Follow
+
+When new lines arrive, decide whether the view should stay pinned to the bottom. If the user had scrolled up, leave their place alone.
+
+```python title="Append and Auto-Follow" hl_lines="3 4 5 6 7 8 9 10"
+def append_line(self, line: str) -> None:
+    max_offset_before = max(0, len(self.buffer) - VIEW_HEIGHT)
+    at_bottom = self.scroll_offset >= max_offset_before # (1)!
+
+    self.buffer.append(line)
+
+    if at_bottom:
+        self.scroll_offset = max(0, len(self.buffer) - VIEW_HEIGHT)
+    self._paint()
+```
+
+1. Capture "were we following the tail?" *before* mutating the buffer. After append, only stick to the end if that was already true.
+
+<br/>
+
+A minimal live demo seeds the buffer and scrolls with the keyboard:
+
+```python title="Full Example" hl_lines="14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30"
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+
+VIEW_HEIGHT = 8
+
+class LogView(BaseGrid, direction="vertical", gap=1):
+    body: str = Field(default="", border="rounded", title=" log ")
+    hint: str = Field(default="j/k or ↓/↑ · q quits", height=1, color="slate-500")
+
+    buffer: list[str] = Field(default_factory=list, state=True)
+    scroll_offset: int = Field(default=0, state=True)
+
+    def __post_init__(self) -> None:
+        self.buffer = [f"line {i:03d}" for i in range(40)]
+        self.scroll_offset = max(0, len(self.buffer) - VIEW_HEIGHT)
+        self._paint()
+
+    def _paint(self) -> None:
+        start = self.scroll_offset
+        self.body = "\n".join(self.buffer[start : start + VIEW_HEIGHT])
+
+    @on_keyboard("up", "k")
+    def scroll_up(self) -> None:
+        self.scroll_offset = max(0, self.scroll_offset - 1)
+        self._paint()
+
+    @on_keyboard("down", "j")
+    def scroll_down(self) -> None:
+        max_offset = max(0, len(self.buffer) - VIEW_HEIGHT)
+        self.scroll_offset = min(max_offset, self.scroll_offset + 1)
+        self._paint()
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal().run(LogView())
+```
+
+<div class="xnano-demo" markdown>
+![scrollable log dark](../assets/tutorials/scrollable_log-dark.gif){.demo-dark}
+![scrollable log light](../assets/tutorials/scrollable_log-light.gif){.demo-light}
+</div>
+
+<br/>
+
+For token streams, call `append_line` (or append many lines and paint once) from `@on_tick` or your producer hook. Keep the full history in `buffer`; only the window is assigned to the field.
+
+[BaseGrid]: ../api/xnano/grid.md

--- a/docs/tutorials/selection-list.md
+++ b/docs/tutorials/selection-list.md
@@ -1,0 +1,147 @@
+---
+title: "Selection Lists"
+icon: "lucide/list-checks"
+---
+
+# Selection Lists
+
+A selection list is items plus an index in state, a painted body with a highlight on the active row, and keyboard hooks that move the index or act on the choice. There is no separate list widget.
+
+## Items and Index
+
+Start with the data only — nothing painted yet.
+
+```python title="Items and Index" hl_lines="8 9"
+from xnano import BaseGrid, Field
+from xnano.components.text import Text
+
+ITEMS = ["Home", "Projects", "Settings", "About"]
+
+class Menu(BaseGrid, direction="vertical", gap=1):
+    body: Text = Field(default=Text(""), border="rounded", title=" Menu ")
+    status: str = Field(default="Select an item.", height=1, color="slate-400")
+
+    items: list = Field(default_factory=lambda: list(ITEMS), state=True)
+    selected: int = Field(default=0, state=True) # (1)!
+```
+
+1. `selected` is pure state — never painted on its own.
+
+## Painting Rows
+
+Derive the body from `items` + `selected`. Rebuild whenever either changes.
+
+```python title="Painting Rows" hl_lines="1 2 3 4 5 6 7 8 9 10 11 12"
+def _paint(self) -> None:
+    rows: list[Text] = []
+    for index, item in enumerate(self.items):
+        if index == self.selected:
+            rows.append(
+                Text([Text(f" › {item}", color="violet-300", modifiers=("bold",))])
+            ) # (1)!
+        else:
+            rows.append(Text([Text(f"   {item}", color="slate-400")]))
+    self.body = Text(rows)
+
+def __post_init__(self) -> None:
+    self._paint()
+```
+
+1. The highlight is just different text (and style) on the selected row. Plain strings work if you don't need per-row color.
+
+## Moving the Selection
+
+```python title="Moving the Selection" hl_lines="3 4 5 8 9 10"
+from xnano import on_keyboard
+
+@on_keyboard("up")
+def move_up(self) -> None:
+    self.selected = (self.selected - 1) % len(self.items)
+    self._paint()
+
+@on_keyboard("down")
+def move_down(self) -> None:
+    self.selected = (self.selected + 1) % len(self.items)
+    self._paint()
+```
+
+## Activating a Row
+
+```python title="Activating a Row" hl_lines="3 4 5"
+@on_keyboard("enter")
+def activate(self) -> None:
+    self.status = f"Opened: {self.items[self.selected]}" # (1)!
+```
+
+1. Activation can set a status line, swap a panel, or anything else — the list only needs to expose the chosen value.
+
+## Putting It Together
+
+```python title="Full Example"
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+from xnano.components.text import Text
+
+ITEMS = ["Home", "Projects", "Settings", "About"]
+
+class Menu(BaseGrid, direction="vertical", gap=1):
+    body: Text = Field(default=Text(""), border="rounded", title=" Menu ")
+    status: str = Field(default="Select an item.", height=1, color="slate-400")
+    hint: str = Field(
+        default="↑ / ↓ · move   enter · activate   q · quit",
+        height=1,
+        color="slate-500",
+    )
+
+    items: list = Field(default_factory=lambda: list(ITEMS), state=True)
+    selected: int = Field(default=0, state=True)
+
+    def _paint(self) -> None:
+        rows: list[Text] = []
+        for index, item in enumerate(self.items):
+            if index == self.selected:
+                rows.append(
+                    Text([Text(f" › {item}", color="violet-300", modifiers=("bold",))])
+                )
+            else:
+                rows.append(Text([Text(f"   {item}", color="slate-400")]))
+        self.body = Text(rows)
+
+    def __post_init__(self) -> None:
+        self._paint()
+
+    @on_keyboard("up")
+    def move_up(self) -> None:
+        self.selected = (self.selected - 1) % len(self.items)
+        self._paint()
+
+    @on_keyboard("down")
+    def move_down(self) -> None:
+        self.selected = (self.selected + 1) % len(self.items)
+        self._paint()
+
+    @on_keyboard("enter")
+    def activate(self) -> None:
+        self.status = f"Opened: {self.items[self.selected]}"
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal().run(Menu())
+```
+
+<div class="xnano-demo" markdown>
+![selection list dark](../assets/tutorials/selection_list-dark.gif){.demo-dark}
+![selection list light](../assets/tutorials/selection_list-light.gif){.demo-light}
+</div>
+
+<br/>
+
+To change the list later, assign a new one (`self.items = [*self.items, "New"]`) and call `_paint()` again. For long buffers that need scrolling, see [scrollable logs]{data-preview}.
+
+[BaseGrid]: ../api/xnano/grid.md
+[Field]: ../api/xnano/fields.md
+[Terminal]: ../api/xnano/tui/terminal.md
+[Context]: ../api/xnano/context.md
+[Text]: ../api/xnano/components/text.md
+[scrollable logs]: scrollable-log.md

--- a/docs/tutorials/shared-state.md
+++ b/docs/tutorials/shared-state.md
@@ -1,0 +1,88 @@
+---
+title: "Shared State"
+icon: "lucide/share-2"
+---
+
+# Shared State
+
+Pass an object to `Terminal(state=...)` and every hook can read and write it through [Context]{data-preview}. Multiple grids and handlers share one instance for the life of the session.
+
+A dataclass, a Pydantic model, or xnano's own `State` all work. Parameterize `Context[AppState]` so `ctx.get_state()` returns a typed object instead of `Any` — same idea as [typing Context by state]{data-preview}.
+
+## Attaching State to the Terminal
+
+Define a schema, construct it once, and hand it to `Terminal`.
+
+```python title="Attaching State" hl_lines="14 15 33"
+import dataclasses
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+
+@dataclasses.dataclass
+class AppState:
+    count: int = 0
+    last_key: str = ""
+
+class Counter(BaseGrid, direction="vertical", gap=1):
+    label: str = Field(default="Count: 0", height=1)
+    meta: str = Field(default="last: —", height=1, color="slate-500")
+
+    @on_keyboard("up")
+    def inc(self, ctx: Context[AppState]) -> None: # (1)!
+        state = ctx.get_state() # (2)!
+        state.count += 1
+        state.last_key = "up"
+        self.label = f"Count: {state.count}"
+        self.meta = f"last: {state.last_key}"
+
+    @on_keyboard("down")
+    def dec(self, ctx: Context[AppState]) -> None:
+        state = ctx.get_state()
+        state.count -= 1
+        state.last_key = "down"
+        self.label = f"Count: {state.count}"
+        self.meta = f"last: {state.last_key}"
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal(state=AppState()).run(Counter()) # (3)!
+```
+
+1. `Context[AppState]` is a typing-only generic — runtime is unchanged, but `get_state()` is no longer `Any`.
+2. `ctx.get_state()` raises if no `state=` was attached to the terminal. Use a `state=True` field when the value only needs to live on one grid.
+3. The same `AppState()` instance is shared by every hook for the life of this session.
+
+<div class="xnano-demo" markdown>
+![shared state dark](../assets/tutorials/shared_state-dark.gif){.demo-dark}
+![shared state light](../assets/tutorials/shared_state-light.gif){.demo-light}
+</div>
+
+<br/>
+
+Both handlers mutate the same object — shared counters, selection, auth, and similar belong on the terminal, not copied onto every grid.
+
+## Shared State vs. Field State
+
+Not every value needs to cross the whole app.
+
+| | Lives on | Good for |
+|---|---|---|
+| `Terminal(state=...)` | the host session | data many handlers or grids share |
+| `Field(..., state=True)` | one grid instance | local UI state that never leaves that grid |
+
+Local toggles, scroll offsets, and per-panel counters usually stay as `state=True` fields — see [fields]{data-preview} and [events & hooks]{data-preview}. Use terminal state when a second grid or a later screen needs the same object.
+
+??? note "Plain Dataclass Is Enough"
+
+    Nothing above requires xnano's `State` helper. A dataclass or Pydantic model works the same way. `State` is a convenience when you don't want a fixed schema up front — covered on the [Context]{data-preview} page.
+
+<br/>
+
+To update the window title or clipboard from the same state, see [title & clipboard]{data-preview} — `ctx.device` and `ctx.get_state()` sit on the same `Context`.
+
+[Context]: ../api/xnano/context.md
+[typing Context by state]: ../core-concepts/context.md
+[fields]: ../core-concepts/fields.md
+[events & hooks]: ../core-concepts/events.md
+[title & clipboard]: title-and-clipboard.md

--- a/docs/tutorials/streaming-content.md
+++ b/docs/tutorials/streaming-content.md
@@ -1,0 +1,108 @@
+---
+title: "Streaming Content"
+icon: "lucide/radio"
+---
+
+# Streaming Content
+
+Two ways to stream text with xnano: update a field inside a live grid on each tick, or call `render()` the way you'd call `print` — including append and in-place replace.
+
+## Live Grid
+
+Buffer chunks into a `state=True` list, then append one chunk to a painted field on every `@on_tick`. A live generator can't live on the grid; a concrete list can.
+
+```python title="Live Grid" hl_lines="14 15 22 23 24 25"
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard, on_tick
+
+class Stream(BaseGrid, direction="vertical", gap=1):
+    body: str = Field(default="Press enter to stream…", border="rounded")
+    hint: str = Field(default="enter · stream   q · quit", height=1, color="slate-500")
+
+    chunks: list = Field(default_factory=list, state=True)
+    index: int = Field(default=0, state=True)
+
+    @on_keyboard("enter")
+    def begin(self) -> None:
+        words = "Streaming is ticks writing into a field, one chunk at a time.".split()
+        self.chunks = [w if i == len(words) - 1 else w + " " for i, w in enumerate(words)]
+        self.index = 0
+        self.body = "" # (1)!
+
+    @on_tick(40)
+    def advance(self) -> None:
+        if self.index >= len(self.chunks):
+            return
+        self.body = self.body + self.chunks[self.index] # (2)!
+        self.index += 1
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal().run(Stream())
+```
+
+1. Start empty, with the source already drained into `chunks`.
+2. Each tick appends the next delta and reassigns the field so the frame repaints.
+
+<div class="xnano-demo" markdown>
+![streaming grid dark](../assets/tutorials/streaming_grid-dark.gif){.demo-dark}
+![streaming grid light](../assets/tutorials/streaming_grid-light.gif){.demo-light}
+</div>
+
+<br/>
+
+If each item from your source is already the *full* string so far (not a bare token), assign that snapshot instead of appending:
+
+```python title="Full Snapshots"
+@on_tick(40)
+def advance(self) -> None:
+    if self.index >= len(self.chunks):
+        return
+    self.body = self.chunks[self.index] # (1)!
+    self.index += 1
+```
+
+1. Use this when the producer sends cumulative text. Appending those would double content.
+
+## `render()` Like `print`
+
+Outside a grid session, `render()` is a drop-in for `print` — same `sep` / `end` / `flush`, plus `stream=` for a tracked region that can append or replace in place.
+
+### Append Chunks
+
+```python title="Append Chunks" hl_lines="3 4"
+from xnano import render
+
+render("Hello", stream="chat", end="", flush=True) # (1)!
+render(" world", stream="chat", end="\n", flush=True)
+```
+
+1. `stream="chat"` names a region. Without `update=True`, each call **appends** to that region (token-by-token style).
+
+<br/>
+
+### Replace the Region
+
+```python title="Replace the Region" hl_lines="3 4"
+from xnano import render
+
+render("Loading…", stream="status", update=True, end="\n") # (1)!
+render("Done!", stream="status", update=True, end="\n")
+```
+
+1. `update=True` **replaces** the whole region — rewinds the previous lines and paints the new content. Useful when each event already has the full string so far.
+
+<br/>
+
+`stream=True` is the same as `stream="default"`. Styling kwargs (`color=`, `border=`, …) still apply to each `render()` call the same way they do for a one-shot print.
+
+??? note "Grid vs. `render()`"
+
+    Use the live grid when the stream is one field among hooks, layout, and other UI. Use `render(..., stream=...)` when you want print-like stdout (or a named stream region) without a `Terminal().run(...)` app.
+
+[BaseGrid]: ../api/xnano/grid.md
+[Field]: ../api/xnano/fields.md
+[Terminal]: ../api/xnano/tui/terminal.md
+[Context]: ../api/xnano/context.md
+[render]: ../api/xnano/_renderable.md

--- a/docs/tutorials/table-browser.md
+++ b/docs/tutorials/table-browser.md
@@ -1,0 +1,138 @@
+---
+title: "Table Browser"
+icon: "lucide/table"
+---
+
+# Table Browser
+
+Drive a [Table]{data-preview}'s `selected` row from keyboard state, and mirror the active row on a status line. Rows are plain data; rebuild the table whenever the selection moves.
+
+## A Declarative Table
+
+Subclass [Table]{data-preview} with `Column` descriptors when the schema is fixed.
+
+??? example "Interactive Example"
+
+    The following code block is interactive and can be run directly in the browser.
+
+    ```pyodide install="xnano>=1.0.8" hl_lines="4 5 6 7 8 9 10"
+    from xnano import render
+    from xnano.components.table import Column, Table
+
+    class Services(Table):
+        service: str = Column()
+        status: str = Column(color=lambda v: "green" if v == "ok" else "red")
+        latency: int = Column(align="right", format="{}ms")
+
+    render(Services(data=[
+        {"service": "api", "status": "ok", "latency": 12},
+        {"service": "db", "status": "degraded", "latency": 340},
+        {"service": "cache", "status": "ok", "latency": 4},
+    ], selected=0))
+    ```
+
+```python title="A Declarative Table" hl_lines="4 5 6 7 8 9 10"
+from xnano import render
+from xnano.components.table import Column, Table
+
+class Services(Table):
+    service: str = Column()
+    status: str = Column(color=lambda v: "green" if v == "ok" else "red")
+    latency: int = Column(align="right", format="{}ms")
+
+render(Services(data=[
+    {"service": "api", "status": "ok", "latency": 12},
+    {"service": "db", "status": "degraded", "latency": 340},
+    {"service": "cache", "status": "ok", "latency": 4},
+], selected=0)) # (1)!
+```
+
+1. `selected=0` highlights the first row. The table keeps that row in view as the list grows.
+
+<br/>
+
+For one-off tables, skip the subclass and pass `columns=` as a mapping of name to header text or a full `Column`.
+
+## Keyboard Selection
+
+Store the rows and index as `state=True` fields. On up/down, clamp the index and reassign the table with a fresh `Services(..., selected=index)`.
+
+```python title="Keyboard Selection" hl_lines="18 19 20 22 23 24 25 27 28 29 30"
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+from xnano.components.table import Column, Table
+
+class Services(Table):
+    service: str = Column()
+    status: str = Column(color=lambda v: "green" if v == "ok" else "red")
+    latency: int = Column(align="right", format="{}ms")
+
+ROWS = [
+    {"service": "api", "status": "ok", "latency": 12},
+    {"service": "db", "status": "degraded", "latency": 340},
+    {"service": "cache", "status": "ok", "latency": 4},
+]
+
+class Browser(BaseGrid, direction="vertical", gap=1):
+    table: Services = Field(
+        default_factory=lambda: Services(data=ROWS, selected=0),
+    )
+    status: str = Field(default="", height=1, color="slate-400")
+    hint: str = Field(default="↑ / ↓ · select   q · quit", height=1, color="slate-500")
+
+    rows: list = Field(default_factory=lambda: list(ROWS), state=True)
+    index: int = Field(default=0, state=True)
+
+    def _refresh(self) -> None:
+        self.table = Services(data=self.rows, selected=self.index) # (1)!
+        row = self.rows[self.index]
+        self.status = f"  {row['service']}: {row['status']} · {row['latency']}ms"
+
+    @on_keyboard("up")
+    def previous(self) -> None:
+        self.index = max(0, self.index - 1)
+        self._refresh()
+
+    @on_keyboard("down")
+    def next(self) -> None:
+        self.index = min(len(self.rows) - 1, self.index + 1)
+        self._refresh()
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+    def __post_init__(self) -> None:
+        self._refresh()
+
+Terminal().run(Browser())
+```
+
+1. Reassign `self.table` with a new `selected=` to move the highlight — same as rewriting a status string after a key press.
+
+<div class="xnano-demo" markdown>
+![table browser dark](../assets/tutorials/table_browser-dark.gif){.demo-dark}
+![table browser light](../assets/tutorials/table_browser-light.gif){.demo-light}
+</div>
+
+<br/>
+
+The status line is ordinary field content derived from the selected dict. Put detail formatting there when you want a pane below the list.
+
+??? note "Data-Driven Alternative"
+
+    If columns aren't fixed, use a plain `Table` and pass `columns=` at construction time:
+
+    ```python
+    Table(
+        data=rows,
+        selected=index,
+        columns={
+            "service": "Service",
+            "latency": Column(align="right", format="{}ms"),
+        },
+    )
+    ```
+
+    Selection and rebuild work the same way.
+
+[Table]: ../api/xnano/components/table.md

--- a/docs/tutorials/tabs.md
+++ b/docs/tutorials/tabs.md
@@ -1,0 +1,173 @@
+---
+title: "Tabs"
+icon: "lucide/folder"
+---
+
+# Tabs
+
+Store the active tab as an index. Change it with the keyboard. Rebuild the tab bar and body from that index before layout — usually in `grid_render`.
+
+## Tab Index
+
+```python title="Tab Index" hl_lines="9"
+from xnano import BaseGrid, Field
+from xnano.components.text import Text
+
+TABS = ["Overview", "Config", "Logs"]
+
+class TabApp(BaseGrid, direction="vertical", gap=1):
+    tab_bar: Text = Field(default=Text(""), height=1)
+    screen: str = Field(default="", border="rounded", title=" Screen ")
+
+    selected_tab: int = Field(default=0, state=True) # (1)!
+```
+
+1. One state field owns which tab is live. Everything visible is derived from it.
+
+## Switching Tabs
+
+Hooks only change the index.
+
+```python title="Switching Tabs" hl_lines="3 4 5 8 9 10"
+from xnano import on_keyboard
+
+@on_keyboard("left")
+def prev_tab(self) -> None:
+    self.selected_tab = (self.selected_tab - 1) % len(TABS)
+
+@on_keyboard("right")
+def next_tab(self) -> None:
+    self.selected_tab = (self.selected_tab + 1) % len(TABS)
+
+@on_keyboard("1")
+def tab_one(self) -> None:
+    self.selected_tab = 0
+```
+
+## Rebuilding the Screen
+
+`grid_render` runs every frame before layout. Put derived paint here so handlers stay short.
+
+```python title="Rebuilding the Screen" hl_lines="1 2 3 4 5 6 7 8 9"
+def grid_render(self) -> None:
+    bodies = {
+        0: "Overview — a short summary of the active workspace.",
+        1: "Config — host, port, and theme live here.",
+        2: "Logs — [INFO] ready\n[DEBUG] tab render ok",
+    }
+    self.screen = bodies[self.selected_tab]
+    self.grid_set_field("screen", title=f" {TABS[self.selected_tab]} ") # (1)!
+```
+
+1. Dynamic field props (title, border color) go through `grid_set_field` when you're not replacing the field's content.
+
+## Styling the Tab Bar
+
+```python title="Styling the Tab Bar" hl_lines="2 3 4 5 6 7 8 9 10 11"
+def grid_render(self) -> None:
+    parts: list[Text] = []
+    for index, name in enumerate(TABS):
+        if index == self.selected_tab:
+            parts.append(
+                Text(f" {name} ", color="violet-300", modifiers=("bold", "underline"))
+            )
+        else:
+            parts.append(Text(f" {name} ", color="slate-500"))
+        if index < len(TABS) - 1:
+            parts.append(Text(" │ ", color="slate-600"))
+    self.tab_bar = Text(parts)
+
+    bodies = {
+        0: "Overview — a short summary of the active workspace.",
+        1: "Config — host, port, and theme live here.",
+        2: "Logs — [INFO] ready\n[DEBUG] tab render ok",
+    }
+    self.screen = bodies[self.selected_tab]
+    self.grid_set_field("screen", title=f" {TABS[self.selected_tab]} ")
+```
+
+## Putting It Together
+
+```python title="Full Example"
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+from xnano.components.text import Text
+
+TABS = ["Overview", "Config", "Logs"]
+
+class TabApp(BaseGrid, direction="vertical", gap=1):
+    tab_bar: Text = Field(default=Text(""), height=1)
+    screen: str = Field(default="", border="rounded", title=" Screen ")
+    hint: str = Field(
+        default="← / → · switch   1–3 · jump   q · quit",
+        height=1,
+        color="slate-500",
+    )
+
+    selected_tab: int = Field(default=0, state=True)
+
+    @on_keyboard("left")
+    def prev_tab(self) -> None:
+        self.selected_tab = (self.selected_tab - 1) % len(TABS)
+
+    @on_keyboard("right")
+    def next_tab(self) -> None:
+        self.selected_tab = (self.selected_tab + 1) % len(TABS)
+
+    @on_keyboard("1")
+    def tab_one(self) -> None:
+        self.selected_tab = 0
+
+    @on_keyboard("2")
+    def tab_two(self) -> None:
+        self.selected_tab = 1
+
+    @on_keyboard("3")
+    def tab_three(self) -> None:
+        self.selected_tab = 2
+
+    def grid_render(self) -> None:
+        parts: list[Text] = []
+        for index, name in enumerate(TABS):
+            if index == self.selected_tab:
+                parts.append(
+                    Text(
+                        f" {name} ",
+                        color="violet-300",
+                        modifiers=("bold", "underline"),
+                    )
+                )
+            else:
+                parts.append(Text(f" {name} ", color="slate-500"))
+            if index < len(TABS) - 1:
+                parts.append(Text(" │ ", color="slate-600"))
+        self.tab_bar = Text(parts)
+
+        bodies = {
+            0: "Overview — a short summary of the active workspace.",
+            1: "Config — host, port, and theme live here.",
+            2: "Logs — [INFO] ready\n[DEBUG] tab render ok",
+        }
+        self.screen = bodies[self.selected_tab]
+        self.grid_set_field("screen", title=f" {TABS[self.selected_tab]} ")
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal().run(TabApp())
+```
+
+<div class="xnano-demo" markdown>
+![tabs dark](../assets/tutorials/tabs-dark.gif){.demo-dark}
+![tabs light](../assets/tutorials/tabs-light.gif){.demo-light}
+</div>
+
+<br/>
+
+For heavier per-tab screens, assign nested grids or components to `screen` the same way — the index still picks which one. `examples/tabs_nav.py` builds different screen types per tab with accent colors that follow the selection.
+
+[BaseGrid]: ../api/xnano/grid.md
+[Field]: ../api/xnano/fields.md
+[Terminal]: ../api/xnano/tui/terminal.md
+[Context]: ../api/xnano/context.md
+[Text]: ../api/xnano/components/text.md

--- a/docs/tutorials/text-inputs.md
+++ b/docs/tutorials/text-inputs.md
@@ -1,0 +1,117 @@
+---
+title: "Text Inputs"
+icon: "lucide/text-cursor"
+---
+
+# Text Inputs
+
+An editable field is a [Text]{data-preview} with `input=True` on a [Field]{data-preview}. Focus, tab order, and key routing are automatic.
+
+## One Input
+
+```python title="One Input" hl_lines="6"
+from xnano import BaseGrid, Field, Terminal
+from xnano.components.text import Text
+
+class Form(BaseGrid, direction="vertical"):
+    name: Text = Field(
+        default_factory=lambda: Text("", input=True, placeholder="your name"), # (1)!
+        height=1,
+        border="rounded",
+        title=" Name ",
+    )
+
+Terminal().run(Form())
+```
+
+1. `input=True` turns a leaf `Text` into a text box. `placeholder` shows while the field is empty and unfocused.
+
+<div class="xnano-demo" markdown>
+![text inputs dark](../assets/tutorials/text_inputs-dark.gif){.demo-dark}
+![text inputs light](../assets/tutorials/text_inputs-light.gif){.demo-light}
+</div>
+
+<br/>
+
+## Reading Content
+
+After typing, the string is on `.content` — not the field attribute itself, which is still the `Text` instance.
+
+```python title="Reading Content" hl_lines="6 7"
+from xnano import on_keyboard
+
+@on_keyboard("enter")
+def submit(self) -> None:
+    name = self.name.content if isinstance(self.name.content, str) else ""
+    self.result = f"Hello {name or '—'}"
+```
+
+## Multiple Inputs
+
+Every `Text(input=True)` on a live grid joins one tab order. Tab cycles focus; no extra wiring.
+
+```python title="Multiple Inputs" hl_lines="6 11"
+from xnano import BaseGrid, Field
+from xnano.components.text import Text
+
+class Form(BaseGrid, direction="vertical", gap=1):
+    name: Text = Field(
+        default_factory=lambda: Text("", input=True, placeholder="your name"),
+        height=1,
+        border="rounded",
+        title=" Name ",
+    )
+    email: Text = Field(
+        default_factory=lambda: Text("", input=True, placeholder="you@example.com"),
+        height=1,
+        border="rounded",
+        title=" Email ",
+    )
+    result: str = Field(default="Press enter to submit.", height=1, color="slate-400")
+```
+
+## Submit on Enter
+
+Character keys stay on the focused input. Enter is free for your handler.
+
+```python title="Submit on Enter" hl_lines="3 4 5 6 7"
+from xnano import on_keyboard
+
+@on_keyboard("enter")
+def submit(self) -> None:
+    name = self.name.content if isinstance(self.name.content, str) else ""
+    email = self.email.content if isinstance(self.email.content, str) else ""
+    self.result = f"Hello {name or '—'} · {email or '—'}"
+```
+
+## Focus Styling
+
+Optional: restyle a field when it gains or loses focus.
+
+```python title="Focus Styling" hl_lines="3 4 7 8"
+from xnano import on_focus
+
+@on_focus("name", kind="gained")
+def highlight_name(self) -> None:
+    self.grid_set_field("name", border_color="violet-400") # (1)!
+
+@on_focus("name", kind="lost")
+def clear_name(self) -> None:
+    self.grid_set_field("name", border_color="slate-600")
+```
+
+1. `grid_set_field` updates layout props without replacing the `Text` (so typed content is kept).
+
+<br/>
+
+??? abstract "More on Text Inputs"
+
+    - `placeholder` accepts a plain string (dim by default) or a styled `Text`.
+    - `cursor` is the caret index into `content`; leave it `None` and it tracks the end as the user types.
+    - Full parameter list: the [Text]{data-preview} API reference. Focus kinds: [events & hooks]{data-preview}.
+
+[Text]: ../api/xnano/components/text.md
+[Field]: ../api/xnano/fields.md
+[BaseGrid]: ../api/xnano/grid.md
+[Terminal]: ../api/xnano/tui/terminal.md
+[events & hooks]: ../core-concepts/events.md

--- a/docs/tutorials/title-and-clipboard.md
+++ b/docs/tutorials/title-and-clipboard.md
@@ -1,0 +1,155 @@
+---
+title: "Title & Clipboard"
+icon: "lucide/clipboard"
+---
+
+# Title & Clipboard
+
+Window title and clipboard sit on the host's [device]{data-preview}, not on any grid. From a hook, use `ctx.device` — the same API on terminal and web.
+
+Layout and fields stay on the grid. Title and clipboard do not.
+
+## Setting the Title
+
+```python title="Setting the Title" hl_lines="4"
+from xnano import Context, on_keyboard
+
+@on_keyboard("t")
+def set_title(self, ctx: Context) -> None:
+    ctx.device.title = "my app" # (1)!
+```
+
+1. On a terminal this is the window title; on web it is the tab title. Same assignment either way.
+
+## Title From Shared State
+
+Pair title updates with `Terminal(state=...)` when the title should track app-wide data.
+
+```python title="State First" hl_lines="4 5 6"
+import dataclasses
+
+@dataclasses.dataclass
+class AppState:
+    unread: int = 0
+```
+
+```python title="Sync Title and Label" hl_lines="3 4 5 6 7"
+def _sync(self, ctx: Context[AppState]) -> None:
+    state = ctx.get_state()
+    self.label = f"Inbox: {state.unread} unread"
+    ctx.device.title = (
+        f"({state.unread}) inbox" if state.unread else "inbox"
+    )
+```
+
+```python title="Keys That Bump Unread" hl_lines="3 4 5 6 9 10 11 12"
+from xnano import on_keyboard
+
+@on_keyboard("+")
+def more(self, ctx: Context[AppState]) -> None:
+    ctx.get_state().unread += 1
+    self._sync(ctx)
+
+@on_keyboard("-")
+def less(self, ctx: Context[AppState]) -> None:
+    state = ctx.get_state()
+    state.unread = max(0, state.unread - 1)
+    self._sync(ctx)
+```
+
+## Full Inbox Example
+
+```python title="Full Inbox Example"
+import dataclasses
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+
+@dataclasses.dataclass
+class AppState:
+    unread: int = 0
+
+class Inbox(BaseGrid, direction="vertical", gap=1):
+    label: str = Field(default="Inbox: 0 unread", height=1)
+    hint: str = Field(
+        default="+ / − unread · q quit",
+        height=1,
+        color="slate-500",
+    )
+
+    def _sync(self, ctx: Context[AppState]) -> None:
+        state = ctx.get_state()
+        self.label = f"Inbox: {state.unread} unread"
+        ctx.device.title = (
+            f"({state.unread}) inbox" if state.unread else "inbox"
+        )
+
+    @on_keyboard("+")
+    def more(self, ctx: Context[AppState]) -> None:
+        ctx.get_state().unread += 1
+        self._sync(ctx)
+
+    @on_keyboard("-")
+    def less(self, ctx: Context[AppState]) -> None:
+        state = ctx.get_state()
+        state.unread = max(0, state.unread - 1)
+        self._sync(ctx)
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal(state=AppState()).run(Inbox())
+```
+
+## Copy to Clipboard
+
+`copy_to_clipboard` is on the same device object.
+
+```python title="Copy to Clipboard" hl_lines="4 5"
+from xnano import Context, on_keyboard
+
+@on_keyboard("ctrl+c")
+def copy(self, ctx: Context) -> None:
+    ctx.device.copy_to_clipboard(self.text) # (1)!
+    self.status = "copied."
+```
+
+1. Clipboard write uses the host implementation — terminal or browser — behind one method.
+
+## Full Clipboard Example
+
+```python title="Full Clipboard Example"
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+
+class Snippet(BaseGrid, direction="vertical", gap=1):
+    text: str = Field(
+        default="hello from xnano",
+        height=1,
+        border="rounded",
+        title=" snippet ",
+    )
+    status: str = Field(
+        default="ctrl+c to copy · q quit",
+        height=1,
+        color="slate-500",
+    )
+
+    @on_keyboard("ctrl+c")
+    def copy(self, ctx: Context) -> None:
+        ctx.device.copy_to_clipboard(self.text)
+        self.status = "copied."
+        ctx.device.title = "snippet · copied"
+
+    @on_keyboard("q")
+    def quit(self, ctx: Context) -> None:
+        ctx.terminal.request_exit()
+
+Terminal().run(Snippet())
+```
+
+<br/>
+
+To hide the caret when you draw your own selection highlight: `ctx.cursor.visible = False`. Terminal-only knobs (raw mode, alternate screen, mouse capture) exist only on the terminal device and are no-ops on web — details on [Device & Cursor]{data-preview}.
+
+[device]: ../core-concepts/device.md
+[Device & Cursor]: ../core-concepts/device.md
+[Context]: ../api/xnano/context.md

--- a/docs/xnano-core/overview.md
+++ b/docs/xnano-core/overview.md
@@ -1,9 +1,0 @@
----
-title: "Overview"
----
-
-# xnano-core
-
-!!! example "Coming Soon"
-
-    Documentation for <code>xnano-core</code> is coming soon.

--- a/zensical.toml
+++ b/zensical.toml
@@ -13,11 +13,56 @@ Copyright &copy; 2026 Hammad Saeed
 
 nav = [
     {"Introduction" = "index.md"},
-    { "xnano" = [
-        "xnano/getting-started.md",
+    "core-concepts/getting-started.md",
+    {"Concepts" = [
+        "core-concepts/terminal.md",
+        "core-concepts/grids.md",
+        "core-concepts/fields.md",
+        "core-concepts/events.md",
+        "core-concepts/actions.md",
+        "core-concepts/context.md",
+        "core-concepts/device.md",
+        "core-concepts/styling.md",
     ]},
-    { "xnano-core" = [
-        "xnano-core/overview.md",
+    {"Beta" = [
+        "core-concepts/web.md",
+        "core-concepts/cli.md",
+    ]},
+    {"Components" = [
+        "components/index.md",
+        "components/text.md",
+        "components/table.md",
+        "components/progress.md",
+        "components/chart.md",
+        "components/sparkline.md",
+        "components/schema.md",
+    ]},
+    {"Tutorials" = [
+        "tutorials/index.md",
+        "tutorials/streaming-content.md",
+        "tutorials/text-inputs.md",
+        "tutorials/selection-list.md",
+        "tutorials/tabs.md",
+        "tutorials/nested-panels.md",
+        "tutorials/confirm-dialog.md",
+        "tutorials/live-progress.md",
+        "tutorials/composed-text.md",
+        "tutorials/shared-state.md",
+        "tutorials/action-bindings.md",
+        "tutorials/title-and-clipboard.md",
+        "tutorials/live-sparklines.md",
+        "tutorials/table-browser.md",
+        "tutorials/custom-component.md",
+        "tutorials/dual-host.md",
+        "tutorials/cli-commands.md",
+        "tutorials/scrollable-log.md",
+        "tutorials/grid-render.md",
+    ]},
+    {"Core Architecture" = [
+        "architecture/xnano-core.md",
+        "architecture/lifecycle.md",
+        "architecture/hosts-and-controllers.md",
+        "architecture/render-nodes.md",
     ]},
     { "API Reference" = [
         { "xnano" = [
@@ -100,6 +145,7 @@ extra_css = [
     "stylesheets/code-theme.css",
     "stylesheets/mkdocstrings.css",
     "stylesheets/components.css",
+    "stylesheets/watercolor.css",
     "stylesheets/nav.css",
 ]
 
@@ -137,7 +183,7 @@ features = [
     # "navigation.prune",
     # "navigation.tabs",
     "navigation.top",
-    # "navigation.sections",
+    "navigation.sections",
     "navigation.tracking",
     "search.highlight",
     "toc.follow",


### PR DESCRIPTION
## Summary

- rewrite the concepts, component, tutorial, and architecture documentation
- refresh the documentation theme, navigation accents, and responsive media presentation
- reorganize the Zensical navigation around the expanded documentation structure

## Validation

- `uv run prek run --all-files`
- `uv run zensical build`