### PR TITLE
fix(tui): render grid roots through layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.0.9"
+pip install "xnano>=1.0.10"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.0.9"
+uv add "xnano>=1.0.10"
 ```
 
 > [!TIP]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.0.9"
+version = "1.0.10"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/tests/test_terminal_render.py
+++ b/tests/test_terminal_render.py
@@ -184,6 +184,27 @@ def test_render_applies_border() -> None:
     assert "boxed" in output
 
 
+def test_render_paints_basegrid_as_layout_root() -> None:
+    # Terminal.render(BaseGrid) must drive the full layout engine. The inline
+    # renderable path only paints field chrome tops (a lone border row).
+    class Card(BaseGrid, direction="vertical"):
+        heading: str = Field(
+            default="Reminder",
+            border="rounded",
+            height=1,
+        )
+        body: str = Field(default="Water the plants.", height=1)
+
+    terminal = Terminal.offscreen(cols=40, rows=10)
+    terminal.render(Card())
+    output = terminal.get_output()
+    lines = [line.rstrip() for line in output.splitlines()]
+    assert any("Reminder" in line for line in lines)
+    assert any("Water the plants." in line for line in lines)
+    assert "╭" in output
+    assert "╰" in output
+
+
 def test_render_offscreen_stays_full_viewport_session() -> None:
     # Rendering into an already-live offscreen session must not attempt to
     # switch it into an inline viewport.

--- a/uv.lock
+++ b/uv.lock
@@ -2586,7 +2586,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.0.9"
+version = "1.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-core" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -6,7 +6,7 @@
 >>> from xnano import BaseGrid, Field, Terminal
 """
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 
 from typing import TYPE_CHECKING
 

--- a/xnano/tui/terminal.py
+++ b/xnano/tui/terminal.py
@@ -696,15 +696,18 @@ class Terminal(AbstractHost, Generic[StateT]):
         self,
         renderables: Sequence[Any],
         field: Any,
+        *,
+        is_grid: bool = False,
     ) -> None:
         """Resolve viewport sizing for a one-shot render and prepare the session.
 
         Each ``render`` call is content-sized. When an inline session is
         already open but the new content needs a different inline viewport
         height, the existing session is torn down and recreated on the next
-        paint.
+        paint. Pass ``is_grid=True`` when the single root is a ``BaseGrid`` so
+        height/width defaults match the interactive ``run`` path.
         """
-        resolved = self._resolve_run(renderables, is_grid=False, field=field)
+        resolved = self._resolve_run(renderables, is_grid=is_grid, field=field)
         if self._session is None:
             self._apply_resolved_run(resolved)
             return
@@ -814,20 +817,30 @@ class Terminal(AbstractHost, Generic[StateT]):
             )
             return
 
-        field = self._build_render_field(
-            color=color,
-            background=background,
-            modifiers=modifiers,
-            align=align,
-            border=border,
-            border_sides=border_sides,
-            border_color=border_color,
-            title=title,
-            title_position=title_position,
-            padding=padding,
-            gap=gap,
-        )
+        from xnano.grid import BaseGrid
+
         items = tuple(renderables)
+        # Mirror ``run``: a lone BaseGrid is the layout root, not an inline
+        # renderable. Painting it through the inline path only draws field
+        # chrome tops (a single border row) and drops the rest of the grid.
+        is_grid = len(items) == 1 and isinstance(items[0], BaseGrid)
+        field = (
+            None
+            if is_grid
+            else self._build_render_field(
+                color=color,
+                background=background,
+                modifiers=modifiers,
+                align=align,
+                border=border,
+                border_sides=border_sides,
+                border_color=border_color,
+                title=title,
+                title_position=title_position,
+                padding=padding,
+                gap=gap,
+            )
+        )
 
         # Wasm / headless builds: paint through a buffer-backed session and
         # write the resulting cell text to stdout (no interactive terminal).
@@ -844,9 +857,12 @@ class Terminal(AbstractHost, Generic[StateT]):
         auto_entered = not self._is_live
         if auto_entered:
             self.__enter__()
-        self._prepare_render_session(items, field)
+        self._prepare_render_session(items, field, is_grid=is_grid)
         try:
-            self._render_frame(renderables=items, field=field)
+            if is_grid:
+                self._render_frame(items[0])
+            else:
+                self._render_frame(renderables=items, field=field)
             if flush:
                 self._flush_session_output()
         finally:


### PR DESCRIPTION
## Summary

- route a lone `BaseGrid` passed to `Terminal.render()` through the full grid layout path
- add regression coverage for grid content and borders in one-shot rendering
- bump xnano and its user-facing install references to `1.0.10`

## Validation

- `uv run pytest` (`1361 passed, 6 skipped`)
- `uv run prek run --all-files`