### PR TITLE
fix: initialize user Grid classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.0.11"
+pip install "xnano>=1.0.13"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.0.11"
+uv add "xnano>=1.0.13"
 ```
 
 > [!TIP]

--- a/docs/xnano/getting-started.md
+++ b/docs/xnano/getting-started.md
@@ -23,13 +23,13 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "pip"
 
     ```bash
-    pip install "xnano>=1.0.11"
+    pip install "xnano>=1.0.13"
     ```
 
 === "uv"
 
     ```bash
-    uv pip install "xnano>=1.0.11"
+    uv pip install "xnano>=1.0.13"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -38,7 +38,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "poetry"
 
     ```bash
-    poetry install "xnano>=1.0.11"
+    poetry install "xnano>=1.0.13"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -47,7 +47,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "conda"
 
     ```bash
-    conda install "xnano>=1.0.11"
+    conda install "xnano>=1.0.13"
     ```
 
 ## What is xnano?
@@ -71,7 +71,7 @@ The main featureset of the library revolves around it's rust-based terminal rend
 
     The following example is interactive and can be run directly in the browser by hitting the <kbd>Run</kbd> button.
 
-```pyodide install="xnano>=1.0.11"
+```pyodide install="xnano>=1.0.13"
 import xnano
 
 xnano.render("hello, terminal!", color="blue")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.0.11"
+version = "1.0.13"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/tests/test_grid_init.py
+++ b/tests/test_grid_init.py
@@ -29,6 +29,23 @@ def test_default_factory_creates_instances() -> None:
     assert root.left.label == "hello"
 
 
+def test_user_class_named_grid_initializes_layout_fields() -> None:
+    """A user class named Grid must initialize values like any other grid."""
+
+    class Grid(BaseGrid):
+        color: str = Field(default="red")
+
+        def grid_render(self) -> None:
+            self.grid_set_field("color", "blue", color="blue")
+
+    grid = Grid()
+
+    assert grid.color == "red"
+    grid.grid_render()
+    assert grid.color == "blue"
+    assert grid._grid_field_info("color").color == "blue"
+
+
 class OptionalPanel(BaseGrid, direction="vertical"):
     body: Text = Field(default=Text("visible"))
     overlay: Text | None = Field(

--- a/tests/test_grid_set_field.py
+++ b/tests/test_grid_set_field.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from xnano.components.text import Text
@@ -56,8 +58,9 @@ def test_set_field_rejects_unknown_field() -> None:
 
 def test_set_field_rejects_immutable_keys() -> None:
     grid = LayoutGrid()
+    set_field: Any = grid.grid_set_field
     with pytest.raises(TypeError, match="default"):
-        grid.grid_set_field("body", default="nope")
+        set_field("body", default="nope")
 
 
 def test_set_field_validates_when_strict() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2680,7 +2680,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.0.11"
+version = "1.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-core" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -6,7 +6,7 @@
 >>> from xnano import BaseGrid, Field, Terminal
 """
 
-__version__ = "1.0.11"
+__version__ = "1.0.13"
 
 from typing import TYPE_CHECKING
 

--- a/xnano/fields.py
+++ b/xnano/fields.py
@@ -39,13 +39,14 @@ if TYPE_CHECKING:
     from xnano._styles import TailwindClass
 
 
-UNSET = object()
+UNSET: Any = object()
 
 
 ClassNameLike: TypeAlias = Union[
     "TailwindClass",
     str,
     "list[TailwindClass | str]",
+    "tuple[TailwindClass | str, ...]",
 ]
 """Tailwind classes as a single class, a space-separated string, or a
 list of class tokens. See ``xnano._styles.TailwindClass`` for the

--- a/xnano/grid.py
+++ b/xnano/grid.py
@@ -126,16 +126,21 @@ if TYPE_CHECKING:
         KnownEffectKind,
     )
 from xnano._types import (
+    Alignment,
     Area,
+    Axis,
     Border,
+    CharacterModifier,
     Direction,
     Padding,
     PaddingLike,
     Side,
+    SizingLike,
 )
 from xnano.core.interface import AbstractInterface
 from xnano.fields import (
     UNSET,
+    ClassNameLike,
     Field,
     GridFieldInfo,
     _normalize_slide_axes,
@@ -864,7 +869,7 @@ class _GridMeta(type):
         setattr(cls, "_grid_static_constraints", static_constraints)
 
         all_fields = {**fields, **state_fields}
-        if name not in ("BaseGrid", "Grid") and all_fields:
+        if all_fields:
             type.__setattr__(
                 cls, "__init__", _build_grid_init(all_fields, defaults)
             )
@@ -1230,13 +1235,71 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         value: Any = UNSET,
         *,
         position: tuple[int, int] | None = None,
-        **field_config: Any,
+        strict: bool = UNSET,
+        slide: Sequence[Axis] | None = UNSET,
+        visible: bool | None = UNSET,
+        color: ColorLike | None = UNSET,
+        background: ColorLike | None = UNSET,
+        width: SizingLike | None = UNSET,
+        height: SizingLike | None = UNSET,
+        gap: int | None = UNSET,
+        direction: Direction | None = UNSET,
+        align: Alignment | None = UNSET,
+        border: Border | None = UNSET,
+        border_sides: Sequence[Side] | None = UNSET,
+        border_color: ColorLike | None = UNSET,
+        title: str | None = UNSET,
+        title_position: FrameTitlePosition | None = UNSET,
+        padding: PaddingLike | None = UNSET,
+        margin: PaddingLike | None = UNSET,
+        modifiers: Sequence[CharacterModifier] | None = UNSET,
+        class_name: ClassNameLike | None = UNSET,
+        bold: bool = UNSET,
+        dim: bool = UNSET,
+        italic: bool = UNSET,
+        underline: bool = UNSET,
+        slow_blink: bool = UNSET,
+        rapid_blink: bool = UNSET,
+        reversed: bool = UNSET,
     ) -> None:
         """Set a layout field's runtime value and/or per-instance field metadata.
 
         Cannot be used on state fields. ``default``, ``default_factory``,
         ``init``, and ``state`` cannot be changed at runtime.
         """
+        field_config: dict[str, Any] = {
+            key: option
+            for key, option in {
+                "strict": strict,
+                "slide": slide,
+                "visible": visible,
+                "color": color,
+                "background": background,
+                "width": width,
+                "height": height,
+                "gap": gap,
+                "direction": direction,
+                "align": align,
+                "border": border,
+                "border_sides": border_sides,
+                "border_color": border_color,
+                "title": title,
+                "title_position": title_position,
+                "padding": padding,
+                "margin": margin,
+                "modifiers": modifiers,
+                "class_name": class_name,
+                "bold": bold,
+                "dim": dim,
+                "italic": italic,
+                "underline": underline,
+                "slow_blink": slow_blink,
+                "rapid_blink": rapid_blink,
+                "reversed": reversed,
+            }.items()
+            if option is not UNSET
+        }
+
         if name in self._grid_state_fields:
             raise TypeError(
                 f"grid_set_field() cannot be used on state field {name!r} on "


### PR DESCRIPTION
## Summary

- initialize fields normally for user-defined classes named `Grid`
- expose all supported `grid_set_field` options as typed keyword parameters
- add tuple support to the `class_name` type and regression coverage
- bump the package and installation docs from 1.0.11 to 1.0.13

## Validation

- `uv run pytest` (1362 passed, 6 skipped)
- `uv run prek run --all-files`