### PR TITLE
refactor: rename @on to @on_action, bump version to 1.0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.0.13"
+pip install "xnano>=1.0.14"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.0.13"
+uv add "xnano>=1.0.14"
 ```
 
 > [!TIP]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.0.13"
+version = "1.0.14"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import cast
 
+import pytest
+
 from xnano._dispatch import dispatch_field_mouse
 from xnano._types import Area
 from xnano.context import Context
@@ -22,7 +24,7 @@ from xnano.events import (
     KeyboardEventData,
     MouseEventData,
     ResizeEventData,
-    on,
+    on_action,
     on_click,
     on_clipboard,
     on_focus,
@@ -258,13 +260,13 @@ def test_perform_runs_keyboard_hook() -> None:
     assert app.n == 1
 
 
-def test_on_decorator_with_shared_keyboard_action() -> None:
+def test_on_action_with_shared_keyboard_action() -> None:
     SAVE = Action.keyboard("ctrl+s")
 
     class App(BaseGrid):
         saved: bool = Field(default=False, state=True)
 
-        @on(SAVE)
+        @on_action(SAVE)
         def save(self, ctx) -> None:
             self.saved = True
 
@@ -276,6 +278,22 @@ def test_on_decorator_with_shared_keyboard_action() -> None:
     # Mismatched binding does not fire.
     terminal.perform(Action.keyboard("ctrl+a"))
     assert app.saved is True
+
+
+def test_deprecated_on_decorator_forwards_to_on_action() -> None:
+    from xnano.events import on  # ty: ignore[deprecated]
+
+    save = Action.keyboard("ctrl+s")
+    with pytest.warns(DeprecationWarning, match="on_action"):
+        decorator = on(save)  # ty: ignore[deprecated]
+
+    assert callable(decorator)
+
+
+def test_on_action_is_exported_from_package_root() -> None:
+    from xnano import on_action as root_on_action
+
+    assert root_on_action is on_action
 
 
 def test_perform_unscoped_mouse_hook() -> None:
@@ -302,7 +320,7 @@ def test_on_decorator_with_shared_mouse_action() -> None:
     class App(BaseGrid):
         n: int = Field(default=0, state=True)
 
-        @on(RIGHT)
+        @on_action(RIGHT)
         def right_click(self, ctx) -> None:
             self.n += 1
 
@@ -506,7 +524,7 @@ def test_field_click_via_action_to_event_and_dispatch() -> None:
         body: str = Field(default="idle")
         n: int = Field(default=0, state=True)
 
-        @on(CLICK_BODY)
+        @on_action(CLICK_BODY)
         def on_body(self, ctx) -> None:
             self.n += 1
             self.body = "clicked"

--- a/tests/webui/test_web_actions.py
+++ b/tests/webui/test_web_actions.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from tests.webui.grids import ClickableGrid, InteractiveGrid, RequestHookGrid
 from xnano.core.actions import Action
-from xnano.events import Event, KeyboardEventData, on, on_keyboard
+from xnano.events import Event, KeyboardEventData, on_action, on_keyboard
 from xnano.fields import Field
 from xnano.grid import BaseGrid
 from xnano.webui import Web
@@ -53,7 +53,7 @@ def test_web_shared_action_on_decorator() -> None:
         n: int = Field(default=0, state=True)
         label: str = Field(default="0", height=1)
 
-        @on(BUMP)
+        @on_action(BUMP)
         def bump(self, ctx) -> None:
             self.n += 1
             self.label = str(self.n)

--- a/uv.lock
+++ b/uv.lock
@@ -2680,7 +2680,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-core" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -6,7 +6,7 @@
 >>> from xnano import BaseGrid, Field, Terminal
 """
 
-__version__ = "1.0.13"
+__version__ = "1.0.14"
 
 from typing import TYPE_CHECKING
 
@@ -16,7 +16,8 @@ if TYPE_CHECKING:
     from xnano.context import Context
     from xnano.core.actions import Action
     from xnano.events import (
-        on,
+        on,  # ty: ignore[deprecated]
+        on_action,
         on_click,
         on_clipboard,
         on_event,
@@ -48,6 +49,7 @@ __all__ = [
     "GridSettings",
     "Style",
     "on",
+    "on_action",
     "on_click",
     "on_clipboard",
     "on_event",
@@ -118,9 +120,29 @@ def __getattr__(name: str):
         return Style
 
     elif name == "on":
-        from xnano.events import on
+        import os as _os
 
-        return on
+        from xnano.events import on  # ty: ignore[deprecated]
+
+        _ignore = _os.environ.get("XNANO_IGNORE_DEPRECATION_WARNINGS")
+        if _ignore is None or not _ignore.lower() in ["1", "true", "yes", "y"]:
+            import warnings
+
+            warnings.warn(
+                "on is deprecated and will be removed in a future version. "
+                "Use on_action instead.\n"
+                "You can set the `XNANO_IGNORE_DEPRECATION_WARNINGS` "
+                "environment variable to ignore this warning.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return on  # ty: ignore[deprecated]
+
+    elif name == "on_action":
+        from xnano.events import on_action
+
+        return on_action
 
     elif name == "on_click":
         from xnano.events import on_click

--- a/xnano/events.py
+++ b/xnano/events.py
@@ -22,6 +22,7 @@ from typing import (
     overload,
 )
 
+from typing_extensions import deprecated
 from xnano_core.core import (
     CoreEvent,
     CoreKeyBinding,
@@ -1243,7 +1244,7 @@ def on_poll(
     return decorator
 
 
-def on(
+def on_action(
     action: Any,
     /,
 ) -> Callable[[EventHookFunction], EventHookFunction]:
@@ -1251,11 +1252,11 @@ def on(
 
     User-facing sugar for storing an Action on a handler. The concrete
     ``@on_keyboard`` / ``@on_click`` decorators remain preferred for
-    simple cases; ``@on`` is for shared Action constants:
+    simple cases; ``@on_action`` is for shared Action constants:
 
         SAVE = Action.keyboard("ctrl+s")
 
-        @on(SAVE)
+        @on_action(SAVE)
         def save(self, ctx): ...
 
     Args:
@@ -1308,17 +1309,38 @@ def on(
             return _decorate_on_tick_hook(fn, action.interval_ms)
         else:
             raise TypeError(
-                f"@on expects an Action instance, got {type(action)!r}"
+                f"@on_action expects an Action instance, got {type(action)!r}"
             )
         return _decorate_hook_function(fn)
 
     return decorator
 
 
+@deprecated(
+    "'on' is deprecated and will be removed in the future; use "
+    "'on_action' instead.\n\n`from xnano.events import on_action`",
+    category=DeprecationWarning,
+)
+def on(
+    action: Any,
+    /,
+) -> Callable[[EventHookFunction], EventHookFunction]:
+    """Bind an action using the deprecated ``@on`` spelling.
+
+    Args:
+        action: An ``Action`` instance.
+
+    Returns:
+        A decorator that binds the action to a hook function.
+    """
+    return on_action(action)
+
+
 __all__ = (
     "PollWhen",
     "FocusHookKind",
     "on",
+    "on_action",
     "on_event",
     "on_resize",
     "on_focus",


### PR DESCRIPTION
## Summary
- Renames the `@on` sugar decorator to `@on_action` for binding a reusable `Action` to a hook. `@on` remains available as a deprecated shim that forwards to `@on_action` and emits a `DeprecationWarning` (silenceable via the `XNANO_IGNORE_DEPRECATION_WARNINGS` environment variable).
- Exports `on_action` from the package root alongside the deprecated `on`.
- Bumps version 1.0.13 → 1.0.14 (README.md, pyproject.toml, uv.lock, xnano/__init__.py).

## Test plan
- [x] `tests/test_actions.py` updated: existing `@on` usages migrated to `@on_action`, plus new tests for the deprecation warning and for `on_action` being exported from the package root.
- [x] `tests/webui/test_web_actions.py` updated to use `@on_action`.
- [ ] `uv run pytest`