### PR TITLE
chore: remove .claude from tracked directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .ruff_cache/
 dist-wasm/
 .DS_Store
+.claude/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
## Summary

- ignore the local `.claude/` directory