### PR TITLE
fix: include text editor in pyodide wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,9 @@ jobs:
         working-directory: xnano-core
         env:
           RUSTUP_TOOLCHAIN: ${{ env.RUST_TOOLCHAIN }}
-        run: pyodide build -o dist -C build-args=--no-default-features
+        run: >-
+          pyodide build -o dist
+          -C build-args="--no-default-features --features editor"
 
       - run: pip install -U twine
 


### PR DESCRIPTION
## Summary

- enable the wasm-safe `editor` feature while keeping terminal support disabled
- restore the `CoreTextEditor` export expected by `xnano_core.core`

Follow-up to #63; the xnano-core release workflow runs through that release work.

## Validation

- `cargo check --manifest-path xnano-core/Cargo.toml --no-default-features --features editor`
- `uv run pytest` (1,373 passed, 6 skipped)
- `uv run prek run --all-files`