### PR TITLE
fix: exit terminal process on hangup

### DIFF
--- a/tests/test_terminal_render.py
+++ b/tests/test_terminal_render.py
@@ -7,6 +7,8 @@ sessions so no TTY is required.
 
 from __future__ import annotations
 
+import signal
+
 import pytest
 
 from xnano import _dispatch as dispatch
@@ -15,6 +17,17 @@ from xnano.components.text import Text
 from xnano.fields import Field
 from xnano.grid import BaseGrid
 from xnano.terminal import Terminal
+
+
+def test_terminal_hangup_terminates_process() -> None:
+    terminal: Terminal = Terminal()
+
+    with pytest.raises(SystemExit) as exit_info:
+        terminal._on_exit_signal(signal.SIGHUP, None)
+
+    assert exit_info.value.code == 128 + signal.SIGHUP
+    assert terminal._exit_requested is True
+
 
 # ---------------------------------------------------------------------------
 # measure_renderable / measure_renderables_height

--- a/xnano/terminal/terminal.py
+++ b/xnano/terminal/terminal.py
@@ -248,13 +248,11 @@ class Terminal(AbstractHost, Generic[StateT]):
 
     def _on_exit_signal(
         self,
-        signum: int,  # noqa: ARG002
+        signum: int,
         frame: Any,  # noqa: ARG002
     ) -> None:
-        # Soft-exit only: never raise from the handler. Raising KeyboardInterrupt
-        # mid-restore can leave private modes / SGR half-cleared for the next
-        # process sharing this terminal.
         self._exit_requested = True
+        raise SystemExit(128 + signum)
 
     def __enter__(self) -> "Terminal[StateT]":
         if self._is_live:


### PR DESCRIPTION
## Summary

- terminate with the conventional signal exit status when a live terminal receives SIGHUP, SIGTERM, or SIGINT
- preserve normal context-manager cleanup while unwinding
- add a regression test for terminal-window hangup behavior

## Validation

- `uv run pytest` (1374 passed, 6 skipped)
- `uv run prek run --all-files`