### PR TITLE
feat: ergonomics pass — container fields, scroll, group focus, web cursor/device parity

### DIFF
--- a/docs/sandbox/rendering.md
+++ b/docs/sandbox/rendering.md
@@ -147,7 +147,6 @@ terminal = Terminal(
     mouse_events=False,
     bracketed_paste=False,
     synchronized_updates=False,
-    debug_wireframe=False,
 )
 terminal.render(
     Text("first", color="cyan"),
@@ -161,9 +160,11 @@ terminal.render(
 ```
 
 The three live-device flags and `tick_interval` configure a live OS session;
-they do not create browser input polling. `state`, `title`, `width`, `height`,
-and `debug_wireframe` are also accepted by [Terminal.offscreen]{data-preview} where
-applicable.
+they do not create browser input polling. `state`, `title`, `width`, and
+`height` are also accepted by [Terminal.offscreen]{data-preview} where
+applicable. To paint layout diagnostics, use `Field(wireframe=True)` on the
+specific field you want inspected — a thin per-cell grid overlay, not a
+whole-terminal switch; see [Field]{data-preview}.
 
 ??? example "Terminal Viewport and Gap"
 
@@ -173,7 +174,6 @@ applicable.
     - **`mouse_events` options.** Use `True` to request mouse capture in a live terminal or `False` to disable it. See the [Terminal class]{data-preview}.
     - **`bracketed_paste` options.** Use `True` to request bracketed-paste mode in a live terminal or `False` to disable it. See the [Terminal class]{data-preview}.
     - **`synchronized_updates` options.** Use `True` to request synchronized terminal updates or `False` to disable them. See the [Terminal class]{data-preview}.
-    - **`debug_wireframe` options.** Use `True` to paint layout diagnostics or `False` for normal rendering. See the [Terminal class]{data-preview}.
     - **`gap` options.** Pass an integer cell count between native renderables. See [Terminal.render]{data-preview}.
 
 ## Explicit Offscreen Buffer
@@ -190,7 +190,6 @@ terminal = Terminal.offscreen(
     rows=7,
     state={"source": "sandbox"},
     title="offscreen",
-    debug_wireframe=False,
 )
 try:
     terminal.render(
@@ -212,7 +211,6 @@ finally:
     - **`rows` options.** Pass the offscreen buffer height as an exact integer cell count. See [Terminal.offscreen]{data-preview}.
     - **`state` options.** Pass any application-state object or omit it. See [Terminal.offscreen]{data-preview}.
     - **`title` options.** Pass terminal title metadata as a string or omit it. See [Terminal.offscreen]{data-preview}.
-    - **Offscreen `debug_wireframe` options.** Use `True` to paint layout diagnostics or `False` for normal rendering. See [Terminal.offscreen]{data-preview}.
 
 ## Action-Driven Frames Without `run()`
 

--- a/examples/agent_chat.py
+++ b/examples/agent_chat.py
@@ -11,13 +11,13 @@ import textwrap
 import time
 from typing import Iterable, Iterator, Literal, TypeAlias
 
-from xnano._types import CharacterModifier
-from xnano.color import tailwind_color
+from xnano.color import Color, ColorLike, tailwind_color
 from xnano.components.text import Text
 from xnano.events import on_keyboard, on_mouse, on_tick
 from xnano.fields import Field
 from xnano.grid import BaseGrid
 from xnano.terminal import Terminal
+from xnano.types import CharacterModifier
 
 ToolKind: TypeAlias = Literal["read", "bash", "edit", "grep"]
 """Supported tool-call kinds shown in the transcript."""
@@ -69,11 +69,7 @@ _WELCOME = [
 ]
 
 
-def _color_hex(color) -> str:
-    return f"#{color.r:02x}{color.g:02x}{color.b:02x}"
-
-
-def _pulsing_color(tick: float, offset: int) -> str:
+def _pulsing_color(tick: float, offset: int) -> Color:
     phase = (tick * 1.4 + offset * 1.1) % len(_PULSE_COLORS)
     index = int(phase) % len(_PULSE_COLORS)
     blend = phase - int(phase)
@@ -82,7 +78,7 @@ def _pulsing_color(tick: float, offset: int) -> str:
     red = int(current.r + (nxt.r - current.r) * blend)
     green = int(current.g + (nxt.g - current.g) * blend)
     blue = int(current.b + (nxt.b - current.b) * blend)
-    return f"#{red:02x}{green:02x}{blue:02x}"
+    return Color(r=red, g=green, b=blue)
 
 
 def _tool_rail_color(
@@ -90,13 +86,12 @@ def _tool_rail_color(
     tick: float,
     offset: int,
     tool_kind: str,
-) -> str:
+) -> ColorLike:
     if status == "active":
         return _pulsing_color(tick, offset)
     if status == "success":
-        accent = _TOOL_ACCENTS.get(tool_kind, tailwind_color("emerald", 500))
-        return _color_hex(accent)
-    return _color_hex(tailwind_color("slate", 700))
+        return _TOOL_ACCENTS.get(tool_kind, tailwind_color("emerald", 500))
+    return tailwind_color("slate", 700)
 
 
 def _stream_chunks(text: str) -> Iterator[str]:
@@ -262,7 +257,7 @@ def _build_message_lines(
                     )
 
             if output:
-                output_bg = _color_hex(tailwind_color("slate", 900))
+                output_bg = tailwind_color("slate", 900)
                 output_rows = _wrap_body(output, content_width - 4)
                 for index in range(len(output_rows)):
                     lines.append(

--- a/examples/dashboard.py
+++ b/examples/dashboard.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import random
 
-from xnano.color import tailwind_color
+from xnano.color import Color, tailwind_color
 from xnano.components.sparkline import Sparkline
 from xnano.components.text import Text
 from xnano.events import on_keyboard, on_tick
@@ -30,10 +30,9 @@ _GRADIENT = [
 ]
 
 
-def _gradient_hex(i: int, total: int) -> str:
+def _gradient_color(i: int, total: int) -> Color:
     if total <= 1:
-        color = _GRADIENT[0]
-        return f"#{color.r:02x}{color.g:02x}{color.b:02x}"
+        return _GRADIENT[0]
     pos = (i / (total - 1)) * (len(_GRADIENT) - 1)
     idx = min(int(pos), len(_GRADIENT) - 2)
     t = pos - idx
@@ -41,7 +40,7 @@ def _gradient_hex(i: int, total: int) -> str:
     red = int(start.r + (end.r - start.r) * t)
     green = int(start.g + (end.g - start.g) * t)
     blue = int(start.b + (end.b - start.b) * t)
-    return f"#{red:02x}{green:02x}{blue:02x}"
+    return Color(r=red, g=green, b=blue)
 
 
 def _build_sparkline(history: list[int], width: int) -> Sparkline:
@@ -52,13 +51,13 @@ def _build_sparkline(history: list[int], width: int) -> Sparkline:
     )
     return Sparkline(
         data=data,
-        colors=tuple(_gradient_hex(i, width) for i in range(len(data))),
+        colors=tuple(_gradient_color(i, width) for i in range(len(data))),
         max_value=100,
     )
 
 
 def _build_gauge(
-    ratio: float, label: str, width: int, fill_color: str
+    ratio: float, label: str, width: int, fill_color: Color
 ) -> Text:
     filled = int(ratio * width)
     return Text(
@@ -232,13 +231,13 @@ class Dashboard(BaseGrid, direction="vertical"):
             self.memory_ratio,
             "RAM",
             gauge_width,
-            f"#{tailwind_color('sky', 400).r:02x}{tailwind_color('sky', 400).g:02x}{tailwind_color('sky', 400).b:02x}",
+            tailwind_color("sky", 400),
         )
         self.main.left.gauges.disk = _build_gauge(
             self.disk_percent / 100,
             "Disk Space",
             gauge_width,
-            f"#{tailwind_color('rose', 400).r:02x}{tailwind_color('rose', 400).g:02x}{tailwind_color('rose', 400).b:02x}",
+            tailwind_color("rose", 400),
         )
         self.main.right = _build_table(self.processes, self.selected_row)
 

--- a/examples/effects_demo.py
+++ b/examples/effects_demo.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import math
 import time
 
-from xnano.color import tailwind_color
+from xnano.color import Color, tailwind_color
 from xnano.components.text import Text
 from xnano.effects import AbstractEffect, Effect
 from xnano.events import on_keyboard, on_tick
@@ -60,23 +60,21 @@ _PALETTES = {
 _EFFECT_DURATION_MS = 900
 
 
-def _pulsing_color(palette: list, phase: float) -> str:
+def _pulsing_color(palette: list, phase: float) -> Color:
     t = (math.sin(phase) + 1) / 2
     idx = int(t * (len(palette) - 1))
-    c = palette[min(idx, len(palette) - 1)]
-    return f"#{c.r:02x}{c.g:02x}{c.b:02x}"
+    return palette[min(idx, len(palette) - 1)]
 
 
 def _build_canvas_effect(key: str) -> AbstractEffect:
     accent = _PALETTES[key][0]
-    accent_color = f"#{accent.r:02x}{accent.g:02x}{accent.b:02x}"
     if key == "c":
         return Effect("coalesce", duration_ms=_EFFECT_DURATION_MS)
     if key == "f":
         violet = tailwind_color("violet", 400)
         return Effect(
             "fade",
-            color=f"#{violet.r:02x}{violet.g:02x}{violet.b:02x}",
+            color=violet,
             duration_ms=_EFFECT_DURATION_MS,
         )
     if key == "d":
@@ -86,7 +84,7 @@ def _build_canvas_effect(key: str) -> AbstractEffect:
         direction="left_to_right",
         gradient_length=14,
         randomness=2,
-        color=accent_color,
+        color=accent,
         duration_ms=_EFFECT_DURATION_MS,
     )
 

--- a/examples/feed.py
+++ b/examples/feed.py
@@ -87,10 +87,6 @@ _METHOD_COLORS = {
 _BASE_LATENCY = {"api": 42, "cache": 4, "db": 78, "worker": 185}
 
 
-def _color_hex(c) -> str:
-    return f"#{c.r:02x}{c.g:02x}{c.b:02x}"
-
-
 # ── Simulated metrics ─────────────────────────────────────────────────────────
 
 _BASES_RPS = {"api": 280.0, "cache": 510.0, "db": 120.0, "worker": 75.0}
@@ -153,7 +149,7 @@ def _gen_event(svc: str, err_pct: float) -> tuple:
     return (time.strftime("%H:%M:%S"), method, endpoint, status, latency, svc)
 
 
-def _build_spark(history: list[float], color) -> Sparkline:
+def _build_spark(history: list[float], color: ColorLike) -> Sparkline:
     n = _HISTORY_LEN
     data = [
         int(v)
@@ -163,9 +159,7 @@ def _build_spark(history: list[float], color) -> Sparkline:
             else [0] * (n - len(history)) + history
         )
     ]
-    return Sparkline(
-        data=data, color=_color_hex(color), max_value=max(max(data), 1)
-    )
+    return Sparkline(data=data, color=color, max_value=max(max(data), 1))
 
 
 # ── Custom components ─────────────────────────────────────────────────────────
@@ -174,8 +168,8 @@ def _build_spark(history: list[float], color) -> Sparkline:
 @dataclasses.dataclass
 class ServiceGraph(AbstractComponent):
     data: list = dataclasses.field(default_factory=list)
-    fill_color: object = dataclasses.field(default=None)
-    edge_color: object = dataclasses.field(default=None)
+    fill_color: ColorLike | None = dataclasses.field(default=None)
+    edge_color: ColorLike | None = dataclasses.field(default=None)
     max_v: float = 1.0
     fit_content: bool = dataclasses.field(default=False, kw_only=True)
 
@@ -194,8 +188,8 @@ class ServiceGraph(AbstractComponent):
                 shapes=[], x_bounds=(0.0, 1.0), y_bounds=(0.0, 1.0)
             )
 
-        fill_hex = _color_hex(self.fill_color or tailwind_color("sky", 800))
-        edge_hex = _color_hex(self.edge_color or tailwind_color("sky", 400))
+        fill_color = self.fill_color or tailwind_color("sky", 800)
+        edge_color = self.edge_color or tailwind_color("sky", 400)
         max_v = max(self.max_v, 1.0)
         axis_c = tailwind_color("slate", 600)
         shapes = []
@@ -204,7 +198,11 @@ class ServiceGraph(AbstractComponent):
             if v > 0.0:
                 shapes.append(
                     CanvasLine(
-                        x1=float(i), y1=0.0, x2=float(i), y2=v, color=fill_hex
+                        x1=float(i),
+                        y1=0.0,
+                        x2=float(i),
+                        y2=v,
+                        color=fill_color,
                     )
                 )
 
@@ -215,7 +213,7 @@ class ServiceGraph(AbstractComponent):
                     y1=smoothed[i - 1],
                     x2=float(i),
                     y2=smoothed[i],
-                    color=edge_hex,
+                    color=edge_color,
                 )
             )
 

--- a/examples/kanban.py
+++ b/examples/kanban.py
@@ -62,10 +62,6 @@ _COL_BORDER = [
 _CHART_DAYS = 28
 
 
-def _color_hex(c) -> str:
-    return f"#{c.r:02x}{c.g:02x}{c.b:02x}"
-
-
 def _smooth(data: list[float], alpha: float = 0.2) -> list[float]:
     if len(data) < 2:
         return data
@@ -319,8 +315,8 @@ class VelocityChart(AbstractComponent):
         data = self.data or [0]
         n = len(data)
         max_v = max(max(data), 1)
-        area_c = _color_hex(tailwind_color("violet", 700))
-        avg_c = _color_hex(tailwind_color("violet", 400))
+        area_c = tailwind_color("violet", 700)
+        avg_c = tailwind_color("violet", 400)
         axis_c = tailwind_color("slate", 600)
         shapes = []
 
@@ -364,7 +360,7 @@ class VelocityChart(AbstractComponent):
                 y1=0.0,
                 x2=float(n - 1),
                 y2=float(max_v),
-                color=_color_hex(tailwind_color("emerald", 600)),
+                color=tailwind_color("emerald", 600),
             )
         )
 

--- a/examples/tabs_nav.py
+++ b/examples/tabs_nav.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import time
 
-from xnano.color import tailwind_color
+from xnano.color import ColorLike, tailwind_color
 from xnano.components.text import Text
 from xnano.events import on_keyboard
 from xnano.fields import Field
@@ -55,7 +55,9 @@ def _tab_bar(selected: int) -> Text:
 
 
 def _monitor_screen(elapsed: float) -> Text:
-    def gauge(label: str, ratio: float, color: str, width: int = 36) -> Text:
+    def gauge(
+        label: str, ratio: float, color: ColorLike, width: int = 36
+    ) -> Text:
         filled = int(ratio * width)
         return Text(
             [
@@ -90,23 +92,11 @@ def _monitor_screen(elapsed: float) -> Text:
     return Text(
         [
             Text("\n"),
-            gauge(
-                "CPU Load",
-                cpu,
-                f"#{tailwind_color('emerald', 400).r:02x}{tailwind_color('emerald', 400).g:02x}{tailwind_color('emerald', 400).b:02x}",
-            ),
+            gauge("CPU Load", cpu, tailwind_color("emerald", 400)),
             Text("\n"),
-            gauge(
-                "Memory  ",
-                mem,
-                f"#{tailwind_color('teal', 400).r:02x}{tailwind_color('teal', 400).g:02x}{tailwind_color('teal', 400).b:02x}",
-            ),
+            gauge("Memory  ", mem, tailwind_color("teal", 400)),
             Text("\n"),
-            gauge(
-                "Disk     ",
-                disk,
-                f"#{tailwind_color('cyan', 400).r:02x}{tailwind_color('cyan', 400).g:02x}{tailwind_color('cyan', 400).b:02x}",
-            ),
+            gauge("Disk     ", disk, tailwind_color("cyan", 400)),
             Text("\n\n"),
             Text("  CPU Load History\n", color=tailwind_color("slate", 400)),
             Text(f"  {spark}", color=tailwind_color("emerald", 400)),

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -605,7 +605,7 @@ def test_slide_drag_matches_mouse_action_and_updates_position() -> None:
 
         @on_mouse(field="body", kind="drag")
         def on_drag(self, ctx) -> None:
-            self.body = f"x={self.field_position('body')[0]}"
+            self.body = f"x={self.grid_field_position('body')[0]}"
 
     grid = SlideApp()
     terminal = Terminal(mouse_events=True)
@@ -635,7 +635,7 @@ def test_slide_drag_matches_mouse_action_and_updates_position() -> None:
             state=None,
         ),
     )
-    assert grid.field_position("body") == (7, 0)
+    assert grid.grid_field_position("body") == (7, 0)
     assert grid.body == "x=7"
 
 
@@ -663,7 +663,7 @@ def test_slide_y_axis_drag_with_action_filter() -> None:
         terminal,
         Context(event=drag, terminal=terminal, state=None),
     )
-    assert grid.field_position("panel") == (0, 5)
+    assert grid.grid_field_position("panel") == (0, 5)
 
 
 def test_slide_press_starts_capture_via_action_click_event() -> None:

--- a/tests/test_autofocus.py
+++ b/tests/test_autofocus.py
@@ -1,0 +1,58 @@
+"""Tests for Field(autofocus=True)."""
+
+from __future__ import annotations
+
+from xnano.components.text import Text
+from xnano.fields import Field
+from xnano.grid import BaseGrid
+from xnano.terminal import Terminal
+
+from helpers import close_offscreen_app, open_offscreen_app
+
+
+def test_autofocus_wins_over_declaration_order() -> None:
+    class App(BaseGrid, direction="vertical"):
+        first: Text = Field(default_factory=lambda: Text("", input=True))
+        second: Text = Field(
+            default_factory=lambda: Text("", input=True), autofocus=True
+        )
+
+    grid = App()
+    terminal = open_offscreen_app(grid)
+    try:
+        assert terminal.field_focus.field_name == "second"
+        assert grid.second._input_focused is True
+        assert grid.first._input_focused is False
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_no_autofocus_falls_back_to_first_field() -> None:
+    class App(BaseGrid, direction="vertical"):
+        first: Text = Field(default_factory=lambda: Text("", input=True))
+        second: Text = Field(default_factory=lambda: Text("", input=True))
+
+    grid = App()
+    terminal = open_offscreen_app(grid)
+    try:
+        assert terminal.field_focus.field_name == "first"
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_autofocus_does_not_override_explicit_focus() -> None:
+    class App(BaseGrid, direction="vertical"):
+        first: Text = Field(default_factory=lambda: Text("", input=True))
+        second: Text = Field(
+            default_factory=lambda: Text("", input=True), autofocus=True
+        )
+
+    grid = App()
+    terminal = Terminal.offscreen()
+    terminal.attach_grid(grid)
+    terminal.focus_field(grid, "first")
+    terminal._render_frame(grid)
+    try:
+        assert terminal.field_focus.field_name == "first"
+    finally:
+        close_offscreen_app(terminal)

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -184,3 +184,33 @@ def test_tailwind_different_shades_differ() -> None:
     light = tailwind_color("blue", 100)
     dark = tailwind_color("blue", 900)
     assert (light.r, light.g, light.b) != (dark.r, dark.g, dark.b)
+
+
+# ---------------------------------------------------------------------------
+# Color.as_hex / Color.as_rgb_tuple
+# ---------------------------------------------------------------------------
+
+
+def test_as_hex_round_trips_from_hex() -> None:
+    c = Color.from_hex("#a78bfa")
+    assert c.as_hex() == "#a78bfa"
+
+
+def test_as_hex_pads_single_digit_channels() -> None:
+    c = Color(r=1, g=2, b=3)
+    assert c.as_hex() == "#010203"
+
+
+def test_as_hex_includes_alpha_when_requested() -> None:
+    c = Color(r=255, g=0, b=0, a=128)
+    assert c.as_hex(include_alpha=True) == "#ff0000" + f"{128:02x}"
+
+
+def test_as_rgb_tuple_without_alpha() -> None:
+    c = Color(r=10, g=20, b=30)
+    assert c.as_rgb_tuple() == (10, 20, 30)
+
+
+def test_as_rgb_tuple_with_alpha() -> None:
+    c = Color(r=10, g=20, b=30, a=128.0)
+    assert c.as_rgb_tuple(include_alpha=True) == (10, 20, 30, 128.0)

--- a/tests/test_component_select.py
+++ b/tests/test_component_select.py
@@ -169,3 +169,37 @@ def test_items_content_lowers_to_list_node() -> None:
     assert isinstance(node, ListNode)
     assert node.selected == 0
     assert len(node.items) == len(_ITEMS)
+
+
+def test_filtered_returns_visible_indices() -> None:
+    select = Select(items=_ITEMS, searchable=False)
+    assert select.filtered == tuple(range(len(_ITEMS)))
+
+
+def test_filtered_narrows_with_query() -> None:
+    select = Select(items=_ITEMS, query="dark")
+    assert set(select.filtered) <= set(range(len(_ITEMS)))
+    assert 0 in select.filtered  # "dark" itself
+
+
+def test_move_advances_and_retreats_selection() -> None:
+    select = Select(items=_ITEMS, searchable=False)
+    select.move(1)
+    assert select.selected == 1
+    select.move(-1)
+    assert select.selected == 0
+
+
+def test_move_clamps_to_filtered_bounds() -> None:
+    select = Select(items=_ITEMS, searchable=False)
+    select.move(1000)
+    assert select.selected == len(_ITEMS) - 1
+    select.move(-1000)
+    assert select.selected == 0
+
+
+def test_move_on_empty_filtered_view_resets_to_zero() -> None:
+    select = Select(items=_ITEMS, query="zzz-no-match")
+    select.selected = 3
+    select.move(1)
+    assert select.selected == 0

--- a/tests/test_container_fields.py
+++ b/tests/test_container_fields.py
@@ -1,0 +1,96 @@
+"""Tests for list/tuple container fields (BaseGrid.paint_field_slot)."""
+
+from __future__ import annotations
+
+from xnano._types import Area
+from xnano.components.text import Text
+from xnano.core.controllers.tui import TerminalController
+from xnano.fields import Field
+from xnano.grid import BaseGrid
+from xnano_core.core import CoreSession
+
+
+def _render(grid: BaseGrid, *, width: int = 40, height: int = 12) -> str:
+    core = CoreSession.offscreen(width=width, height=height)
+    session = TerminalController(
+        core, terminal_width=width, terminal_height=height, is_offscreen=True
+    )
+    grid._grid_build_frame(Area(x=0, y=0, width=width, height=height), session)
+    session.commit_requests()
+    return session.get_core_session_output_text()
+
+
+def test_list_of_strings_renders_each_on_its_own_line() -> None:
+    class G(BaseGrid, direction="vertical"):
+        items: list = Field(default_factory=list, direction="vertical")
+
+    grid = G()
+    grid.items = ["a", "b", "c"]
+    output = _render(grid)
+    assert "a" in output
+    assert "b" in output
+    assert "c" in output
+    # Must not fall back to the raw Python repr.
+    assert "[" not in output
+
+
+def test_list_of_text_components_renders_each_item() -> None:
+    class G(BaseGrid, direction="vertical"):
+        items: list = Field(default_factory=list, direction="vertical")
+
+    grid = G()
+    grid.items = [Text("hello"), Text("world")]
+    output = _render(grid)
+    assert "hello" in output
+    assert "world" in output
+
+
+def test_nested_list_falls_through_to_str_one_level_only() -> None:
+    class G(BaseGrid, direction="vertical"):
+        items: list = Field(default_factory=list, direction="vertical")
+
+    grid = G()
+    grid.items = ["a", ["b", "c"], "d"]
+    output = _render(grid)
+    assert "a" in output
+    assert "d" in output
+    # The inner list is NOT expanded — it renders as its Python repr.
+    assert "['b', 'c']" in output
+
+
+def test_empty_list_renders_nothing() -> None:
+    class G(BaseGrid, direction="vertical"):
+        items: list = Field(default_factory=list, direction="vertical")
+
+    grid = G()
+    grid.items = []
+    output = _render(grid)
+    assert output.strip() == ""
+
+
+def test_gap_inserts_blank_space_between_items() -> None:
+    class GNoGap(BaseGrid, direction="vertical"):
+        items: list = Field(default_factory=list, direction="vertical", gap=0)
+
+    class GWithGap(BaseGrid, direction="vertical"):
+        items: list = Field(default_factory=list, direction="vertical", gap=2)
+
+    no_gap = GNoGap()
+    no_gap.items = ["a", "b"]
+    with_gap = GWithGap()
+    with_gap.items = ["a", "b"]
+
+    no_gap_output = _render(no_gap)
+    gap_output = _render(with_gap)
+    assert no_gap_output.index("b") < gap_output.index("b")
+
+
+def test_container_direction_defaults_to_vertical_when_unset() -> None:
+    class G(BaseGrid, direction="vertical"):
+        items: list = Field(default_factory=list)
+
+    grid = G()
+    grid.items = ["a", "b"]
+    output = _render(grid)
+    assert "a" in output
+    assert "b" in output

--- a/tests/test_field_focus.py
+++ b/tests/test_field_focus.py
@@ -91,6 +91,7 @@ def _terminal_with_form(form: _Form | None = None) -> tuple[Any, _Form]:
         bound.append(
             _OnFocusHookFunctionEntry(
                 field=entry["field"],
+                group=None,
                 kind=entry["kind"],
                 handler=handler,
             )
@@ -239,6 +240,7 @@ def test_terminal_focus_helpers() -> None:
         term._hooks.on_focus_hooks.append(
             _OnFocusHookFunctionEntry(
                 field=entry["field"],
+                group=None,
                 kind=entry["kind"],
                 handler=handler,
             )

--- a/tests/test_grid_init.py
+++ b/tests/test_grid_init.py
@@ -203,3 +203,34 @@ def test_grid_supports_abc_mixin() -> None:
     with pytest.raises(TypeError):
         AbstractWindow()
     assert ConcreteWindow().title == "t"
+
+
+def test_grid_with_only_init_false_fields_constructs() -> None:
+    """A class whose every field is init=False must not fail to define.
+
+    Regression test: the generated __init__ used to always emit a bare
+    trailing ``*`` (``def __init__(self, *):``), which is a SyntaxError
+    when there are no required/optional names left to follow it.
+    """
+
+    class AllInitFalse(BaseGrid):
+        a: str = Field(default="leaf", init=False)
+
+    instance = AllInitFalse()
+    assert instance.a == "leaf"
+
+
+def test_nested_grids_with_only_init_false_fields_construct() -> None:
+    """Nested default_factory grids where every field is init=False."""
+
+    class NestedLeaf(BaseGrid):
+        a: str = Field(default="leaf", init=False)
+
+    class NestedInner(BaseGrid):
+        leaf: NestedLeaf = Field(default_factory=NestedLeaf, init=False)
+
+    class NestedOuter(BaseGrid):
+        inner: NestedInner = Field(default_factory=NestedInner, init=False)
+
+    outer = NestedOuter()
+    assert outer.inner.leaf.a == "leaf"

--- a/tests/test_grid_post_init.py
+++ b/tests/test_grid_post_init.py
@@ -1,0 +1,79 @@
+"""Tests for BaseGrid.grid_post_init lifecycle hook."""
+
+from __future__ import annotations
+
+from xnano.context import Context
+from xnano.fields import Field
+from xnano.grid import BaseGrid
+
+from helpers import close_offscreen_app, open_offscreen_app
+
+
+def test_grid_post_init_fires_zero_arg_form() -> None:
+    calls: list[str] = []
+
+    class G(BaseGrid):
+        a: str = Field(default="hi")
+
+        def grid_post_init(self) -> None:
+            calls.append("called")
+
+    grid = G()
+    terminal = open_offscreen_app(grid)
+    try:
+        assert calls == ["called"]
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_grid_post_init_receives_ctx_and_state() -> None:
+    seen: list[object] = []
+
+    class G(BaseGrid):
+        a: str = Field(default="hi")
+
+        def grid_post_init(  # ty: ignore[invalid-method-override]
+            self, ctx: Context
+        ) -> None:
+            seen.append(ctx.state)
+            self.a = "post-init-ran"
+
+    grid = G()
+    state = {"workspace": "demo"}
+    terminal = open_offscreen_app(grid, state=state)
+    try:
+        assert seen == [state]
+        assert grid.a == "post-init-ran"
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_grid_post_init_fires_exactly_once_per_instance() -> None:
+    calls: list[str] = []
+
+    class G(BaseGrid):
+        a: str = Field(default="hi")
+
+        def grid_post_init(self) -> None:
+            calls.append("called")
+
+    grid = G()
+    terminal = open_offscreen_app(grid)
+    try:
+        # A second frame paints the same instance again.
+        terminal._render_frame(grid)
+        assert calls == ["called"]
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_grid_post_init_default_is_noop() -> None:
+    class G(BaseGrid):
+        a: str = Field(default="hi")
+
+    grid = G()
+    terminal = open_offscreen_app(grid)
+    try:
+        assert grid.a == "hi"
+    finally:
+        close_offscreen_app(terminal)

--- a/tests/test_grid_set_field.py
+++ b/tests/test_grid_set_field.py
@@ -69,6 +69,52 @@ def test_set_field_validates_when_strict() -> None:
         grid.grid_set_field("body", 123)
 
 
+def test_update_field_changes_style_without_value_param() -> None:
+    grid = LayoutGrid()
+    grid.grid_update_field("body", color="red", modifiers=["bold"])
+    field = grid._grid_field_info("body")
+    assert field.color == "red"
+    assert field.modifiers == ["bold"]
+    assert grid.body == "hello"
+
+
+def test_update_field_rejects_state_fields() -> None:
+    grid = StatefulGrid()
+    with pytest.raises(TypeError, match="state field"):
+        grid.grid_update_field("count", color="red")
+
+
+def test_update_field_rejects_unknown_field() -> None:
+    grid = LayoutGrid()
+    with pytest.raises(AttributeError, match="missing"):
+        grid.grid_update_field("missing", color="red")
+
+
+def test_set_field_is_noop_when_value_unchanged() -> None:
+    grid = LayoutGrid()
+    grid.grid_set_field("body", visible=False)
+    assert grid._grid_has_field_overrides()
+    grid.grid_set_field("body", visible=False)
+    override_after_first_change = grid._grid_field_info("body")
+    grid.grid_set_field("body", visible=False)
+    assert grid._grid_field_info("body") is override_after_first_change
+
+
+def test_set_field_creates_override_when_value_changes() -> None:
+    grid = LayoutGrid()
+    grid.grid_set_field("body", visible=False)
+    assert grid._grid_has_field_overrides()
+
+
+def test_update_field_has_no_value_or_position_parameters() -> None:
+    grid = LayoutGrid()
+    update_field: Any = grid.grid_update_field
+    with pytest.raises(TypeError):
+        update_field("body", value="nope")
+    with pytest.raises(TypeError):
+        update_field("body", position=(1, 1))
+
+
 def test_grid_slot_renders_text_component_offscreen() -> None:
     class TextGrid(BaseGrid):
         body: Text = Field(default_factory=lambda: Text(content="hello"))

--- a/tests/test_grid_slide.py
+++ b/tests/test_grid_slide.py
@@ -31,7 +31,7 @@ class DragHookGrid(BaseGrid):
 
     @on_mouse(field="body", kind="drag")
     def on_drag(self, ctx: Context) -> None:
-        self.body = f"x={self.field_position('body')[0]}"
+        self.body = f"x={self.grid_field_position('body')[0]}"
 
 
 def test_slide_paint_area_offsets_within_parent() -> None:
@@ -124,7 +124,7 @@ def test_slide_capture_updates_position_on_drag() -> None:
             state=None,
         )
     )
-    assert grid.field_position("body") == (5, 3)
+    assert grid.grid_field_position("body") == (5, 3)
 
 
 def test_set_field_slide_and_position() -> None:
@@ -133,7 +133,7 @@ def test_set_field_slide_and_position() -> None:
     grid._grid_last_slot_areas = {"body": Area(x=0, y=0, width=6, height=3)}
     grid.grid_set_field("body", slide=["x"], position=(4, 0))
     assert grid._grid_field_info("body").slide == ["x"]
-    assert grid.field_position("body") == (4, 0)
+    assert grid.grid_field_position("body") == (4, 0)
 
 
 def test_drag_hook_fires_while_sliding() -> None:

--- a/tests/test_grid_type_validation.py
+++ b/tests/test_grid_type_validation.py
@@ -247,7 +247,7 @@ def test_set_field_position_does_not_validate_value() -> None:
         "body": Area(x=0, y=0, width=4, height=2),
     }
     panel.grid_set_field("body", position=(2, 0))
-    assert panel.field_position("body")[0] == 2
+    assert panel.grid_field_position("body")[0] == 2
 
 
 def test_field_validation_error_wraps_validation_error() -> None:

--- a/tests/test_group_focus.py
+++ b/tests/test_group_focus.py
@@ -1,0 +1,119 @@
+"""Tests for Field(group=...) — terminal-global focus & click addressing."""
+
+from __future__ import annotations
+
+from xnano._dispatch import dispatch_field_mouse
+from xnano._types import Area
+from xnano.components.text import Text
+from xnano.context import Context
+from xnano.core.actions import Action
+from xnano.events import on_click, on_focus
+from xnano.fields import Field
+from xnano.grid import BaseGrid, _GridFieldHit
+from xnano.terminal import Terminal
+
+
+class InputRow(BaseGrid, direction="horizontal"):
+    field: Text = Field(
+        default_factory=lambda: Text("", input=True), group="composer"
+    )
+
+
+class Sidebar(BaseGrid):
+    history: str = Field(default="log", group="transcript")
+
+
+def _terminal_with(*grids: BaseGrid) -> Terminal:
+    terminal = Terminal.offscreen()
+    for grid in grids:
+        terminal.attach_grid(grid)
+    return terminal
+
+
+def test_focus_group_resolves_nested_field() -> None:
+    row = InputRow()
+    terminal = _terminal_with(row)
+    assert terminal.focus_group("composer") is True
+    assert terminal.focused_group == "composer"
+
+
+def test_focus_group_unknown_returns_false() -> None:
+    row = InputRow()
+    terminal = _terminal_with(row)
+    assert terminal.focus_group("does-not-exist") is False
+    assert terminal.focused_group is None
+
+
+def test_ctx_focus_and_is_focused() -> None:
+    row = InputRow()
+    terminal = _terminal_with(row)
+    ctx = Context(event=None, terminal=terminal, state=terminal.state)
+    assert ctx.focus("composer") is True
+    assert ctx.is_focused("composer") is True
+    assert ctx.focused_group == "composer"
+
+
+def test_group_spans_multiple_grids_first_wins() -> None:
+    row = InputRow()
+    sidebar = Sidebar()
+    terminal = _terminal_with(row, sidebar)
+    assert terminal.focus_group("composer") is True
+    assert terminal.field_focus.grid is row
+
+
+def test_on_focus_group_fires_on_gain_and_lost() -> None:
+    events: list[str] = []
+
+    class App(BaseGrid):
+        field: Text = Field(
+            default_factory=lambda: Text("", input=True), group="composer"
+        )
+
+        @on_focus(group="composer", kind="gained")
+        def _gained(self) -> None:
+            events.append("gained")
+
+        @on_focus(group="composer", kind="lost")
+        def _lost(self) -> None:
+            events.append("lost")
+
+    app = App()
+    terminal = _terminal_with(app)
+    assert terminal.focus_group("composer") is True
+    assert events == ["gained"]
+    terminal.blur_field()
+    assert events == ["gained", "lost"]
+
+
+def test_on_click_group_fires_regardless_of_grid() -> None:
+    hits: list[str] = []
+
+    class App(BaseGrid):
+        field: Text = Field(
+            default_factory=lambda: Text("", input=True), group="composer"
+        )
+
+        @on_click(group="composer")
+        def _clicked(self) -> None:
+            hits.append("clicked")
+
+    app = App()
+    terminal = _terminal_with(app)
+    terminal._mouse_geometry_active = True
+    paint = Area(x=0, y=0, width=10, height=1)
+    terminal._field_hits.append(
+        _GridFieldHit(
+            grid=app,
+            field_name="field",
+            area=paint,
+            slot_area=paint,
+            parent_area=Area(x=0, y=0, width=40, height=20),
+            slide_axes=[],
+        )
+    )
+    event = Action.click("field").to_event()
+    dispatch_field_mouse(
+        terminal,
+        Context(event=event, terminal=terminal, state=terminal.state),
+    )
+    assert hits == ["clicked"]

--- a/tests/test_scroll_fields.py
+++ b/tests/test_scroll_fields.py
@@ -1,0 +1,235 @@
+"""Tests for Field(scroll=...) — windowed container fields."""
+
+from __future__ import annotations
+
+from xnano._dispatch import dispatch_field_mouse
+from xnano._types import Area
+from xnano.context import Context
+from xnano.core.controllers.tui import compute_scroll_window
+from xnano.events import Event, MouseEventData
+from xnano.fields import Field
+from xnano.grid import BaseGrid, _GridFieldHit
+from xnano_core.core import CoreSession
+from xnano.core.controllers.tui import TerminalController
+
+
+# ---------------------------------------------------------------------------
+# compute_scroll_window — pure function
+# ---------------------------------------------------------------------------
+
+
+def test_window_anchors_at_bottom_by_default() -> None:
+    assert compute_scroll_window([1, 1, 1, 1, 1], 0, 3, 0) == (2, 5)
+
+
+def test_window_shifts_with_offset() -> None:
+    assert compute_scroll_window([1, 1, 1, 1, 1], 0, 3, 1) == (1, 4)
+
+
+def test_window_always_includes_at_least_one_item() -> None:
+    assert compute_scroll_window([10, 10], 0, 1, 0) == (1, 2)
+
+
+def test_window_empty_input() -> None:
+    assert compute_scroll_window([], 0, 5, 0) == (0, 0)
+
+
+def test_window_respects_gap() -> None:
+    # 3 items of length 1, gap 1: item+gap+item+gap+item = 5 > available=3
+    start, end = compute_scroll_window([1, 1, 1], 1, 3, 0)
+    assert end == 3
+    assert start >= 1
+
+
+# ---------------------------------------------------------------------------
+# Rendered windowing
+# ---------------------------------------------------------------------------
+
+
+def _render(grid: BaseGrid, *, width: int = 20, height: int = 4) -> str:
+    core = CoreSession.offscreen(width=width, height=height)
+    session = TerminalController(
+        core, terminal_width=width, terminal_height=height, is_offscreen=True
+    )
+    grid._grid_build_frame(Area(x=0, y=0, width=width, height=height), session)
+    session.commit_requests()
+    return session.get_core_session_output_text()
+
+
+def test_scroll_field_shows_only_the_tail_by_default() -> None:
+    class App(BaseGrid, direction="vertical"):
+        items: list = Field(
+            default_factory=list, direction="vertical", scroll=True
+        )
+
+    grid = App()
+    grid.items = [f"line{i}" for i in range(10)]
+    output = _render(grid, height=4)
+    assert "line9" in output
+    assert "line0" not in output
+
+
+def test_scroll_offset_shifts_the_window() -> None:
+    class App(BaseGrid, direction="vertical"):
+        items: list = Field(
+            default_factory=list, direction="vertical", scroll=True
+        )
+
+    grid = App()
+    grid.items = [f"line{i}" for i in range(10)]
+    grid._grid_set_field_scroll_offset("items", 9)
+    output = _render(grid, height=4)
+    assert "line0" in output
+    assert "line9" not in output
+
+
+def test_content_that_fits_ignores_offset() -> None:
+    class App(BaseGrid, direction="vertical"):
+        items: list = Field(
+            default_factory=list, direction="vertical", scroll=True
+        )
+
+    grid = App()
+    grid.items = ["a", "b"]
+    output = _render(grid, height=10)
+    assert "a" in output
+    assert "b" in output
+
+
+# ---------------------------------------------------------------------------
+# ScrollHandle / ctx.scroll(group)
+# ---------------------------------------------------------------------------
+
+
+def test_ctx_scroll_resolves_by_group() -> None:
+    class App(BaseGrid, direction="vertical"):
+        items: list = Field(
+            default_factory=list,
+            direction="vertical",
+            scroll=True,
+            group="transcript",
+        )
+
+    grid = App()
+    terminal = _attach(grid)
+    ctx = Context(event=None, terminal=terminal, state=terminal.state)
+    handle = ctx.scroll("transcript")
+    assert handle is not None
+    assert handle.offset == 0
+    handle.offset = 5
+    assert grid._grid_field_scroll_offset("items") == 5
+
+
+def test_ctx_scroll_unknown_group_returns_none() -> None:
+    class App(BaseGrid, direction="vertical"):
+        items: list = Field(default_factory=list, group="transcript")
+
+    grid = App()
+    terminal = _attach(grid)
+    ctx = Context(event=None, terminal=terminal, state=terminal.state)
+    assert ctx.scroll("does-not-exist") is None
+
+
+def test_scroll_handle_to_bottom_and_scroll_by() -> None:
+    class App(BaseGrid, direction="vertical"):
+        items: list = Field(
+            default_factory=list, scroll=True, group="transcript"
+        )
+
+    grid = App()
+    terminal = _attach(grid)
+    ctx = Context(event=None, terminal=terminal, state=terminal.state)
+    handle = ctx.scroll("transcript")
+    assert handle is not None
+    handle.scroll_by(3)
+    assert handle.offset == 3
+    handle.to_bottom()
+    assert handle.offset == 0
+
+
+def test_scroll_handle_follow_persists_across_lookups() -> None:
+    class App(BaseGrid, direction="vertical"):
+        items: list = Field(
+            default_factory=list, scroll=True, group="transcript"
+        )
+
+    grid = App()
+    terminal = _attach(grid)
+    ctx = Context(event=None, terminal=terminal, state=terminal.state)
+    first = ctx.scroll("transcript")
+    assert first is not None
+    first.follow = True
+    second = ctx.scroll("transcript")
+    assert second is not None
+    assert second.follow is True
+
+
+# ---------------------------------------------------------------------------
+# Mouse wheel dispatch
+# ---------------------------------------------------------------------------
+
+
+def _attach(grid: BaseGrid):
+    from xnano.terminal import Terminal
+
+    terminal = Terminal.offscreen()
+    terminal.attach_grid(grid)
+    return terminal
+
+
+def test_wheel_up_increases_offset_on_scrollable_field() -> None:
+    class App(BaseGrid, direction="vertical"):
+        items: list = Field(
+            default_factory=list, direction="vertical", scroll=True
+        )
+
+    grid = App()
+    terminal = _attach(grid)
+    terminal._mouse_geometry_active = True
+    paint = Area(x=0, y=0, width=20, height=4)
+    terminal._field_hits.append(
+        _GridFieldHit(
+            grid=grid,
+            field_name="items",
+            area=paint,
+            slot_area=paint,
+            parent_area=Area(x=0, y=0, width=20, height=4),
+            slide_axes=[],
+        )
+    )
+    event = Event.from_data(MouseEventData(kind="scroll_up", x=1, y=1, button="unknown"))
+    dispatch_field_mouse(
+        terminal, Context(event=event, terminal=terminal, state=None)
+    )
+    assert grid._grid_field_scroll_offset("items") == 1
+
+    down_event = Event.from_data(MouseEventData(kind="scroll_down", x=1, y=1, button="unknown"))
+    dispatch_field_mouse(
+        terminal, Context(event=down_event, terminal=terminal, state=None)
+    )
+    assert grid._grid_field_scroll_offset("items") == 0
+
+
+def test_wheel_ignores_non_scroll_fields() -> None:
+    class App(BaseGrid, direction="vertical"):
+        body: str = Field(default="hi")
+
+    grid = App()
+    terminal = _attach(grid)
+    terminal._mouse_geometry_active = True
+    paint = Area(x=0, y=0, width=20, height=4)
+    terminal._field_hits.append(
+        _GridFieldHit(
+            grid=grid,
+            field_name="body",
+            area=paint,
+            slot_area=paint,
+            parent_area=Area(x=0, y=0, width=20, height=4),
+            slide_axes=[],
+        )
+    )
+    event = Event.from_data(MouseEventData(kind="scroll_up", x=1, y=1, button="unknown"))
+    # Should not raise even though "body" isn't scrollable.
+    dispatch_field_mouse(
+        terminal, Context(event=event, terminal=terminal, state=None)
+    )

--- a/tests/test_terminal_cursor_device.py
+++ b/tests/test_terminal_cursor_device.py
@@ -1,0 +1,131 @@
+"""Tests for TerminalCursor/TerminalDevice offscreen safety.
+
+Offscreen sessions (tests, and every ``Web`` visitor under the hood — see
+``xnano.web.render.WebRenderer``) must never issue real OS terminal escape
+codes: there's no live terminal attached to receive them, and doing so
+would write to whatever process happens to own stdout.
+"""
+
+from __future__ import annotations
+
+from xnano.terminal import Terminal
+
+
+def test_offscreen_cursor_tracks_position_locally() -> None:
+    terminal = Terminal.offscreen()
+    terminal.cursor.move_to(5, 7)
+    assert terminal.cursor.get_position() == (5, 7)
+
+
+def test_offscreen_cursor_visible_toggle_tracked() -> None:
+    terminal = Terminal.offscreen()
+    terminal.cursor.visible = False
+    assert terminal.cursor.visible is False
+    terminal.cursor.visible = True
+    assert terminal.cursor.visible is True
+
+
+def test_offscreen_cursor_relative_moves() -> None:
+    terminal = Terminal.offscreen()
+    terminal.cursor.move_to(5, 5)
+    terminal.cursor.move_up(2)
+    terminal.cursor.move_right(3)
+    assert terminal.cursor.get_position() == (8, 3)
+
+
+def test_offscreen_cursor_save_restore() -> None:
+    terminal = Terminal.offscreen()
+    terminal.cursor.move_to(4, 4)
+    terminal.cursor.save_position()
+    terminal.cursor.move_to(0, 0)
+    terminal.cursor.restore_position()
+    assert terminal.cursor.get_position() == (4, 4)
+
+
+def test_offscreen_cursor_never_calls_native(monkeypatch) -> None:
+    import xnano.terminal.cursor as cursor_module
+
+    calls: list[str] = []
+    for name in dir(cursor_module.native):
+        if name.startswith("_"):
+            continue
+        try:
+            monkeypatch.setattr(
+                cursor_module.native,
+                name,
+                lambda *a, name=name, **k: calls.append(name),
+            )
+        except (AttributeError, TypeError):
+            pass
+
+    terminal = Terminal.offscreen()
+    cursor = terminal.cursor
+    cursor.move_to(1, 1)
+    cursor.move_to_column(2)
+    cursor.move_to_row(3)
+    cursor.move_up()
+    cursor.move_down()
+    cursor.move_left()
+    cursor.move_right()
+    cursor.move_to_next_line()
+    cursor.move_to_previous_line()
+    cursor.save_position()
+    cursor.restore_position()
+    cursor.visible = False
+    cursor.visible = True
+    cursor.style = "steady_block"
+    cursor.enable_blinking()
+    cursor.disable_blinking()
+    assert calls == []
+
+
+def test_offscreen_device_title_tracked_locally() -> None:
+    terminal = Terminal.offscreen()
+    terminal.device.title = "hello"
+    assert terminal.device.title == "hello"
+
+
+def test_offscreen_device_flags_tracked_locally() -> None:
+    terminal = Terminal.offscreen()
+    terminal.device.raw_mode = True
+    assert terminal.device.raw_mode is True
+    terminal.device.mouse_capture = True
+    assert terminal.device.mouse_capture is True
+
+
+def test_offscreen_device_never_calls_native(monkeypatch) -> None:
+    import xnano.terminal.device as device_module
+
+    calls: list[str] = []
+    for name in dir(device_module.native):
+        if name.startswith("_"):
+            continue
+        try:
+            monkeypatch.setattr(
+                device_module.native,
+                name,
+                lambda *a, name=name, **k: calls.append(name),
+            )
+        except (AttributeError, TypeError):
+            pass
+
+    terminal = Terminal.offscreen()
+    device = terminal.device
+    device.raw_mode = True
+    device.alternate_screen = True
+    device.line_wrap = False
+    device.mouse_capture = True
+    device.bracketed_paste = True
+    device.focus_change = True
+    device.synchronized_updates = True
+    device.title = "x"
+    device.clear()
+    device.scroll_up()
+    device.scroll_down()
+    assert calls == []
+
+
+def test_offscreen_device_copy_to_clipboard_returns_false() -> None:
+    terminal = Terminal.offscreen()
+    assert terminal.device.copy_to_clipboard("text") is None
+    assert terminal.copy_to_clipboard("text") is False

--- a/tests/test_terminal_render.py
+++ b/tests/test_terminal_render.py
@@ -19,6 +19,10 @@ from xnano.grid import BaseGrid
 from xnano.terminal import Terminal
 
 
+@pytest.mark.skipif(
+    not hasattr(signal, "SIGHUP"),
+    reason="SIGHUP is POSIX-only; no equivalent in Python's signal module on Windows",
+)
 def test_terminal_hangup_terminates_process() -> None:
     terminal: Terminal = Terminal()
 

--- a/tests/test_text_passthrough.py
+++ b/tests/test_text_passthrough.py
@@ -1,0 +1,131 @@
+"""Tests for Text(passthrough=...) — declarative key release, no subclass."""
+
+from __future__ import annotations
+
+from xnano.components.text import Text
+from xnano.events import on_keyboard
+from xnano.fields import Field
+from xnano.grid import BaseGrid
+
+from helpers import close_offscreen_app, open_offscreen_app, press, type_text
+
+
+def test_passthrough_key_is_not_consumed_by_input() -> None:
+    events: list[str] = []
+
+    class App(BaseGrid):
+        field: Text = Field(
+            default_factory=lambda: Text(
+                "", input=True, passthrough=("ctrl+s",)
+            )
+        )
+
+        @on_keyboard("ctrl+s")
+        def _quit(self) -> None:
+            events.append("quit")
+
+    grid = App()
+    terminal = open_offscreen_app(grid)
+    try:
+        press(terminal, "ctrl+s")
+        assert events == ["quit"]
+        assert grid.field.value == ""
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_non_passthrough_keys_still_edit_normally() -> None:
+    class App(BaseGrid):
+        field: Text = Field(
+            default_factory=lambda: Text(
+                "", input=True, passthrough=("ctrl+s",)
+            )
+        )
+
+    grid = App()
+    terminal = open_offscreen_app(grid)
+    try:
+        type_text(terminal, "hi")
+        assert grid.field.value == "hi"
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_up_down_passthrough_reaches_app_hooks() -> None:
+    events: list[str] = []
+
+    class App(BaseGrid):
+        field: Text = Field(
+            default_factory=lambda: Text(
+                "", input=True, passthrough=("up", "down")
+            )
+        )
+
+        @on_keyboard("up")
+        def _up(self) -> None:
+            events.append("up")
+
+        @on_keyboard("down")
+        def _down(self) -> None:
+            events.append("down")
+
+    grid = App()
+    terminal = open_offscreen_app(grid)
+    try:
+        press(terminal, "up")
+        press(terminal, "down")
+        assert events == ["up", "down"]
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_passthrough_intercepts_a_key_the_input_would_otherwise_consume() -> (
+    None
+):
+    """``left`` moves the caret by default (apply_text_keyboard consumes
+    it) — declaring it as passthrough releases it to app hooks instead."""
+    events: list[str] = []
+
+    class App(BaseGrid):
+        field: Text = Field(
+            default_factory=lambda: Text(
+                "ab", input=True, cursor=2, passthrough=("left",)
+            )
+        )
+
+        @on_keyboard("left")
+        def _moved(self) -> None:
+            events.append("moved")
+
+    grid = App()
+    terminal = open_offscreen_app(grid)
+    try:
+        press(terminal, "left")
+        assert events == ["moved"]
+        assert grid.field.cursor == 2  # untouched — input never saw the key
+    finally:
+        close_offscreen_app(terminal)
+
+
+def test_without_passthrough_left_is_consumed_by_the_input() -> None:
+    """Same key, no passthrough — the input's own caret movement wins and
+    the app-level hook never fires."""
+    events: list[str] = []
+
+    class App(BaseGrid):
+        field: Text = Field(
+            default_factory=lambda: Text("ab", input=True, cursor=2)
+        )
+
+        @on_keyboard("left")
+        def _moved(self) -> None:
+            events.append("moved")
+
+    grid = App()
+    terminal = open_offscreen_app(grid)
+    try:
+        press(terminal, "left")
+        assert events == []
+        assert grid.field.cursor == 1  # the input moved its own caret
+    finally:
+        close_offscreen_app(terminal)

--- a/tests/test_types_reexport.py
+++ b/tests/test_types_reexport.py
@@ -1,0 +1,11 @@
+"""Tests for the public xnano.types re-export module."""
+
+from __future__ import annotations
+
+
+def test_types_module_reexports_signature_facing_names() -> None:
+    from xnano import _types
+    from xnano import types as public_types
+
+    for name in public_types.__all__:
+        assert getattr(public_types, name) is getattr(_types, name)

--- a/tests/test_usage_scenarios.py
+++ b/tests/test_usage_scenarios.py
@@ -405,6 +405,7 @@ def _bind_all_hooks(terminal: Any, grid: Any, cls: type) -> None:
         terminal._hooks.on_focus_hooks.append(
             {
                 "field": entry["field"],
+                "group": entry.get("group"),
                 "kind": entry["kind"],
                 "handler": handler,
             }

--- a/tests/test_wireframe_field.py
+++ b/tests/test_wireframe_field.py
@@ -1,0 +1,59 @@
+"""Tests for Field(wireframe=...) — per-field debug cell-grid overlay."""
+
+from __future__ import annotations
+
+from xnano._types import Area
+from xnano.core.controllers.tui import TerminalController
+from xnano.fields import Field
+from xnano.grid import BaseGrid
+from xnano.terminal import Terminal
+from xnano_core.core import CoreSession
+
+
+def _render(grid: BaseGrid, *, width: int = 10, height: int = 5) -> str:
+    core = CoreSession.offscreen(width=width, height=height)
+    session = TerminalController(
+        core, terminal_width=width, terminal_height=height, is_offscreen=True
+    )
+    grid._grid_build_frame(Area(x=0, y=0, width=width, height=height), session)
+    session.commit_requests()
+    return session.get_core_session_output_text()
+
+
+def test_wireframe_field_paints_dot_overlay() -> None:
+    class App(BaseGrid, direction="vertical"):
+        body: str = Field(default="hi", wireframe=True, height=3)
+
+    grid = App()
+    output = _render(grid)
+    assert "·" in output
+
+
+def test_field_without_wireframe_has_no_dots() -> None:
+    class App(BaseGrid, direction="vertical"):
+        body: str = Field(default="hi", height=3)
+
+    grid = App()
+    output = _render(grid)
+    assert "·" not in output
+
+
+def test_wireframe_can_be_toggled_live() -> None:
+    class App(BaseGrid, direction="vertical"):
+        body: str = Field(default="hi", height=3)
+
+    grid = App()
+    assert "·" not in _render(grid)
+    grid.grid_update_field("body", wireframe=True)
+    assert "·" in _render(grid)
+    grid.grid_update_field("body", wireframe=False)
+    assert "·" not in _render(grid)
+
+
+def test_terminal_no_longer_accepts_debug_wireframe() -> None:
+    import inspect
+
+    params = inspect.signature(Terminal.__init__).parameters
+    assert "debug_wireframe" not in params
+    offscreen_params = inspect.signature(Terminal.offscreen).parameters
+    assert "debug_wireframe" not in offscreen_params

--- a/tests/web/test_cell_stream.py
+++ b/tests/web/test_cell_stream.py
@@ -123,3 +123,128 @@ def test_table_renders_on_web_without_web_code() -> None:
         assert "ada" in text
     finally:
         renderer.close()
+
+
+# ---------------------------------------------------------------------------
+# ctx.cursor / ctx.device — native to web, same as terminal
+# ---------------------------------------------------------------------------
+
+
+def test_cursor_hidden_by_default_omits_cursor_from_frame() -> None:
+    class G(BaseGrid):
+        title: Text = Field(default=Text("hi"))
+
+    renderer = WebRenderer(G(), cols=10, rows=2)
+    try:
+        renderer.terminal.cursor.visible = False
+        frame = renderer.frame()
+        assert frame["cursor"] is None
+    finally:
+        renderer.close()
+
+
+def test_cursor_moved_and_shown_appears_in_frame() -> None:
+    class G(BaseGrid):
+        title: Text = Field(default=Text("hi"))
+
+    renderer = WebRenderer(G(), cols=10, rows=2)
+    try:
+        renderer.terminal.cursor.move_to(3, 1)
+        renderer.terminal.cursor.visible = True
+        frame = renderer.frame()
+        assert frame["cursor"] == [3, 1]
+    finally:
+        renderer.close()
+
+
+def test_cursor_moves_do_not_touch_real_terminal_escapes(
+    monkeypatch,
+) -> None:
+    """Offscreen (web) cursor moves must never shell out to native escapes —
+    that would write to the server process's own stdout."""
+    import xnano.terminal.cursor as cursor_module
+
+    calls: list[str] = []
+    for name in (
+        "show_cursor",
+        "hide_cursor",
+        "move_cursor_to",
+        "set_cursor_style",
+    ):
+        monkeypatch.setattr(
+            cursor_module.native,
+            name,
+            lambda *a, name=name, **k: calls.append(name),
+        )
+
+    class G(BaseGrid):
+        title: Text = Field(default=Text("hi"))
+
+    renderer = WebRenderer(G(), cols=10, rows=2)
+    try:
+        renderer.terminal.cursor.move_to(2, 2)
+        renderer.terminal.cursor.visible = True
+        renderer.terminal.cursor.visible = False
+        renderer.terminal.cursor.style = "steady_bar"
+        assert calls == []
+    finally:
+        renderer.close()
+
+
+def test_device_title_change_is_included_in_frame() -> None:
+    class G(BaseGrid):
+        title: Text = Field(default=Text("hi"))
+
+    renderer = WebRenderer(G(), cols=10, rows=2)
+    try:
+        renderer.frame()  # first frame, no title set yet
+        renderer.terminal.device.title = "new title"
+        frame = renderer.frame()
+        assert frame["title"] == "new title"
+    finally:
+        renderer.close()
+
+
+def test_device_title_unchanged_is_not_resent() -> None:
+    class G(BaseGrid):
+        title: Text = Field(default=Text("hi"))
+
+    renderer = WebRenderer(G(), cols=10, rows=2)
+    try:
+        renderer.terminal.device.title = "same"
+        first = renderer.frame()
+        second = renderer.frame()
+        assert first.get("title") == "same"
+        assert "title" not in second
+    finally:
+        renderer.close()
+
+
+def test_device_settings_do_not_touch_native_escapes(monkeypatch) -> None:
+    import xnano.terminal.device as device_module
+
+    calls: list[str] = []
+    for name in (
+        "enable_raw_mode",
+        "clear_terminal",
+        "scroll_up",
+        "set_terminal_title",
+    ):
+        monkeypatch.setattr(
+            device_module.native,
+            name,
+            lambda *a, name=name, **k: calls.append(name),
+        )
+
+    class G(BaseGrid):
+        title: Text = Field(default=Text("hi"))
+
+    renderer = WebRenderer(G(), cols=10, rows=2)
+    try:
+        renderer.terminal.device.raw_mode = True
+        renderer.terminal.device.clear()
+        renderer.terminal.device.scroll_up()
+        renderer.terminal.device.title = "x"
+        assert calls == []
+    finally:
+        renderer.close()

--- a/xnano/_dispatch.py
+++ b/xnano/_dispatch.py
@@ -440,17 +440,30 @@ def render_frame(
         track_frame_grid(terminal, root)
 
         # Seed focus before paint so the caret/placeholder render correctly
-        # on the first frame.
+        # on the first frame. Prefer Field(autofocus=True) over the first
+        # focusable field in declaration order.
         if getattr(terminal, "_field_focus", None) is None:
             fields = getattr(type(root), "_grid_fields", {}) or {}
+            fallback: str | None = None
+            picked: str | None = None
             for field_name in fields:
                 value = getattr(root, field_name, None)
-                if is_focusable_component(value):
-                    terminal._field_focus = FieldFocus(
-                        grid=root, field_name=field_name
-                    )
-                    cast(Any, value)._input_focused = True
+                if not is_focusable_component(value):
+                    continue
+                if fallback is None:
+                    fallback = field_name
+                if getattr(
+                    root._grid_field_info(field_name), "autofocus", False
+                ):
+                    picked = field_name
                     break
+            picked = picked or fallback
+            if picked is not None:
+                value = getattr(root, picked, None)
+                terminal._field_focus = FieldFocus(
+                    grid=root, field_name=picked
+                )
+                cast(Any, value)._input_focused = True
         else:
             current = terminal._field_focus
             text = getattr(current.grid, current.field_name, None)
@@ -771,13 +784,67 @@ def dispatch_hooks(terminal: "Terminal[Any]", ctx: "Context[Any]") -> None:
             invoke_hook(handler, grid, ctx)
 
 
+def _dispatch_group_click(
+    terminal: "Terminal[Any]",
+    grid: Any,
+    field_name: str,
+    mouse: Any,
+    ctx: "Context[Any]",
+) -> None:
+    from xnano._types import field_group
+
+    group = field_group(grid, field_name)
+    if group is None:
+        return
+    for handler in terminal._hooks.on_click_group_hooks:
+        if (
+            getattr(handler, _EventHooksRegistry.ON_MOUSE_GROUP_ATTR, None)
+            != group
+        ):
+            continue
+        if not field_mouse_handler_matches(handler, mouse):
+            continue
+        invoke_hook(handler, None, ctx)
+
+
+_SCROLL_WHEEL_STEP = 1
+
+
+def _dispatch_field_scroll(terminal: "Terminal[Any]", mouse: Any) -> bool:
+    """Adjust scroll offset for a ``Field(scroll=...)`` field under the
+    cursor. Returns ``True`` when a scrollable field was hit."""
+    coordinate = (mouse.x, mouse.y)
+    for hit in reversed(terminal._field_hits):
+        if not hit.area.contains(coordinate):
+            continue
+        field = hit.grid._grid_field_info(hit.field_name)
+        if not field.scroll:
+            continue
+        current = hit.grid._grid_field_scroll_offset(hit.field_name)
+        if mouse.kind == "scroll_up":
+            hit.grid._grid_set_field_scroll_offset(
+                hit.field_name, current + _SCROLL_WHEEL_STEP
+            )
+        elif mouse.kind == "scroll_down":
+            hit.grid._grid_set_field_scroll_offset(
+                hit.field_name, max(0, current - _SCROLL_WHEEL_STEP)
+            )
+        return True
+    return False
+
+
 def dispatch_field_mouse(
     terminal: "Terminal[Any]", ctx: "Context[Any]"
 ) -> None:
     from xnano.grid import _GridSlideCapture
 
     mouse = ctx.event.mouse_event if ctx.event is not None else None
-    if mouse is None or mouse.kind not in {"press", "drag", "release"}:
+    if mouse is None:
+        return
+    if mouse.kind in ("scroll_up", "scroll_down"):
+        _dispatch_field_scroll(terminal, mouse)
+        return
+    if mouse.kind not in {"press", "drag", "release"}:
         return
 
     capture = terminal._slide_capture
@@ -789,6 +856,9 @@ def dispatch_field_mouse(
         handler = resolve_grid_mouse_handler(capture.grid, capture.field_name)
         if handler is not None and field_mouse_handler_matches(handler, mouse):
             invoke_hook(handler, capture.grid, ctx)
+        _dispatch_group_click(
+            terminal, capture.grid, capture.field_name, mouse, ctx
+        )
         return
 
     coordinate = (mouse.x, mouse.y)
@@ -814,6 +884,7 @@ def dispatch_field_mouse(
         handler = resolve_grid_mouse_handler(hit.grid, hit.field_name)
         if handler is not None and field_mouse_handler_matches(handler, mouse):
             invoke_hook(handler, hit.grid, ctx)
+        _dispatch_group_click(terminal, hit.grid, hit.field_name, mouse, ctx)
         return
 
 
@@ -855,6 +926,13 @@ def track_frame_grid(terminal: "Terminal[Any]", grid: Any) -> None:
         # The strong reference keeps ``id(grid)`` unique for the life of
         # the terminal (bound hook handlers hold the instance anyway).
         attached[id(grid)] = grid
+        # Fired exactly once per instance, after this grid's own hooks are
+        # bound (so anything it triggers already has a live handler) and
+        # before its first paint on this terminal.
+        from xnano.context import Context
+
+        ctx = Context(event=None, terminal=terminal, state=terminal.state)
+        invoke_hook(grid.grid_post_init, None, ctx)
     terminal._attached_frame_grids.append(grid)
 
 
@@ -900,10 +978,16 @@ def merge_hooks(
         terminal._hooks.on_focus_hooks.append(
             _OnFocusHookFunctionEntry(
                 field=entry["field"],
+                group=entry["group"],
                 kind=entry["kind"],
                 handler=rebind_hook_handler(entry["handler"], grid),
             )
         )
+
+    terminal._hooks.on_click_group_hooks.extend(
+        rebind_hook_handler(handler, grid)
+        for handler in other.on_click_group_hooks
+    )
 
     for entry in other.on_poll_hooks:
         terminal._hooks.on_poll_hooks.append(
@@ -926,6 +1010,8 @@ def merge_hooks(
         handler = entry["handler"]
         if (
             getattr(handler, _EventHooksRegistry.ON_MOUSE_FIELD_ATTR, None)
+            is not None
+            or getattr(handler, _EventHooksRegistry.ON_MOUSE_GROUP_ATTR, None)
             is not None
         ):
             continue

--- a/xnano/_function_hooks.py
+++ b/xnano/_function_hooks.py
@@ -92,6 +92,7 @@ FocusHookKind: TypeAlias = Literal["gained", "lost"]
 
 class _OnFocusHookFunctionEntry(TypedDict):
     field: str | None
+    group: str | None
     kind: FocusHookKind | None
     handler: EventHookFunction
 
@@ -109,6 +110,7 @@ class _EventHooksRegistry:
     ON_CLIPBOARD_HOOK_ATTR: ClassVar[str] = "__xnano_on_clipboard__"
     ON_FOCUS_HOOK_ATTR: ClassVar[str] = "__xnano_on_focus__"
     ON_FOCUS_FIELD_ATTR: ClassVar[str] = "__xnano_on_focus_field__"
+    ON_FOCUS_GROUP_ATTR: ClassVar[str] = "__xnano_on_focus_group__"
     ON_FOCUS_KIND_ATTR: ClassVar[str] = "__xnano_on_focus_kind__"
     ON_POLL_HOOK_ATTR: ClassVar[str] = "__xnano_on_poll__"
     ON_POLL_WHEN_ATTR: ClassVar[str] = "__xnano_on_poll_when__"
@@ -117,6 +119,7 @@ class _EventHooksRegistry:
     ON_KEYBOARD_FILTER_ATTR: ClassVar[str] = "__xnano_on_keyboard_filter__"
     ON_MOUSE_FILTER_ATTR: ClassVar[str] = "__xnano_on_mouse_filter__"
     ON_MOUSE_FIELD_ATTR: ClassVar[str] = "__xnano_on_mouse_field__"
+    ON_MOUSE_GROUP_ATTR: ClassVar[str] = "__xnano_on_mouse_group__"
     ON_TICK_INTERVAL_ATTR: ClassVar[str] = "__xnano_on_tick_interval__"
     ON_STATE_EXPRESSION_ATTR: ClassVar[str] = "__xnano_on_state_expression__"
     ON_FIELD_HOOK_ATTR: ClassVar[str] = "__xnano_on_field__"
@@ -138,6 +141,9 @@ class _EventHooksRegistry:
         default_factory=list, init=False
     )
     on_focus_hooks: list[_OnFocusHookFunctionEntry] = dataclasses.field(
+        default_factory=list, init=False
+    )
+    on_click_group_hooks: list[EventHookFunction] = dataclasses.field(
         default_factory=list, init=False
     )
     on_poll_hooks: list[_OnPollHookFunctionEntry] = dataclasses.field(
@@ -196,10 +202,13 @@ class _EventHooksRegistry:
             self.on_focus_hooks.append(
                 _OnFocusHookFunctionEntry(
                     field=getattr(handler, self.ON_FOCUS_FIELD_ATTR, None),
+                    group=getattr(handler, self.ON_FOCUS_GROUP_ATTR, None),
                     kind=getattr(handler, self.ON_FOCUS_KIND_ATTR, None),
                     handler=handler,
                 )
             )
+        if hasattr(handler, self.ON_MOUSE_GROUP_ATTR):
+            self.on_click_group_hooks.append(handler)
         if hasattr(handler, self.ON_POLL_HOOK_ATTR):
             when = getattr(handler, self.ON_POLL_WHEN_ATTR, "idle")
             self.on_poll_hooks.append(
@@ -256,6 +265,7 @@ class _EventHooksRegistry:
         registry.on_focus_hooks = [
             entry.copy() for entry in cached.on_focus_hooks
         ]
+        registry.on_click_group_hooks = cached.on_click_group_hooks.copy()
         registry.on_poll_hooks = [
             entry.copy() for entry in cached.on_poll_hooks
         ]
@@ -337,6 +347,8 @@ class _EventHooksRegistry:
                             handler=member,
                         )
                     )
+                if hasattr(member, cls.ON_MOUSE_GROUP_ATTR):
+                    registry.on_click_group_hooks.append(member)
                 if hasattr(member, cls.ON_RESIZE_HOOK_ATTR):
                     registry.on_resize_hooks.append(member)
                 if hasattr(member, cls.ON_CLIPBOARD_HOOK_ATTR):
@@ -346,6 +358,9 @@ class _EventHooksRegistry:
                         _OnFocusHookFunctionEntry(
                             field=getattr(
                                 member, cls.ON_FOCUS_FIELD_ATTR, None
+                            ),
+                            group=getattr(
+                                member, cls.ON_FOCUS_GROUP_ATTR, None
                             ),
                             kind=getattr(member, cls.ON_FOCUS_KIND_ATTR, None),
                             handler=member,

--- a/xnano/_types.py
+++ b/xnano/_types.py
@@ -37,6 +37,12 @@ Values:
 """
 
 
+ScrollLike: TypeAlias = "bool | Literal['vertical', 'horizontal', 'auto']"
+"""``Field(scroll=...)`` value. ``True`` scrolls along the field's
+``direction``; ``"vertical"``/``"horizontal"`` force an axis; ``"auto"``
+scrolls only when content overflows the slot."""
+
+
 Axis: TypeAlias = Literal["x", "y"]
 """The axis along which a grid field or area should be laid out.
 
@@ -1021,6 +1027,126 @@ def get_focusable_component(grid: Any, field_name: str) -> Any | None:
     return None
 
 
+def field_group(grid: Any, field_name: str) -> str | None:
+    """Return the ``group`` declared on ``grid.field_name``, if any."""
+    info_getter = getattr(grid, "_grid_field_info", None)
+    if info_getter is None:
+        return None
+    try:
+        return info_getter(field_name).group
+    except (KeyError, AttributeError):
+        return None
+
+
+def collect_group_targets(terminal: Terminal[Any]) -> dict[str, FieldFocus]:
+    """Map ``group`` name -> ``(grid, field_name)`` from the last frame.
+
+    Unlike ``collect_focusable_fields``, every layout field is eligible —
+    a ``group`` can label a non-focusable field too (e.g. a scrollable
+    transcript), not just editable inputs. First occurrence wins when two
+    fields declare the same group.
+    """
+    result: dict[str, FieldFocus] = {}
+    for grid in terminal._attached_frame_grids:
+        fields = getattr(type(grid), "_grid_fields", None) or getattr(
+            grid, "_grid_fields", {}
+        )
+        for field_name in fields:
+            group = field_group(grid, field_name)
+            if group and group not in result:
+                result[group] = FieldFocus(grid=grid, field_name=field_name)
+    return result
+
+
+def resolve_group_target(
+    terminal: Terminal[Any], group: str
+) -> FieldFocus | None:
+    """Return the ``(grid, field_name)`` currently labeled ``group``."""
+    return collect_group_targets(terminal).get(group)
+
+
+def focus_group(
+    terminal: Terminal[Any],
+    group: str,
+    *,
+    fire_hooks: bool = True,
+) -> bool:
+    """Focus the field labeled ``group``, regardless of which grid it's on.
+
+    Returns:
+        ``True`` when a field with this group was found and is focusable.
+    """
+    target = resolve_group_target(terminal, group)
+    if target is None:
+        return False
+    return set_field_focus(
+        terminal, target.grid, target.field_name, fire_hooks=fire_hooks
+    )
+
+
+def focused_group_name(terminal: Terminal[Any]) -> str | None:
+    """Return the ``group`` of the currently focused field, if any."""
+    current = getattr(terminal, "_field_focus", None)
+    if current is None:
+        return None
+    return field_group(current.grid, current.field_name)
+
+
+def is_group_focused(terminal: Terminal[Any], group: str) -> bool:
+    """Return whether the field labeled ``group`` currently holds focus."""
+    return focused_group_name(terminal) == group
+
+
+@dataclasses.dataclass(slots=True)
+class ScrollHandle:
+    """Programmatic control for a ``Field(scroll=...)`` field, resolved by
+    ``group`` — see ``ctx.scroll(group)``.
+
+    Attributes:
+        offset: Items back from the end currently shown (``0`` = pinned to
+            the most recent / bottom item).
+        follow: When ``True``, the field re-pins to ``offset=0`` whenever
+            new items are appended (persists across frames).
+    """
+
+    grid: Any
+    field_name: str
+
+    @property
+    def offset(self) -> int:
+        return self.grid._grid_field_scroll_offset(self.field_name)
+
+    @offset.setter
+    def offset(self, value: int) -> None:
+        self.grid._grid_set_field_scroll_offset(self.field_name, value)
+
+    @property
+    def follow(self) -> bool:
+        return self.grid._grid_field_scroll_follow(self.field_name)
+
+    @follow.setter
+    def follow(self, value: bool) -> None:
+        self.grid._grid_set_field_scroll_follow(self.field_name, value)
+
+    def to_bottom(self) -> None:
+        """Jump to the most recent item (``offset = 0``)."""
+        self.offset = 0
+
+    def scroll_by(self, delta: int) -> None:
+        """Move the window by ``delta`` items (positive = toward older)."""
+        self.offset = max(0, self.offset + delta)
+
+
+def scroll_handle_for_group(
+    terminal: Terminal[Any], group: str
+) -> ScrollHandle | None:
+    """Return a ``ScrollHandle`` for the field labeled ``group``, if any."""
+    target = resolve_group_target(terminal, group)
+    if target is None:
+        return None
+    return ScrollHandle(grid=target.grid, field_name=target.field_name)
+
+
 def collect_focusable_fields(terminal: Terminal[Any]) -> list[FieldFocus]:
     """Collect focusable input fields in paint/declaration order.
 
@@ -1251,7 +1377,11 @@ def cycle_field_focus(
 
 
 def ensure_default_field_focus(terminal: Terminal[Any]) -> None:
-    """Focus the first input field when nothing is focused yet."""
+    """Focus the default input field when nothing is focused yet.
+
+    Prefers a field declared ``Field(autofocus=True)`` over plain
+    declaration-order (the first focusable field encountered).
+    """
     current = getattr(terminal, "_field_focus", None)
     if current is not None:
         sync_input_focus_flags(terminal)
@@ -1261,13 +1391,26 @@ def ensure_default_field_focus(terminal: Terminal[Any]) -> None:
             _fire_field_focus_hooks(terminal, current, kind="gained")
         return
     targets = collect_focusable_fields(terminal)
-    if targets:
-        set_field_focus(
-            terminal,
-            targets[0].grid,
-            targets[0].field_name,
-            fire_hooks=True,
-        )
+    if not targets:
+        return
+    pick = next(
+        (
+            target
+            for target in targets
+            if getattr(
+                target.grid._grid_field_info(target.field_name),
+                "autofocus",
+                False,
+            )
+        ),
+        targets[0],
+    )
+    set_field_focus(
+        terminal,
+        pick.grid,
+        pick.field_name,
+        fire_hooks=True,
+    )
 
 
 def place_cursor_for_focus(terminal: Terminal[Any]) -> None:
@@ -1319,16 +1462,22 @@ def _fire_field_focus_hooks(
     )
     ctx = Context(event=None, terminal=terminal, state=terminal.state)
     terminal._last_field_focus_event = focus_data
+    target_group = field_group(target.grid, target.field_name)
 
     for entry in terminal._hooks.on_focus_hooks:
         field_filter = entry["field"]
+        group_filter = entry.get("group")
         kind_filter = entry["kind"]
         handler = entry["handler"]
 
-        if field_filter is None:
+        if group_filter is not None:
+            if group_filter != target_group:
+                continue
+        elif field_filter is not None:
+            if field_filter != target.field_name:
+                continue
+        else:
             # Terminal-only focus hooks ignore field focus transitions.
-            continue
-        if field_filter != target.field_name:
             continue
         if kind_filter is not None and kind_filter != kind:
             continue
@@ -1355,6 +1504,7 @@ __all__ = (
     "Direction",
     "CharacterModifier",
     "PaddingLike",
+    "ScrollLike",
     "ScrollbarOrientationLike",
     "CanvasMarkerLike",
     "GraphTypeLike",

--- a/xnano/cli/command.py
+++ b/xnano/cli/command.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import sys
-from typing import Any, Callable
+from typing import Any, Callable, get_type_hints
 
 from xnano import _validation as validation
 
@@ -94,6 +94,9 @@ class Command:
     )
     _parameters: list[CommandLineParameter] = dataclasses.field(
         default_factory=list, init=False
+    )
+    _option_by_flag: dict[str, CommandLineParameter] = dataclasses.field(
+        default_factory=dict, init=False
     )
 
     @staticmethod
@@ -205,10 +208,10 @@ class Command:
         Args:
             func: The function to inspect.
         """
+        self._parameters.clear()
+        self._option_by_flag.clear()
         signature = inspect.signature(func)
         try:
-            from typing import get_type_hints
-
             type_hints = get_type_hints(func)
         except Exception:
             type_hints = {}
@@ -272,6 +275,8 @@ class Command:
                         explicit=True,
                     )
                 )
+                for flag in flags:
+                    self._option_by_flag[flag] = self._parameters[-1]
             else:
                 flag_name = "--" + name.replace("_", "-")
                 is_flag = annotation is bool or (
@@ -289,6 +294,7 @@ class Command:
                         explicit=False,
                     )
                 )
+                self._option_by_flag[flag_name] = self._parameters[-1]
 
     def parse_arguments(
         self, arguments: list[str]
@@ -307,30 +313,31 @@ class Command:
             HelpException: If help is requested.
             ValueError: If parsing or validation fails.
         """
-        option_by_flag = {}
-        for param in self._parameters:
-            if param.flags:
-                for flag in param.flags:
-                    option_by_flag[flag] = param
-
         parsed_values = {}
         positional_params = list(self._parameters)
+        positional_index = 0
+        options_enabled = True
 
         index = 0
         while index < len(arguments):
             arg = arguments[index]
 
-            if self.help and arg in ("--help", "-h"):
+            if options_enabled and arg == "--":
+                options_enabled = False
+                index += 1
+                continue
+
+            if options_enabled and self.help and arg in ("--help", "-h"):
                 raise HelpException(self)
 
-            if arg.startswith("-"):
+            if options_enabled and arg.startswith("-") and arg != "-":
                 if "=" in arg:
                     flag, val = arg.split("=", 1)
                 else:
                     flag = arg
                     val = None
 
-                param = option_by_flag.get(flag)
+                param = self._option_by_flag.get(flag)
                 if not param:
                     raise ValueError(f"Unknown option: {flag}")
 
@@ -354,15 +361,17 @@ class Command:
                     sub_cmd = self._subcommands[arg]
                     return sub_cmd.parse_arguments(arguments[index + 1 :])
 
-                # Match to the first remaining positional parameter that hasn't been set yet
-                matched_param = None
-                for p in positional_params:
-                    if p.parameter_name not in parsed_values:
-                        matched_param = p
-                        break
+                while (
+                    positional_index < len(positional_params)
+                    and positional_params[positional_index].parameter_name
+                    in parsed_values
+                ):
+                    positional_index += 1
 
-                if matched_param:
+                if positional_index < len(positional_params):
+                    matched_param = positional_params[positional_index]
                     parsed_values[matched_param.parameter_name] = arg
+                    positional_index += 1
                 else:
                     if self._subcommands:
                         raise ValueError(
@@ -470,7 +479,9 @@ class Command:
             lines.append("Arguments:")
             for arg in arguments_list:
                 help_text = arg.help or ""
-                desc = f"  {arg.parameter_name.upper():<20} {help_text}"
+                desc = (
+                    f"  {arg.parameter_name.upper():<20} {help_text}".rstrip()
+                )
                 if arg.default is not UNSET:
                     desc += f" (default: {arg.default})"
                 lines.append(desc)
@@ -481,7 +492,7 @@ class Command:
             for opt in options_list:
                 flags_str = ", ".join(opt.flags or [])
                 help_text = opt.help or ""
-                desc = f"  {flags_str:<20} {help_text}"
+                desc = f"  {flags_str:<20} {help_text}".rstrip()
                 if opt.default is not UNSET:
                     desc += f" [default: {opt.default}]"
                 lines.append(desc)

--- a/xnano/color.py
+++ b/xnano/color.py
@@ -867,6 +867,34 @@ class Color:
             f"or Color instance), got {type(color).__name__!r} instead."
         )
 
+    def as_hex(self, *, include_alpha: bool = False) -> str:
+        """Return this color as a ``#rrggbb`` (or ``#rrggbbaa``) hex string.
+
+        Args:
+            include_alpha: When ``True``, append the alpha channel as a
+                two-digit hex suffix.
+
+        Returns:
+            A lowercase, leading-``#`` hex color string.
+        """
+        hex_str = f"#{self.r:02x}{self.g:02x}{self.b:02x}"
+        if include_alpha:
+            hex_str += f"{round(self.a):02x}"
+        return hex_str
+
+    def as_rgb_tuple(
+        self, *, include_alpha: bool = False
+    ) -> "tuple[int, int, int] | tuple[int, int, int, float]":
+        """Return this color as an ``(r, g, b)`` or ``(r, g, b, a)`` tuple.
+
+        Args:
+            include_alpha: When ``True``, include the alpha channel as the
+                fourth tuple element.
+        """
+        if include_alpha:
+            return (self.r, self.g, self.b, self.a)
+        return (self.r, self.g, self.b)
+
 
 def pydantic_color(color: ColorName) -> Color:
     """Creates a new ``Color`` instance from a known color name derived

--- a/xnano/components/select.py
+++ b/xnano/components/select.py
@@ -147,6 +147,30 @@ class Select(AbstractComponent):
         )
 
     @property
+    def filtered(self) -> tuple[int, ...]:
+        """Indices into ``items`` currently visible, in display order.
+
+        The public counterpart of the internal match-scored ``_filtered()``
+        — use this (or ``visible_items``) instead of reaching into the
+        private method just to learn what's currently on screen.
+        """
+        return tuple(index for index, _ in self._filtered())
+
+    def move(self, delta: int) -> None:
+        """Move ``selected`` by ``delta``, clamped to the filtered view.
+
+        Equivalent to hand-clamping ``selected`` against ``filtered``
+        yourself — the safe way to move the highlight from a keyboard
+        handler without under/overflowing the visible range.
+        """
+        visible_count = len(self._filtered())
+        if visible_count == 0:
+            self.selected = 0
+            return
+        current = max(0, min(self.selected, visible_count - 1))
+        self.selected = max(0, min(visible_count - 1, current + delta))
+
+    @property
     def value(self) -> str | None:
         """Plain text of the selected item, or ``None`` when the
         filtered view is empty."""

--- a/xnano/components/text.py
+++ b/xnano/components/text.py
@@ -9,7 +9,7 @@ editable input fields.
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Sequence
 
 from xnano._types import Alignment, CharacterModifier
 from xnano.components.abstract import AbstractComponent
@@ -110,6 +110,11 @@ class Text(AbstractComponent):
     language: str | None = None
     """Syntax-highlight ``content`` as this language (a Pygments lexer
     name such as ``"python"``); no markdown parsing."""
+    passthrough: Sequence[str] = ()
+    """Key bindings this input never captures, even while focused (e.g.
+    ``("ctrl+c", "up", "down")``) — ``handle_keyboard`` returns ``False``
+    for them immediately, so they bubble to ``@on_keyboard`` app hooks
+    instead of being consumed as text editing."""
     _input_focused: bool = dataclasses.field(
         default=False, init=False, repr=False, compare=False
     )
@@ -457,6 +462,8 @@ class Text(AbstractComponent):
         Returns:
             ``True`` when the key was consumed as text editing.
         """
+        if self.passthrough and keyboard.matches(*self.passthrough):
+            return False
         if self._editor is not None:
             native = getattr(keyboard, "_native_event", None)
             if native is None:

--- a/xnano/context.py
+++ b/xnano/context.py
@@ -12,6 +12,7 @@ import dataclasses
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 if TYPE_CHECKING:
+    from xnano._types import ScrollHandle
     from xnano.core.actions import Actions
     from xnano.core.hosts import AbstractHost
     from xnano.core.stage import Stage
@@ -42,7 +43,7 @@ class Context(Generic[StateT]):
     state: StateT
 
     @property
-    def host(self) -> "Terminal[StateT] | AbstractHost":
+    def host(self) -> "AbstractHost":
         """Active host for this context (alias of ``terminal``).
 
         Named ``host`` so code that is interface-kind-agnostic can avoid
@@ -71,33 +72,52 @@ class Context(Generic[StateT]):
         return self.state
 
     @property
-    def cursor(self) -> "TerminalCursor | None":
+    def cursor(self) -> "TerminalCursor":
         """Cursor / caret controls for the active host (show, hide, style)."""
-        return None if self.terminal is None else self.terminal.cursor
+        return self.terminal.cursor
 
     @property
-    def device(self) -> "TerminalDevice | None":
+    def device(self) -> "TerminalDevice":
         """Device controls for the active host (title, clear, size, clipboard)."""
-        return None if self.terminal is None else self.terminal.device
+        return self.terminal.device
 
     @property
-    def actions(self) -> "Actions | None":
+    def actions(self) -> "Actions":
         """Perform synthetic input and requests (``press``, ``click``, …)."""
-        if self.terminal is None:
-            return None
-        getter = getattr(self.terminal, "actions", None)
-        if getter is None:
-            return None
-        return getter if not callable(getter) else self.terminal.actions  # type: ignore[return-value]
+        return self.terminal.actions
 
     @property
-    def stage(self) -> "Stage | None":
+    def stage(self) -> "Stage":
         """Layout map and cell-level paint / wireframe for the active host."""
-        if self.terminal is None:
-            return None
-        if not hasattr(self.terminal, "stage"):
-            return None
-        return self.terminal.stage  # type: ignore[return-value]
+        return self.terminal.stage
+
+    def focus(self, group: str) -> bool:
+        """Focus the field labeled ``group``, on any attached grid.
+
+        Terminal-global — no grid reference or nesting knowledge required.
+        See ``Field(group=...)``.
+        """
+        return self.terminal.focus_group(group)
+
+    @property
+    def focused_group(self) -> str | None:
+        """``group`` of the currently focused field, or ``None``."""
+        return self.terminal.focused_group
+
+    def is_focused(self, group: str) -> bool:
+        """Return whether the field labeled ``group`` currently holds focus."""
+        return self.focused_group == group
+
+    def scroll(self, group: str) -> "ScrollHandle | None":
+        """Return a scroll handle for the ``Field(scroll=...)`` field
+        labeled ``group``, or ``None`` when no such field is attached.
+
+            ctx.scroll("transcript").to_bottom()
+            ctx.scroll("transcript").follow = True
+        """
+        from xnano._types import scroll_handle_for_group
+
+        return scroll_handle_for_group(self.terminal, group)
 
     def with_scope(self, **kwargs: Any) -> "Context[StateT]":
         """Return a shallow copy with the given fields replaced."""

--- a/xnano/core/controllers/abstract.py
+++ b/xnano/core/controllers/abstract.py
@@ -235,7 +235,7 @@ class AbstractController(abc.ABC):
         )
 
     def measure_field_slot(
-        self, value: Any, direction: Direction, field: GridFieldInfo
+        self, value: Any, direction: Direction, field: GridFieldInfo | None
     ) -> int:
         """Measures the size of a given slot based on a given value, direction,
         and grid field info.

--- a/xnano/core/controllers/tui.py
+++ b/xnano/core/controllers/tui.py
@@ -172,6 +172,45 @@ class RenderRequest(Generic[StateT]):
     """Optional ``CoreRenderIR`` object (bypasses native widget wrapping)."""
 
 
+def compute_scroll_window(
+    lengths: Sequence[int],
+    gap: int,
+    available: int,
+    offset_from_bottom: int,
+) -> tuple[int, int]:
+    """Return ``(start, end)`` indices of the suffix window that fits.
+
+    ``offset_from_bottom=0`` anchors the window at the last item (pinned
+    to bottom); larger values shift the window toward older items. Items
+    are added greedily from the anchor backward while they still fit
+    within ``available`` — always including at least one item.
+
+    Args:
+        lengths: Content length of each item along the scroll axis.
+        gap: Space reserved between consecutive items.
+        available: Total space available along the scroll axis.
+        offset_from_bottom: How many items back from the end to anchor.
+
+    Returns:
+        A ``(start, end)`` slice into ``lengths``/the source item sequence.
+    """
+    n = len(lengths)
+    if n == 0:
+        return (0, 0)
+    end = max(1, n - max(0, offset_from_bottom))
+    start = end
+    total = 0
+    while start > 0:
+        candidate = lengths[start - 1]
+        extra_gap = gap if total > 0 else 0
+        new_total = total + extra_gap + candidate
+        if new_total > available and total > 0:
+            break
+        total = new_total
+        start -= 1
+    return (start, end)
+
+
 class TerminalController(AbstractController, Generic[StateT]):
     """Live-terminal implementation of ``AbstractController``.
 
@@ -450,7 +489,7 @@ class TerminalController(AbstractController, Generic[StateT]):
         self,
         value: Any,
         direction: Direction,
-        field: "GridFieldInfo",
+        field: "GridFieldInfo | None",
     ) -> int:
         """Return the content length along ``direction`` for a slot value."""
         if value is None:
@@ -548,6 +587,24 @@ class TerminalController(AbstractController, Generic[StateT]):
             return
         self.paint_node(node, area, z=z, effect_key=effect_key)
 
+    def paint_field_wireframe(self, area: Area) -> None:
+        """Overlay a thin per-cell grid lattice across ``area``.
+
+        Content already painted into ``area`` this frame is unaffected —
+        this is a debug overlay only (``Field(wireframe=True)``), composited
+        at a high z so it's visible on top of normal content.
+        """
+        if area.width <= 0 or area.height <= 0:
+            return
+        row = "·" * area.width
+        node = ParagraphNode(
+            text="\n".join([row] * area.height),
+            color="slate-500",
+            modifiers=("dim",),
+            wrap=False,
+        )
+        self.paint_node(node, area, z=9_000)
+
     def render_component(
         self,
         component: AbstractComponent,
@@ -611,11 +668,120 @@ class TerminalController(AbstractController, Generic[StateT]):
         *,
         parent_z: int = 0,
         effect_key: str | None = None,
+        owner: Any | None = None,
+        owner_field_name: str | None = None,
     ) -> None:
-        """Dispatch-render a layout field's value into ``area``."""
+        """Dispatch-render a layout field's value into ``area``.
+
+        ``owner``/``owner_field_name`` identify the ``BaseGrid`` instance
+        and field name this value belongs to — only used for
+        ``Field(scroll=...)`` windowing, which needs a stable place to
+        persist scroll offset across frames.
+        """
         if value is None:
             return
 
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            self._paint_container_field(
+                value,
+                area,
+                field,
+                parent_z=parent_z,
+                effect_key=effect_key,
+                owner=owner,
+                owner_field_name=owner_field_name,
+            )
+            return
+
+        self._paint_scalar_field_slot(
+            value, area, field, parent_z=parent_z, effect_key=effect_key
+        )
+
+    def _paint_container_field(
+        self,
+        items: Sequence[Any],
+        area: Area,
+        field: "GridFieldInfo | None",
+        *,
+        parent_z: int = 0,
+        effect_key: str | None = None,
+        owner: Any | None = None,
+        owner_field_name: str | None = None,
+    ) -> None:
+        """Lay ``items`` out as child slots along ``field.direction``.
+
+        One level of container semantics only: each item is painted
+        through ``_paint_scalar_field_slot`` (not the full
+        ``paint_field_slot`` ladder), so a nested list/tuple item falls
+        through to its ``str()`` representation rather than being
+        expanded into a further container.
+        """
+        if not items:
+            return
+
+        direction: Direction = (
+            field.direction
+            if field is not None and field.direction is not None
+            else "vertical"
+        )
+        gap = field.gap if field is not None and field.gap else 0
+        lengths = [
+            max(1, self.measure_field_slot(item, direction, field))
+            for item in items
+        ]
+
+        start = 0
+        end = len(items)
+        if (
+            field is not None
+            and field.scroll
+            and owner is not None
+            and owner_field_name is not None
+        ):
+            available = area.height if direction == "vertical" else area.width
+            if owner._grid_field_scroll_follow(owner_field_name):
+                previous_count = getattr(
+                    owner, "_grid_field_scroll_item_counts", {}
+                ).get(owner_field_name, 0)
+                if len(items) > previous_count:
+                    owner._grid_set_field_scroll_offset(owner_field_name, 0)
+                owner.__dict__.setdefault(
+                    "_grid_field_scroll_item_counts", {}
+                )[owner_field_name] = len(items)
+            offset = owner._grid_field_scroll_offset(owner_field_name)
+            start, end = compute_scroll_window(lengths, gap, available, offset)
+            # Clamp the stored offset so it never points past the top.
+            max_offset = max(0, len(items) - 1)
+            if offset > max_offset:
+                owner._grid_set_field_scroll_offset(
+                    owner_field_name, max_offset
+                )
+
+        window_items = items[start:end]
+        window_lengths = lengths[start:end]
+        constraints = [
+            LayoutConstraint("content", length) for length in window_lengths
+        ]
+        slot_areas = self.split_layout(area, direction, gap, constraints)
+        for item, slot_area in zip(window_items, slot_areas):
+            self._paint_scalar_field_slot(
+                item,
+                slot_area,
+                field,
+                parent_z=parent_z,
+                effect_key=effect_key,
+            )
+
+    def _paint_scalar_field_slot(
+        self,
+        value: Any,
+        area: Area,
+        field: "GridFieldInfo | None",
+        *,
+        parent_z: int = 0,
+        effect_key: str | None = None,
+    ) -> None:
+        """Dispatch-render a single (non-container) field value."""
         from xnano.grid import BaseGrid
 
         if isinstance(value, BaseGrid):

--- a/xnano/core/hosts.py
+++ b/xnano/core/hosts.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 import abc
 import collections
 import contextvars
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from xnano.core.device import AbstractCursor, AbstractDevice
 from xnano.core.exceptions import HookError
+
+if TYPE_CHECKING:
+    from xnano.core.actions import Actions
+    from xnano.core.stage import Stage
 
 _MAX_PERFORM_DEPTH: int = 32
 """Maximum actions drained from a single ``perform`` chain.
@@ -153,7 +157,7 @@ class AbstractHost(abc.ABC):
         """Cursor / caret controls for this host (visibility and style)."""
 
     @property
-    def actions(self) -> Any:
+    def actions(self) -> "Actions":
         """Perform synthetic input and requests against this host.
 
         Returns:
@@ -166,7 +170,7 @@ class AbstractHost(abc.ABC):
         return self._actions
 
     @property
-    def stage(self) -> Any:
+    def stage(self) -> "Stage":
         """Layout map and cell-level paint / wireframe for this host.
 
         Returns:

--- a/xnano/events.py
+++ b/xnano/events.py
@@ -760,6 +760,7 @@ def _decorate_on_mouse_hook(
     buttons: tuple[str, ...] = (),
     kind: MouseEventKind | None = None,
     field: str | None = None,
+    group: str | None = None,
 ) -> EventHookFunction:
     """Decorate a hook function with the ``@on_mouse`` decorator.
 
@@ -768,6 +769,8 @@ def _decorate_on_mouse_hook(
         buttons: The buttons to filter the hook function by.
         kind: The kind of mouse event to filter the hook function by.
         field: The field to filter the hook function by.
+        group: The terminal-global group to filter the hook function by
+            (nesting-independent — see ``Field(group=...)``).
 
     Returns:
         The decorated hook function.
@@ -789,6 +792,8 @@ def _decorate_on_mouse_hook(
     )
     if field is not None:
         setattr(fn, _EventHooksRegistry.ON_MOUSE_FIELD_ATTR, field)
+    if group is not None:
+        setattr(fn, _EventHooksRegistry.ON_MOUSE_GROUP_ATTR, group)
     return _decorate_hook_function(fn)
 
 
@@ -933,20 +938,36 @@ def on_click(
     button: MouseButton = "left",
     kind: MouseEventKind = "press",
 ) -> EventHookFunction: ...
+@overload
 def on_click(
-    field_or_handler: "str | EventHookFunction",
+    *,
+    group: str,
+    button: MouseButton = "left",
+    kind: MouseEventKind = "press",
+) -> Callable[[EventHookFunction], EventHookFunction]: ...
+def on_click(
+    field_or_handler: "str | EventHookFunction | None" = None,
     /,
     *,
     field: str | None = None,
+    group: str | None = None,
     button: MouseButton = "left",
     kind: MouseEventKind = "press",
 ) -> "EventHookFunction | Callable[[EventHookFunction], EventHookFunction]":
-    """Register a click handler for a grid layout field.
+    """Register a click handler for a grid layout field, or a group.
+
+    A field-scoped handler binds to one field on the declaring grid class.
+    A group-scoped handler fires whenever any field sharing ``group`` is
+    clicked, regardless of which grid it lives on — see ``Field(group=...)``.
 
     Example:
         @on_click("body")
         def highlight_body(self, ctx: Context) -> None:
             self.body = Paragraph("clicked", color="red")
+
+        @on_click(group="composer")
+        def focus_composer(self, ctx: Context) -> None:
+            ctx.focus("composer")
     """
     if isinstance(field_or_handler, str):
         field_name = field_or_handler
@@ -961,13 +982,29 @@ def on_click(
 
         return decorator
 
-    if field is None:
-        raise TypeError("on_click requires a field name")
+    if field_or_handler is None:
+        if group is None and field is None:
+            raise TypeError("on_click requires a field name or a group")
+
+        def group_decorator(fn: EventHookFunction) -> EventHookFunction:
+            return _decorate_on_mouse_hook(
+                fn,
+                buttons=(button,),
+                kind=kind,
+                field=field,
+                group=group,
+            )
+
+        return group_decorator
+
+    if field is None and group is None:
+        raise TypeError("on_click requires a field name or a group")
     return _decorate_on_mouse_hook(
         field_or_handler,
         buttons=(button,),
         kind=kind,
         field=field,
+        group=group,
     )
 
 
@@ -1047,6 +1084,7 @@ def on_focus(
 def on_focus(
     *,
     field: str | None = None,
+    group: str | None = None,
     kind: FocusHookKind | None = None,
 ) -> Callable[[EventHookFunction], EventHookFunction]: ...
 def on_focus(
@@ -1054,13 +1092,17 @@ def on_focus(
     /,
     *,
     field: str | None = None,
+    group: str | None = None,
     kind: FocusHookKind | None = None,
 ) -> "EventHookFunction | Callable[[EventHookFunction], EventHookFunction]":
-    """Register a focus hook for the terminal window or a grid field.
+    """Register a focus hook for the terminal window, a field, or a group.
 
     Bare ``@on_focus`` fires on OS-level terminal focus gained/lost events.
     Pass a field name to listen for application field focus instead — the
-    caret moving onto/off an editable ``Text(input=True)`` field:
+    caret moving onto/off an editable ``Text(input=True)`` field. Pass
+    ``group=`` to listen across grids instead of one field — fires whenever
+    any field sharing that group (see ``Field(group=...)``) gains or loses
+    focus, regardless of which grid it lives on:
 
         @on_focus
         def _window(self, ctx: Context) -> None:
@@ -1073,17 +1115,24 @@ def on_focus(
         @on_focus("prompt", kind="lost")
         def _prompt_blurred(self) -> None:
             self.status = "left prompt"
+
+        @on_focus(group="composer")
+        def _composer_focused(self) -> None:
+            self.status = "editing"
     """
 
     def _decorate(
         fn: EventHookFunction,
         *,
         field_name: str | None,
+        group_name: str | None,
         focus_kind: FocusHookKind | None,
     ) -> EventHookFunction:
         setattr(fn, _EventHooksRegistry.ON_FOCUS_HOOK_ATTR, True)
         if field_name is not None:
             setattr(fn, _EventHooksRegistry.ON_FOCUS_FIELD_ATTR, field_name)
+        if group_name is not None:
+            setattr(fn, _EventHooksRegistry.ON_FOCUS_GROUP_ATTR, group_name)
         if focus_kind is not None:
             setattr(fn, _EventHooksRegistry.ON_FOCUS_KIND_ATTR, focus_kind)
         return _decorate_hook_function(fn)
@@ -1092,6 +1141,7 @@ def on_focus(
         return _decorate(
             handler_or_field,
             field_name=field,
+            group_name=group,
             focus_kind=kind,
         )
 
@@ -1100,7 +1150,12 @@ def on_focus(
     )
 
     def decorator(fn: EventHookFunction) -> EventHookFunction:
-        return _decorate(fn, field_name=resolved_field, focus_kind=kind)
+        return _decorate(
+            fn,
+            field_name=resolved_field,
+            group_name=group,
+            focus_kind=kind,
+        )
 
     return decorator
 

--- a/xnano/fields.py
+++ b/xnano/fields.py
@@ -200,6 +200,24 @@ class GridFieldInfo:
     """The padding to be applied around the content area of this field."""
     slide: list[str] | None = None
     """The axes along which this field may slide within its parent grid."""
+    group: str | None = None
+    """Terminal-global focus/event identifier. Fields on different grids
+    that share a ``group`` are addressed together by ``ctx.focus(group)``,
+    ``@on_focus(group=...)``, and ``@on_click(group=...)`` — no grid
+    reference or nesting knowledge required."""
+    autofocus: bool | None = None
+    """Whether this field receives focus by default when nothing else is
+    focused yet (preferred over declaration-order default selection)."""
+    scroll: "types.ScrollLike | None" = None
+    """Enable windowed scrolling for a container field whose content
+    overflows its slot. ``True`` scrolls along ``direction``; pass
+    ``"vertical"``/``"horizontal"`` to force an axis. See ``ctx.scroll(group)``
+    for programmatic control (``.to_bottom()``, ``.follow``)."""
+    wireframe: bool | None = None
+    """Live-toggle a debug overlay showing the cell grid this field
+    occupies. Content renders normally underneath; this only adds a thin
+    per-cell lattice on top. Toggle live via ``grid_set_field``/
+    ``grid_update_field``."""
     class_name: tuple[str, ...] | None = None
     """Tailwind CSS class tokens attached to this field.
 
@@ -333,6 +351,10 @@ def Field(
     padding: types.PaddingLike | None = None,
     margin: types.PaddingLike | None = None,
     slide: Sequence[types.Axis] | None = None,
+    group: str | None = None,
+    autofocus: bool | None = None,
+    scroll: types.ScrollLike | None = None,
+    wireframe: bool | None = None,
     class_name: ClassNameLike | None = None,
 ) -> Any: ...
 
@@ -362,6 +384,10 @@ def Field(
     padding: types.PaddingLike | None = None,
     margin: types.PaddingLike | None = None,
     slide: Sequence[types.Axis] | None = None,
+    group: str | None = None,
+    autofocus: bool | None = None,
+    scroll: types.ScrollLike | None = None,
+    wireframe: bool | None = None,
     class_name: ClassNameLike | None = None,
 ) -> _T: ...
 
@@ -390,6 +416,10 @@ def Field(
     padding: types.PaddingLike | None = None,
     margin: types.PaddingLike | None = None,
     slide: Sequence[types.Axis] | None = None,
+    group: str | None = None,
+    autofocus: bool | None = None,
+    scroll: types.ScrollLike | None = None,
+    wireframe: bool | None = None,
     class_name: ClassNameLike | None = None,
 ) -> _T: ...
 
@@ -419,6 +449,10 @@ def Field(
     padding: types.PaddingLike | None = None,
     margin: types.PaddingLike | None = None,
     slide: Sequence[types.Axis] | None = None,
+    group: str | None = None,
+    autofocus: bool | None = None,
+    scroll: types.ScrollLike | None = None,
+    wireframe: bool | None = None,
     class_name: ClassNameLike | None = None,
 ) -> Any: ...
 
@@ -447,6 +481,10 @@ def Field(
     padding: types.PaddingLike | None = None,
     margin: types.PaddingLike | None = None,
     slide: Sequence[types.Axis] | None = None,
+    group: str | None = None,
+    autofocus: bool | None = None,
+    scroll: types.ScrollLike | None = None,
+    wireframe: bool | None = None,
     class_name: ClassNameLike | None = None,
 ) -> GridFieldInfo:
     """Create a new grid field info instance.
@@ -556,6 +594,10 @@ def Field(
         padding=padding,
         margin=margin,
         slide=_normalize_slide_axes(slide),
+        group=group,
+        autofocus=autofocus,
+        scroll=scroll,
+        wireframe=wireframe,
         class_name=tokens,
     )  # type: ignore[return-value]
 

--- a/xnano/grid.py
+++ b/xnano/grid.py
@@ -182,6 +182,7 @@ _GRID_FIELD_CONFIG_KEYS: frozenset[str] = frozenset(
         "strict",
         "slide",
         "visible",
+        "wireframe",
         "color",
         "background",
         "width",
@@ -612,13 +613,15 @@ def _build_grid_init(
         else:
             required.append(name)
 
-    params = ["self", "*"]
-    params.extend(required)
-    for name in optional:
-        if name in factory_names:
-            params.append(f"{name}=__missing__")
-        else:
-            params.append(f"{name}=__defaults__['{name}']")
+    params = ["self"]
+    if required or optional:
+        params.append("*")
+        params.extend(required)
+        for name in optional:
+            if name in factory_names:
+                params.append(f"{name}=__missing__")
+            else:
+                params.append(f"{name}=__defaults__['{name}']")
 
     lines = [f"def __init__({', '.join(params)}):"]
     for name in required + optional:
@@ -984,6 +987,24 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
     def __post_init__(self) -> None:
         """Called at the end of the generated ``__init__``. Override to run post-construction logic."""
 
+    def grid_post_init(self) -> None:
+        """Called exactly once, when this grid is first attached to a live
+        terminal — after its own hooks are bound, before its first paint.
+
+        Unlike ``__post_init__`` (construction time, no terminal attached
+        yet), ``ctx``/``ctx.state`` are live here. Override with either
+        signature — the extra parameter is optional, matching every other
+        ``@on_*`` hook, dispatched by arity at runtime (see ``_call_hook``):
+
+            def grid_post_init(self) -> None: ...
+            def grid_post_init(self, ctx: Context[MyState]) -> None: ...
+
+        A static type checker sees the one-parameter form as an invalid
+        override (this base declares zero); that's a known false positive
+        for this flexible-arity hook pattern — add
+        ``# ty: ignore[invalid-method-override]`` on the override line.
+        """
+
     @property
     def focused(self) -> bool:
         """Whether any of this grid's fields currently holds field focus.
@@ -1192,7 +1213,8 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         if type(self)._grid_field_handlers:
             return True
         for field_name in self._grid_fields:
-            if self._grid_field_info(field_name).slide:
+            info = self._grid_field_info(field_name)
+            if info.slide or info.group or info.scroll:
                 return True
             value = getattr(self, field_name, None)
             if (
@@ -1230,20 +1252,119 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         self.__dict__.setdefault("_grid_field_positions", {})[name] = clamped
         return clamped
 
-    def field_position(self, name: str) -> tuple[int, int]:
+    def grid_field_position(self, name: str) -> tuple[int, int]:
         """Return the parent-relative slide offset for a layout field."""
         return self._grid_field_position(name)
+
+    def _grid_field_scroll_offset(self, name: str) -> int:
+        offsets = getattr(self, "_grid_field_scroll_offsets", None)
+        if offsets and name in offsets:
+            return offsets[name]
+        return 0
+
+    def _grid_set_field_scroll_offset(self, name: str, offset: int) -> None:
+        self.__dict__.setdefault("_grid_field_scroll_offsets", {})[name] = max(
+            0, offset
+        )
+
+    def _grid_field_scroll_follow(self, name: str) -> bool:
+        follow = getattr(self, "_grid_field_scroll_follow_flags", None)
+        if follow and name in follow:
+            return follow[name]
+        return False
+
+    def _grid_set_field_scroll_follow(self, name: str, follow: bool) -> None:
+        self.__dict__.setdefault("_grid_field_scroll_follow_flags", {})[
+            name
+        ] = follow
 
     def _grid_field_needs_hit(
         self, field_name: str, field: GridFieldInfo
     ) -> bool:
         if field.slide:
             return True
+        if field.group or field.scroll:
+            return True
         if _resolve_grid_mouse_handler(self, field_name) is not None:
             return True
         from xnano._types import is_focusable_component
 
         return is_focusable_component(getattr(self, field_name, None))
+
+    def _grid_apply_field_config(
+        self,
+        name: str,
+        field_config: dict[str, Any],
+        *,
+        caller: str,
+    ) -> None:
+        """Validate and store per-instance style/layout overrides for ``name``.
+
+        Shared by ``grid_set_field`` and ``grid_update_field`` — the only
+        difference between the two callers is which keyword arguments they
+        expose; the validation and override-storage logic is identical.
+        """
+        if name in self._grid_state_fields:
+            raise TypeError(
+                f"{caller}() cannot be used on state field {name!r} on "
+                f"{type(self).__name__}"
+            )
+        if name not in self._grid_fields:
+            raise AttributeError(
+                f"{type(self).__name__} has no layout field {name!r}"
+            )
+
+        forbidden = _GRID_FIELD_IMMUTABLE_KEYS & field_config.keys()
+        if forbidden:
+            raise TypeError(
+                f"{caller}() does not accept {', '.join(sorted(forbidden))}"
+            )
+
+        unknown = set(field_config) - _GRID_FIELD_CONFIG_KEYS
+        if unknown:
+            raise TypeError(
+                f"{caller}() got unexpected keyword arguments: "
+                f"{', '.join(sorted(unknown))}"
+            )
+
+        if not field_config:
+            return
+
+        if "class_name" in field_config:
+            field_config = _expand_field_class_name_config(field_config)
+        if any(key in field_config for key in _GRID_MODIFIER_FLAG_KEYS):
+            field_config = _apply_field_modifier_flags(
+                field_config,
+                self._grid_field_info(name).modifiers,
+            )
+        if "slide" in field_config:
+            field_config = {
+                **field_config,
+                "slide": _normalize_slide_axes(field_config["slide"]),
+            }
+        if "width" in field_config or "height" in field_config:
+            from xnano._types import Sizing
+
+            normalized = dict(field_config)
+            if "width" in normalized:
+                normalized["width"] = Sizing.parse(normalized["width"])
+            if "height" in normalized:
+                normalized["height"] = Sizing.parse(normalized["height"])
+            field_config = normalized
+
+        current = self._grid_field_info(name)
+        # A no-op toggle (setting an attribute to the value it already
+        # has) skips override creation entirely — cheap to call every
+        # frame, and doesn't permanently drop the grid out of the static
+        # layout fast path for a change that didn't change anything.
+        if all(
+            getattr(current, key) == value
+            for key, value in field_config.items()
+        ):
+            return
+
+        overrides = self.__dict__.setdefault("_grid_field_overrides", {})
+        overrides[name] = dataclasses.replace(current, **field_config)
 
     def grid_set_field(
         self,
@@ -1254,6 +1375,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         strict: bool = UNSET,
         slide: Sequence[Axis] | None = UNSET,
         visible: bool | None = UNSET,
+        wireframe: bool | None = UNSET,
         color: ColorLike | None = UNSET,
         background: ColorLike | None = UNSET,
         width: SizingLike | None = UNSET,
@@ -1282,6 +1404,10 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
 
         Cannot be used on state fields. ``default``, ``default_factory``,
         ``init``, and ``state`` cannot be changed at runtime.
+
+        For frequent, value-free style ticks (e.g. from ``on_tick`` or an
+        effect callback), prefer ``grid_update_field`` — it skips the
+        value/position handling this method carries for the general case.
         """
         field_config: dict[str, Any] = {
             key: option
@@ -1289,6 +1415,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                 "strict": strict,
                 "slide": slide,
                 "visible": visible,
+                "wireframe": wireframe,
                 "color": color,
                 "background": background,
                 "width": width,
@@ -1316,56 +1443,9 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             if option is not UNSET
         }
 
-        if name in self._grid_state_fields:
-            raise TypeError(
-                f"grid_set_field() cannot be used on state field {name!r} on "
-                f"{type(self).__name__}"
-            )
-        if name not in self._grid_fields:
-            raise AttributeError(
-                f"{type(self).__name__} has no layout field {name!r}"
-            )
-
-        forbidden = _GRID_FIELD_IMMUTABLE_KEYS & field_config.keys()
-        if forbidden:
-            raise TypeError(
-                f"grid_set_field() does not accept {', '.join(sorted(forbidden))}"
-            )
-
-        unknown = set(field_config) - _GRID_FIELD_CONFIG_KEYS
-        if unknown:
-            raise TypeError(
-                "grid_set_field() got unexpected keyword arguments: "
-                f"{', '.join(sorted(unknown))}"
-            )
-
-        if field_config:
-            if "class_name" in field_config:
-                field_config = _expand_field_class_name_config(field_config)
-            if any(key in field_config for key in _GRID_MODIFIER_FLAG_KEYS):
-                field_config = _apply_field_modifier_flags(
-                    field_config,
-                    self._grid_field_info(name).modifiers,
-                )
-            if "slide" in field_config:
-                field_config = {
-                    **field_config,
-                    "slide": _normalize_slide_axes(field_config["slide"]),
-                }
-            if "width" in field_config or "height" in field_config:
-                from xnano._types import Sizing
-
-                normalized = dict(field_config)
-                if "width" in normalized:
-                    normalized["width"] = Sizing.parse(normalized["width"])
-                if "height" in normalized:
-                    normalized["height"] = Sizing.parse(normalized["height"])
-                field_config = normalized
-            overrides = self.__dict__.setdefault("_grid_field_overrides", {})
-            overrides[name] = dataclasses.replace(
-                self._grid_field_info(name),
-                **field_config,
-            )
+        self._grid_apply_field_config(
+            name, field_config, caller="grid_set_field"
+        )
 
         if position is not None:
             slot = getattr(self, "_grid_last_slot_areas", {}).get(name)
@@ -1387,6 +1467,83 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             if self._grid_strict:
                 value = self._grid_validate_field(name, value, field=field)
             object.__setattr__(self, name, value)
+
+    def grid_update_field(
+        self,
+        name: str,
+        *,
+        slide: Sequence[Axis] | None = UNSET,
+        visible: bool | None = UNSET,
+        wireframe: bool | None = UNSET,
+        color: ColorLike | None = UNSET,
+        background: ColorLike | None = UNSET,
+        width: SizingLike | None = UNSET,
+        height: SizingLike | None = UNSET,
+        gap: int | None = UNSET,
+        direction: Direction | None = UNSET,
+        align: Alignment | None = UNSET,
+        border: Border | None = UNSET,
+        border_sides: Sequence[Side] | None = UNSET,
+        border_color: ColorLike | None = UNSET,
+        title: str | None = UNSET,
+        title_position: FrameTitlePosition | None = UNSET,
+        padding: PaddingLike | None = UNSET,
+        margin: PaddingLike | None = UNSET,
+        modifiers: Sequence[CharacterModifier] | None = UNSET,
+        class_name: ClassNameLike | None = UNSET,
+        bold: bool = UNSET,
+        dim: bool = UNSET,
+        italic: bool = UNSET,
+        underline: bool = UNSET,
+        slow_blink: bool = UNSET,
+        rapid_blink: bool = UNSET,
+        reversed: bool = UNSET,
+    ) -> None:
+        """Update a layout field's style/layout attributes, live, in-place.
+
+        A narrower sibling of ``grid_set_field`` for frequent, value-free
+        attribute changes — pulsing a border color from ``on_tick``,
+        toggling a modifier from an effect callback. It has no ``value=``
+        or ``position=`` parameters at all, so a per-frame style tick never
+        pays for that method's value-validation branch. Raises the same
+        ``TypeError``/``AttributeError`` as ``grid_set_field`` for state
+        fields, unknown fields, or unknown keys.
+        """
+        field_config: dict[str, Any] = {
+            key: option
+            for key, option in {
+                "slide": slide,
+                "visible": visible,
+                "wireframe": wireframe,
+                "color": color,
+                "background": background,
+                "width": width,
+                "height": height,
+                "gap": gap,
+                "direction": direction,
+                "align": align,
+                "border": border,
+                "border_sides": border_sides,
+                "border_color": border_color,
+                "title": title,
+                "title_position": title_position,
+                "padding": padding,
+                "margin": margin,
+                "modifiers": modifiers,
+                "class_name": class_name,
+                "bold": bold,
+                "dim": dim,
+                "italic": italic,
+                "underline": underline,
+                "slow_blink": slow_blink,
+                "rapid_blink": rapid_blink,
+                "reversed": reversed,
+            }.items()
+            if option is not UNSET
+        }
+        self._grid_apply_field_config(
+            name, field_config, caller="grid_update_field"
+        )
 
     def _grid_resolve_visible(self, field: GridFieldInfo, value: Any) -> bool:
         if field.visible is None:
@@ -1571,7 +1728,15 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                 field,
                 parent_z=self.z,
                 effect_key=field_name,
+                owner=self,
+                owner_field_name=field_name,
             )
+            if field.wireframe:
+                paint_wireframe = getattr(
+                    session, "paint_field_wireframe", None
+                )
+                if paint_wireframe is not None:
+                    paint_wireframe(paint_area)
 
 
 def _grid_slide_paint_area(

--- a/xnano/terminal/cursor.py
+++ b/xnano/terminal/cursor.py
@@ -56,16 +56,30 @@ Values:
 
 
 class TerminalCursor(AbstractCursor):
-    """Show, hide, style, and move the terminal cursor.
+    """Show, hide, style, and move the cursor for the active session.
 
     Obtained from a live ``Terminal`` (``terminal.cursor`` or
     ``ctx.cursor`` in hooks). Do not construct this class yourself.
+
+    Position/visibility/style are always tracked locally, so ``ctx.cursor``
+    behaves identically whether the session is a live terminal or an
+    offscreen one (tests, or a ``Web`` session — every browser visitor
+    is served by an offscreen ``Terminal`` under the hood; see
+    ``xnano.web.render.WebRenderer``). Only a *live* session additionally
+    issues the real OS terminal escape codes; an offscreen session would
+    otherwise write those escapes to whatever process happens to own
+    stdout (dangerous for a web server) or block on a query with no real
+    terminal to answer it.
     """
 
     __slots__ = (
         "_terminal",
         "_style",
         "_visible",
+        "_x",
+        "_y",
+        "_saved_position",
+        "_blinking",
     )
 
     def __init__(
@@ -82,6 +96,21 @@ class TerminalCursor(AbstractCursor):
         self._terminal = _terminal
         self._visible = _visible
         self._style = _style
+        self._x = 0
+        self._y = 0
+        self._saved_position: Coordinate | None = None
+        self._blinking = True
+
+    def _is_live(self) -> bool:
+        """Whether this session has a real terminal attached.
+
+        ``False`` for offscreen sessions (tests, ``Web`` visitors) —
+        state is still tracked locally either way, but native OS escape
+        codes are only issued when there's a real terminal to receive
+        them.
+        """
+        session = getattr(self._terminal, "_session", None)
+        return session is not None and not session._is_offscreen
 
     @property
     def visible(self) -> bool:
@@ -95,10 +124,11 @@ class TerminalCursor(AbstractCursor):
         if not isinstance(value, bool):
             raise TypeError("`visible` must be a boolean.")
         self._visible = value
-        if value:
-            native.show_cursor()
-        else:
-            native.hide_cursor()
+        if self._is_live():
+            if value:
+                native.show_cursor()
+            else:
+                native.hide_cursor()
 
     @property
     def style(self) -> CursorStyle:
@@ -113,64 +143,100 @@ class TerminalCursor(AbstractCursor):
                 + ", ".join(CursorStyle.__args__)
             )
         self._style = value
-        native.set_cursor_style(native_types._NATIVE_CURSOR_STYLE_TYPES[value])
+        if self._is_live():
+            native.set_cursor_style(
+                native_types._NATIVE_CURSOR_STYLE_TYPES[value]
+            )
 
     def get_position(self) -> Coordinate:
-        """Get the current cursor position."""
-        position = native.get_cursor_position()
-        return (position.x, position.y)
+        """Get the current cursor position.
+
+        Returns the locally tracked position — reliable for both live and
+        offscreen sessions (a live terminal's own native position query
+        is not consulted, since every move already updates local state).
+        """
+        return (self._x, self._y)
 
     def save_position(self) -> None:
         """Save the current cursor position."""
-        native.save_cursor_position()
+        self._saved_position = (self._x, self._y)
+        if self._is_live():
+            native.save_cursor_position()
 
     def restore_position(self) -> None:
         """Restore the saved cursor position."""
-        native.restore_cursor_position()
+        if self._saved_position is not None:
+            self._x, self._y = self._saved_position
+        if self._is_live():
+            native.restore_cursor_position()
 
     def move_to(self, x: int, y: int) -> None:
         """Move the cursor to the given position."""
-        native.move_cursor_to(x, y)
+        self._x, self._y = x, y
+        if self._is_live():
+            native.move_cursor_to(x, y)
 
     def move_to_column(self, x: int) -> None:
         """Move the cursor to the given column."""
-        native.move_cursor_to_column(x)
+        self._x = x
+        if self._is_live():
+            native.move_cursor_to_column(x)
 
     def move_to_row(self, y: int) -> None:
         """Move the cursor to the given row."""
-        native.move_cursor_to_row(y)
+        self._y = y
+        if self._is_live():
+            native.move_cursor_to_row(y)
 
     def move_up(self, count: int = 1) -> None:
         """Move the cursor up by the given count."""
-        native.move_cursor_up(count)
+        self._y = max(0, self._y - count)
+        if self._is_live():
+            native.move_cursor_up(count)
 
     def move_down(self, count: int = 1) -> None:
         """Move the cursor down by the given count."""
-        native.move_cursor_down(count)
+        self._y += count
+        if self._is_live():
+            native.move_cursor_down(count)
 
     def move_left(self, count: int = 1) -> None:
         """Move the cursor left by the given count."""
-        native.move_cursor_left(count)
+        self._x = max(0, self._x - count)
+        if self._is_live():
+            native.move_cursor_left(count)
 
     def move_right(self, count: int = 1) -> None:
         """Move the cursor right by the given count."""
-        native.move_cursor_right(count)
+        self._x += count
+        if self._is_live():
+            native.move_cursor_right(count)
 
     def move_to_next_line(self, count: int = 1) -> None:
         """Move the cursor to the next line by the given count."""
-        native.move_cursor_to_next_line(count)
+        self._x = 0
+        self._y += count
+        if self._is_live():
+            native.move_cursor_to_next_line(count)
 
     def move_to_previous_line(self, count: int = 1) -> None:
         """Move the cursor to the previous line by the given count."""
-        native.move_cursor_to_previous_line(count)
+        self._x = 0
+        self._y = max(0, self._y - count)
+        if self._is_live():
+            native.move_cursor_to_previous_line(count)
 
     def enable_blinking(self) -> None:
         """Enable cursor blinking."""
-        native.enable_cursor_blinking()
+        self._blinking = True
+        if self._is_live():
+            native.enable_cursor_blinking()
 
     def disable_blinking(self) -> None:
         """Disable cursor blinking."""
-        native.disable_cursor_blinking()
+        self._blinking = False
+        if self._is_live():
+            native.disable_cursor_blinking()
 
 
 __all__ = ("TerminalCursor", "CursorStyle")

--- a/xnano/terminal/device.py
+++ b/xnano/terminal/device.py
@@ -40,11 +40,20 @@ _NATIVE_CLEAR_TYPES: dict[ClearType, Any] = {
 
 
 class TerminalDevice(AbstractDevice):
-    """Control terminal device settings during a live session.
+    """Control device settings for the active session.
 
     Title, clear, size, scroll, clipboard, raw mode, alternate screen,
     mouse capture, and related flags. Obtained from ``terminal.device``
     or ``ctx.device`` — do not construct this class yourself.
+
+    Flags and title are always tracked locally, so ``ctx.device`` behaves
+    identically whether the session is a live terminal or an offscreen
+    one (tests, or a ``Web`` session — every browser visitor is served by
+    an offscreen ``Terminal`` under the hood; see
+    ``xnano.web.render.WebRenderer``). Only a *live* session additionally
+    issues the real OS terminal escape codes; an offscreen session would
+    otherwise write those escapes to whatever process happens to own
+    stdout, which is wrong for a headless web server.
     """
 
     __slots__ = (
@@ -56,6 +65,7 @@ class TerminalDevice(AbstractDevice):
         "_bracketed_paste",
         "_focus_change",
         "_synchronized_updates",
+        "_title",
     )
 
     def __init__(self, _terminal: "Terminal[Any]") -> None:
@@ -71,6 +81,13 @@ class TerminalDevice(AbstractDevice):
         self._bracketed_paste: bool = False
         self._focus_change: bool = False
         self._synchronized_updates: bool = False
+        self._title: str | None = None
+
+    def _is_live(self) -> bool:
+        """Whether this session has a real terminal attached (see
+        ``TerminalCursor._is_live`` for the same distinction)."""
+        session = getattr(self._terminal, "_session", None)
+        return session is not None and not session._is_offscreen
 
     @property
     def raw_mode(self) -> bool:
@@ -82,10 +99,11 @@ class TerminalDevice(AbstractDevice):
 
         with SESSION_DEVICE_LOCK:
             self._raw_mode = value
-            if value:
-                native.enable_raw_mode()
-            else:
-                native.disable_raw_mode()
+            if self._is_live():
+                if value:
+                    native.enable_raw_mode()
+                else:
+                    native.disable_raw_mode()
 
     @property
     def alternate_screen(self) -> bool:
@@ -97,10 +115,11 @@ class TerminalDevice(AbstractDevice):
 
         with SESSION_DEVICE_LOCK:
             self._alternate_screen = value
-            if value:
-                native.enter_alternate_screen()
-            else:
-                native.leave_alternate_screen()
+            if self._is_live():
+                if value:
+                    native.enter_alternate_screen()
+                else:
+                    native.leave_alternate_screen()
 
     @property
     def line_wrap(self) -> bool:
@@ -112,10 +131,11 @@ class TerminalDevice(AbstractDevice):
 
         with SESSION_DEVICE_LOCK:
             self._line_wrap = value
-            if value:
-                native.enable_line_wrap()
-            else:
-                native.disable_line_wrap()
+            if self._is_live():
+                if value:
+                    native.enable_line_wrap()
+                else:
+                    native.disable_line_wrap()
 
     @property
     def mouse_capture(self) -> bool:
@@ -127,10 +147,11 @@ class TerminalDevice(AbstractDevice):
 
         with SESSION_DEVICE_LOCK:
             self._mouse_capture = value
-            if value:
-                native.enable_mouse_capture()
-            else:
-                native.disable_mouse_capture()
+            if self._is_live():
+                if value:
+                    native.enable_mouse_capture()
+                else:
+                    native.disable_mouse_capture()
 
     @property
     def bracketed_paste(self) -> bool:
@@ -142,10 +163,11 @@ class TerminalDevice(AbstractDevice):
 
         with SESSION_DEVICE_LOCK:
             self._bracketed_paste = value
-            if value:
-                native.enable_bracketed_paste()
-            else:
-                native.disable_bracketed_paste()
+            if self._is_live():
+                if value:
+                    native.enable_bracketed_paste()
+                else:
+                    native.disable_bracketed_paste()
 
     @property
     def focus_change(self) -> bool:
@@ -157,10 +179,11 @@ class TerminalDevice(AbstractDevice):
 
         with SESSION_DEVICE_LOCK:
             self._focus_change = value
-            if value:
-                native.enable_focus_change()
-            else:
-                native.disable_focus_change()
+            if self._is_live():
+                if value:
+                    native.enable_focus_change()
+                else:
+                    native.disable_focus_change()
 
     @property
     def synchronized_updates(self) -> bool:
@@ -172,43 +195,48 @@ class TerminalDevice(AbstractDevice):
 
         with SESSION_DEVICE_LOCK:
             self._synchronized_updates = value
-            if value:
-                native.begin_synchronized_update()
-            else:
-                native.end_synchronized_update()
+            if self._is_live():
+                if value:
+                    native.begin_synchronized_update()
+                else:
+                    native.end_synchronized_update()
 
     def set_title(self, title: str) -> None:
         """Set the terminal window title."""
         from xnano.core.controllers.tui import SESSION_DEVICE_LOCK
 
         with SESSION_DEVICE_LOCK:
-            native.set_terminal_title(title)
+            if self._is_live():
+                native.set_terminal_title(title)
 
     def clear(self, kind: ClearType = "all") -> None:
         """Clear the terminal display."""
         from xnano.core.controllers.tui import SESSION_DEVICE_LOCK
 
         with SESSION_DEVICE_LOCK:
-            native.clear_terminal(_NATIVE_CLEAR_TYPES[kind])
+            if self._is_live():
+                native.clear_terminal(_NATIVE_CLEAR_TYPES[kind])
 
     def scroll_up(self, n: int = 1) -> None:
         """Scroll the terminal up by ``n`` lines."""
         from xnano.core.controllers.tui import SESSION_DEVICE_LOCK
 
         with SESSION_DEVICE_LOCK:
-            native.scroll_up(n)
+            if self._is_live():
+                native.scroll_up(n)
 
     def scroll_down(self, n: int = 1) -> None:
         """Scroll the terminal down by ``n`` lines."""
         from xnano.core.controllers.tui import SESSION_DEVICE_LOCK
 
         with SESSION_DEVICE_LOCK:
-            native.scroll_down(n)
+            if self._is_live():
+                native.scroll_down(n)
 
     @property
     def title(self) -> str | None:
-        """Window title last set on this device, if any."""
-        return getattr(self, "_title", None)
+        """Window/page title last set on this device, if any."""
+        return self._title
 
     @title.setter
     def title(self, value: str | None) -> None:

--- a/xnano/terminal/terminal.py
+++ b/xnano/terminal/terminal.py
@@ -16,6 +16,10 @@ import sys
 import warnings
 from typing import IO, TYPE_CHECKING, Any, Generic, Sequence, TextIO, TypeVar
 
+_SIGHUP: int | None = getattr(signal, "SIGHUP", None)
+"""``SIGHUP`` is POSIX-only (controlling-terminal hangup); ``None`` on
+Windows, where there is no equivalent exposed through ``signal``."""
+
 if TYPE_CHECKING:
     from xnano._types import (
         Alignment,
@@ -43,6 +47,8 @@ from xnano.grid import BaseGrid
 
 if TYPE_CHECKING:
     from xnano.core.controllers.tui import TerminalController
+    from xnano.terminal.cursor import TerminalCursor
+    from xnano.terminal.device import TerminalDevice
 
 
 StateT = TypeVar("StateT")
@@ -193,7 +199,6 @@ class Terminal(AbstractHost, Generic[StateT]):
         bracketed_paste: bool = False,
         synchronized_updates: bool = False,
         tick_interval: int = 16,
-        debug_wireframe: bool = False,
     ) -> None:
         from xnano._types import Sizing
 
@@ -234,8 +239,6 @@ class Terminal(AbstractHost, Generic[StateT]):
         self._cursor: Any = None
         self._device: Any = None
         self._run_renderables: tuple[Any, ...] | None = None
-        if debug_wireframe:
-            self.stage.wireframe(True)
         self._run_field: Any = None
         self._inline_height: int | None = None
         self._pending_enter: bool = False
@@ -279,9 +282,10 @@ class Terminal(AbstractHost, Generic[StateT]):
             self._prev_sigterm = signal.signal(
                 signal.SIGTERM, self._on_exit_signal
             )
-            self._prev_sighup = signal.signal(
-                signal.SIGHUP, self._on_exit_signal
-            )
+            if _SIGHUP is not None:
+                self._prev_sighup = signal.signal(
+                    _SIGHUP, self._on_exit_signal
+                )
         except (OSError, ValueError):
             pass
         return self
@@ -385,8 +389,8 @@ class Terminal(AbstractHost, Generic[StateT]):
                 if self._prev_sigterm is not None:
                     signal.signal(signal.SIGTERM, self._prev_sigterm)
                     self._prev_sigterm = None
-                if self._prev_sighup is not None:
-                    signal.signal(signal.SIGHUP, self._prev_sighup)
+                if _SIGHUP is not None and self._prev_sighup is not None:
+                    signal.signal(_SIGHUP, self._prev_sighup)
                     self._prev_sighup = None
             except (OSError, ValueError):
                 pass
@@ -456,16 +460,13 @@ class Terminal(AbstractHost, Generic[StateT]):
         rows: int = 12,
         state: StateT | None = None,
         title: str | None = None,
-        debug_wireframe: bool = False,
     ) -> "Terminal[StateT]":
         """Return a terminal backed by an offscreen (test) buffer."""
         from xnano_core.core import CoreSession
 
         from xnano.core.controllers.tui import TerminalController
 
-        terminal: Terminal[StateT] = cls(
-            title=title, state=state, debug_wireframe=debug_wireframe
-        )
+        terminal: Terminal[StateT] = cls(title=title, state=state)
         terminal._session = TerminalController(
             CoreSession.offscreen(width=cols, height=rows),
             terminal_width=cols,
@@ -496,6 +497,23 @@ class Terminal(AbstractHost, Generic[StateT]):
         from xnano._types import set_field_focus
 
         return set_field_focus(self, grid, field_name)
+
+    def focus_group(self, group: str) -> bool:
+        """Focus the field labeled ``group``, on any attached grid.
+
+        Terminal-global — no grid reference or nesting knowledge required,
+        unlike ``focus_field``. See ``Field(group=...)``.
+        """
+        from xnano._types import focus_group
+
+        return focus_group(self, group)
+
+    @property
+    def focused_group(self) -> str | None:
+        """``group`` of the currently focused field, or ``None``."""
+        from xnano._types import focused_group_name
+
+        return focused_group_name(self)
 
     def blur_field(self) -> None:
         """Clear application field focus."""
@@ -1143,7 +1161,7 @@ class Terminal(AbstractHost, Generic[StateT]):
         return (rect.width, rect.height)
 
     @property
-    def cursor(self) -> Any:
+    def cursor(self) -> "TerminalCursor":
         """Live cursor controller for this terminal session."""
         if self._cursor is None:
             from xnano.terminal.cursor import TerminalCursor
@@ -1152,7 +1170,7 @@ class Terminal(AbstractHost, Generic[StateT]):
         return self._cursor
 
     @property
-    def device(self) -> Any:
+    def device(self) -> "TerminalDevice":
         """Live device controller for this terminal session."""
         if self._device is None:
             from xnano.terminal.device import TerminalDevice

--- a/xnano/types.py
+++ b/xnano/types.py
@@ -1,0 +1,41 @@
+"""xnano.types
+
+---
+
+Public re-exports of the type vocabulary that appears in ``Field()`` and
+component keyword signatures (``Alignment``, ``Direction``, ``modifiers``,
+sizing, ...). These live internally in ``xnano._types``; import them from
+here rather than reaching into the private module.
+"""
+
+from __future__ import annotations
+
+from xnano._types import (
+    Alignment,
+    Axis,
+    Border,
+    CharacterModifier,
+    Direction,
+    FrameTitlePosition,
+    Padding,
+    PaddingLike,
+    ScrollLike,
+    Side,
+    Sizing,
+    SizingLike,
+)
+
+__all__ = (
+    "Alignment",
+    "Axis",
+    "Border",
+    "CharacterModifier",
+    "Direction",
+    "FrameTitlePosition",
+    "Padding",
+    "PaddingLike",
+    "ScrollLike",
+    "Side",
+    "Sizing",
+    "SizingLike",
+)

--- a/xnano/web/frame.py
+++ b/xnano/web/frame.py
@@ -15,7 +15,9 @@ Wire shape (one frame):
             "0": [["hi ", "#ff0000", null, 1], ["there", null, null, 0]],
             ...
         },
-        "cursor": [x, y]              # or null
+        "cursor": [x, y],             # or null (ctx.cursor state)
+        "title": "new title"          # optional — only sent when
+                                       # ctx.device.title changes
     }
 
 A span is ``[text, fg, bg, modifiers]`` where ``fg``/``bg`` are

--- a/xnano/web/render.py
+++ b/xnano/web/render.py
@@ -42,6 +42,7 @@ class WebRenderer(Generic[StateT]):
         self._cols = cols
         self._rows = rows
         self._previous: tuple[Row, ...] | None = None
+        self._previous_title: str | None = None
         self._terminal: Any = Terminal.offscreen(
             cols=cols, rows=rows, state=state, title=title
         )
@@ -72,6 +73,7 @@ class WebRenderer(Generic[StateT]):
         self._cols = max(1, cols)
         self._rows = max(1, rows)
         self._previous = None
+        self._previous_title = None
         self._terminal = Terminal.offscreen(
             cols=self._cols, rows=self._rows, state=state, title=title
         )
@@ -86,15 +88,27 @@ class WebRenderer(Generic[StateT]):
         return serialize_rows(buffer)
 
     def frame(self) -> dict[str, Any]:
-        """Render one frame and return the wire dict (row-diffed)."""
+        """Render one frame and return the wire dict (row-diffed).
+
+        ``ctx.cursor``/``ctx.device`` work identically to the terminal
+        host (see ``TerminalCursor``/``TerminalDevice``) — a hook that
+        moves or shows/hides the cursor here is reflected in the browser
+        canvas exactly as it would move the real terminal caret.
+        """
         rows = self._render_rows()
+        cursor_state = self._terminal.cursor
+        cursor = cursor_state.get_position() if cursor_state.visible else None
         frame = build_frame(
             rows,
             width=self._cols,
             height=self._rows,
-            cursor=None,
+            cursor=cursor,
             previous=self._previous,
         )
+        title = self._terminal.device.title
+        if title is not None and title != self._previous_title:
+            frame["title"] = title
+            self._previous_title = title
         self._previous = rows
         return frame
 

--- a/xnano/web/static/painter.js
+++ b/xnano/web/static/painter.js
@@ -2,9 +2,10 @@
 // sends key/mouse/resize events back to the server. No dependencies.
 //
 // Frame wire shape (see xnano/web/frame.py):
-//   { w, h, full, rows: { "y": [[text, fg, bg, mods], ...] }, cursor }
+//   { w, h, full, rows: { "y": [[text, fg, bg, mods], ...] }, cursor, title }
 // A span's fg/bg are "#rrggbb" or null (terminal default); mods is a
-// bitfield: bold=1 dim=2 italic=4 underline=8 reversed=16.
+// bitfield: bold=1 dim=2 italic=4 underline=8 reversed=16. "title" is
+// only present when ctx.device.title changed this frame.
 
 (function () {
   "use strict";
@@ -61,6 +62,7 @@
       }
     }
     cursor = frame.cursor;
+    if (frame.title) { document.title = frame.title; }
     paint();
   }
 


### PR DESCRIPTION
## Summary

- **Container fields** — `list[Text]`/`list[str]` fields render as a laid-out stack along `direction`/`gap` instead of the raw Python repr (one level of expansion; nested lists still fall through to `str()`).
- **`Field(scroll=...)`** — windowed rendering for overflowing container fields, mouse-wheel support, and `ctx.scroll(group)` (`.offset`, `.follow`, `.to_bottom()`, `.scroll_by()`). Keyboard arrow/page/home/end scrolling is intentionally not included — it needs the focus system extended to non-component field values, a design decision left open rather than bolted on.
- **`group=`** — a terminal-global identifier on `Field(...)` so fields on different grids can be addressed together: `ctx.focus(group)`, `ctx.is_focused(group)`, `@on_focus(group=...)`, `@on_click(group=...)`.
- **`Field(autofocus=True)`** — a field wins default focus over declaration-order when nothing else is focused yet.
- **`Text(passthrough=...)`** — declare keys an editable input never captures, so they bubble to `@on_keyboard` hooks without subclassing to override `handle_keyboard`.
- **`Field(wireframe=...)`** replaces `Terminal(debug_wireframe=...)` — a per-field debug overlay (thin per-cell grid) instead of a whole-terminal switch, live-toggleable via `grid_set_field`/`grid_update_field`.
- **`grid_field_position`** (renamed from `field_position`) and **`grid_update_field`** — a narrower, value-free sibling of `grid_set_field` for frequent style ticks (`on_tick`, effects).
- **`xnano/types.py`** — public re-export of the `Field()`/component type vocabulary (`Alignment`, `Direction`, `CharacterModifier`, `ScrollLike`, ...) that previously only lived in the private `xnano._types`.
- **`Color.as_hex()` / `.as_rgb_tuple()`** — outbound conversions to match the inbound `from_hex`/`from_rgba`/`parse`; fixed six example files that were hand-rolling `f"#{c.r:02x}..."` instead.
- **Web `cursor`/`device` parity** — every `Web` visitor already runs on a real offscreen `Terminal`, but `TerminalCursor`/`TerminalDevice` issued raw OS terminal escape codes unconditionally instead of tracking state locally. Fixed: state is now always tracked locally, native escapes only fire for a genuinely live session, and `WebRenderer` forwards real cursor position/visibility and device title into the browser frame (previously hardcoded to `cursor=None`).
- **`Context`/`Terminal`/`AbstractHost` typing** — `cursor`/`device`/`actions`/`stage` no longer typed `Any` or an unearned `| None` (they're guaranteed non-`None` lazy singletons).
- **`grid_post_init`** — fires once per grid instance when first attached to a live terminal, with `ctx`/state available (unlike `__post_init__`, which runs at construction before any terminal exists).
- **`Select.move()` / `.filtered`** — public alternatives to reaching into the private `_filtered()` for highlight movement.
- **`grid_set_field`** is now a no-op (no override churn) when the new value matches the current one.

## Fixes

- `BaseGrid` subclass where every field is `init=False` (including nested `default_factory` grids) failed at class-definition time with `SyntaxError: named arguments must follow bare *`. Root cause: the generated `__init__` always emitted a bare trailing `*` even with nothing to follow it.
- `signal.SIGHUP` doesn't exist on Windows; `Terminal.__enter__`/`__exit__` referenced it unconditionally outside the `except (OSError, ValueError)` guard, so every `Terminal.run()` raised `AttributeError` on Windows.
- `@on_focus(field=...)` matches by field name only, not grid identity — a pre-existing gap found while building `group=`, documented but not fixed here (flagged for a follow-up landing alongside the `group=` matching it shares code with).

## Test plan

- [x] `uv run pytest tests/` — 1402 passed, 6 skipped
- [x] `uv run ty check` — clean
- [x] `uv run prek run --all-files` — clean
- [x] All example apps (`examples/*.py`) import cleanly