### PR TITLE
fix: complete beta runtime integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.1.1"
+pip install "xnano>=1.1.2"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.1.1"
+uv add "xnano>=1.1.2"
 ```
 
 > [!TIP]

--- a/docs/xnano/getting-started.md
+++ b/docs/xnano/getting-started.md
@@ -23,13 +23,13 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "pip"
 
     ```bash
-    pip install "xnano>=1.1.1"
+    pip install "xnano>=1.1.2"
     ```
 
 === "uv"
 
     ```bash
-    uv pip install "xnano>=1.1.1"
+    uv pip install "xnano>=1.1.2"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -38,7 +38,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "poetry"
 
     ```bash
-    poetry install "xnano>=1.1.1"
+    poetry install "xnano>=1.1.2"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -47,7 +47,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "conda"
 
     ```bash
-    conda install "xnano>=1.1.1"
+    conda install "xnano>=1.1.2"
     ```
 
 ## What is xnano?
@@ -71,7 +71,7 @@ The main featureset of the library revolves around it's rust-based terminal rend
 
     The following example is interactive and can be run directly in the browser by hitting the <kbd>Run</kbd> button.
 
-```pyodide install="xnano>=1.1.1"
+```pyodide install="xnano>=1.1.2"
 import xnano
 
 xnano.render("hello, terminal!", color="blue")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.1.1"
+version = "1.1.2"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/tests/beta/test_field_component_matrix.py
+++ b/tests/beta/test_field_component_matrix.py
@@ -1,0 +1,205 @@
+"""tests.beta.test_field_component_matrix
+
+---
+
+Exercise every public Field option and every concrete beta component through
+the real offscreen grid renderer.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable, cast
+
+import pytest
+
+from xnano.beta.components import (
+    Bar,
+    Button,
+    Chart,
+    Dropdown,
+    Image,
+    ImageData,
+    ImageFrame,
+    Input,
+    Link,
+    Loader,
+    Markdown,
+    Options,
+    Scrollbar,
+    Select,
+    Table,
+    Text,
+)
+from xnano.beta.core import Runtime
+from xnano.beta.fields import Field, GridFieldInfo
+from xnano.beta.grids import BaseGrid
+
+
+_COMPONENTS: tuple[tuple[str, Callable[[], Any]], ...] = (
+    ("bar", lambda: Bar(data=[1, 3, 2])),
+    ("button", lambda: Button(label="Run")),
+    ("chart", lambda: Chart(series={"cpu": [1, 3, 2]})),
+    ("dropdown", lambda: Dropdown(items=("one", "two"))),
+    (
+        "image",
+        lambda: Image(
+            source=ImageData(
+                width=1,
+                height=2,
+                frames=(ImageFrame(bytes((255, 0, 0, 0, 0, 0)), 50),),
+            )
+        ),
+    ),
+    ("input", lambda: Input("query")),
+    ("link", lambda: Link("docs", url="https://example.com")),
+    ("loader", lambda: Loader(value=0.5, style="bar")),
+    ("markdown", lambda: Markdown("**ready**")),
+    ("options", lambda: Options(items=("one", "two"))),
+    ("scrollbar", lambda: Scrollbar(content_length=20, viewport_length=5)),
+    ("select", lambda: Select(items=("one", "two"))),
+    ("table", lambda: Table(data=[{"name": "api", "status": "ok"}])),
+    ("text", lambda: Text("ready")),
+)
+
+_FIELD_PROFILES: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("plain", {}),
+    (
+        "chrome",
+        {
+            "border": "rounded",
+            "border_sides": ("top", "right", "bottom", "left"),
+            "border_color": "cyan",
+            "title": "Field",
+            "title_position": "top",
+            "padding": 1,
+            "margin": 1,
+        },
+    ),
+    (
+        "layout",
+        {
+            "width": "75%",
+            "height": "75%",
+            "gap": 1,
+            "direction": "horizontal",
+            "align": "center",
+        },
+    ),
+    (
+        "style",
+        {
+            "color": "yellow",
+            "background": "blue",
+            "modifiers": ("bold", "underline"),
+            "class_name": "p-1 text-red-500 bg-slate-900",
+        },
+    ),
+    (
+        "interactive",
+        {
+            "slide": ("x", "y"),
+            "group": "main",
+            "autofocus": True,
+            "scroll": True,
+            "wireframe": True,
+        },
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("component_name", "factory"),
+    _COMPONENTS,
+    ids=[item[0] for item in _COMPONENTS],
+)
+@pytest.mark.parametrize(
+    ("profile_name", "field_options"),
+    _FIELD_PROFILES,
+    ids=[item[0] for item in _FIELD_PROFILES],
+)
+def test_every_component_renders_in_every_field_profile(
+    component_name: str,
+    factory: Callable[[], Any],
+    profile_name: str,
+    field_options: dict[str, Any],
+) -> None:
+    class App(BaseGrid):
+        content: Any = Field(default_factory=factory, **field_options)
+
+    runtime = Runtime.offscreen(48, 12)
+    try:
+        app = App()
+        runtime.set_root(app)
+        frame = runtime.render()
+        assert frame.width == 48, (component_name, profile_name)
+        assert frame.height == 12, (component_name, profile_name)
+        assert runtime.stage.get_area("content") is not None
+    finally:
+        runtime.close()
+
+
+def test_every_field_parameter_is_explicitly_covered() -> None:
+    covered = {
+        "default",
+        "default_factory",
+        "state",
+        "strict",
+        "init",
+        "visible",
+        *{
+            name
+            for _, profile in _FIELD_PROFILES
+            for name in profile
+        },
+    }
+    parameters = set(inspect.signature(Field).parameters)
+    assert covered == parameters
+
+    hidden = cast(GridFieldInfo, Field(default="hidden", visible=False))
+    state = cast(
+        GridFieldInfo,
+        Field(default=1, state=True, strict=True, init=False),
+    )
+    factory = cast(
+        GridFieldInfo,
+        Field(default_factory=lambda: "made"),
+    )
+    assert hidden.visible is False
+    assert state.state is True and state.strict is True and state.init is False
+    assert factory.default_factory is not None
+
+
+def test_field_options_work_together_on_container_values() -> None:
+    class App(BaseGrid):
+        items: list[str] = Field(
+            default_factory=lambda: ["one", "two", "three"],
+            color="yellow",
+            background="blue",
+            width="fit",
+            height="fit",
+            gap=1,
+            direction="vertical",
+            align="center",
+            border="double",
+            border_color="cyan",
+            title="Rows",
+            padding=(1, 2),
+            margin=1,
+            slide=("x", "y"),
+            group="rows",
+            scroll=True,
+            wireframe=True,
+            class_name="font-bold",
+        )
+
+    runtime = Runtime.offscreen(32, 12)
+    try:
+        app = App()
+        runtime.set_root(app)
+        frame = runtime.render()
+        assert "Rows" in frame.text
+        assert "·" in frame.text
+        assert runtime.stage.get_area("items") is not None
+    finally:
+        runtime.close()

--- a/tests/beta/test_grids.py
+++ b/tests/beta/test_grids.py
@@ -60,10 +60,7 @@ def test_grid_init_preserves_keyword_only_signature() -> None:
 
     signature = inspect.signature(App.__init__)
     assert "body" in signature.parameters
-    assert (
-        signature.parameters["body"].kind
-        is inspect.Parameter.KEYWORD_ONLY
-    )
+    assert signature.parameters["body"].kind is inspect.Parameter.KEYWORD_ONLY
 
 
 def test_on_state_expression_fires_via_safe_evaluator() -> None:

--- a/tests/beta/test_runtime.py
+++ b/tests/beta/test_runtime.py
@@ -27,6 +27,93 @@ def test_offscreen_runtime_render_text() -> None:
         runtime.close()
 
 
+def test_runtime_uses_complete_grid_rendering_and_default_exit() -> None:
+    from xnano.beta.actions import Action
+    from xnano.beta.fields import Field
+    from xnano.beta.grids import BaseGrid
+
+    class App(BaseGrid):
+        name: str = Field(default="John Doe", border="rounded")
+
+        def grid_render(self) -> None:
+            self.name = "Jane Doe"
+
+    runtime = Runtime.offscreen(20, 4)
+    try:
+        app = App()
+        runtime.set_root(app)
+        frame = runtime.render()
+        assert "╭──────────────────╮" in frame.text
+        assert "│Jane Doe" in frame.text
+        assert runtime.stage.get_area("name") is not None
+        runtime.perform(Action.keyboard("ctrl+c"))
+        assert runtime.pump() is False
+    finally:
+        runtime.close()
+
+
+def test_runtime_resolves_mouse_field_for_click_hooks() -> None:
+    from xnano.beta import hooks
+    from xnano.beta.actions import Action
+    from xnano.beta.fields import Field
+    from xnano.beta.grids import BaseGrid
+
+    class App(BaseGrid):
+        button: str = Field(default="Click", group="action")
+        clicked: bool = Field(default=False, state=True)
+
+        @hooks.on_click("button")
+        def click(self) -> None:
+            self.clicked = True
+
+    runtime = Runtime.offscreen(20, 4)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        runtime.perform(Action.mouse("left", kind="press"))
+        assert app.clicked is True
+    finally:
+        runtime.close()
+
+
+def test_runtime_honors_focus_filters_and_tick_intervals() -> None:
+    from xnano.beta import hooks
+    from xnano.beta.actions import Action
+    from xnano.beta.components.input import Input
+    from xnano.beta.fields import Field
+    from xnano.beta.grids import BaseGrid
+
+    class App(BaseGrid):
+        name: Input = Field(default_factory=Input, group="name")
+        focus_count: int = Field(default=0, state=True)
+        tick_count: int = Field(default=0, state=True)
+
+        @hooks.on_focus(group="name", kind="gained")
+        def focused(self) -> None:
+            self.focus_count += 1
+
+        @hooks.on_tick(100)
+        def ticked(self) -> None:
+            self.tick_count += 1
+
+    runtime = Runtime.offscreen(20, 4)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        runtime.blur()
+        runtime.focus("name")
+        assert app.focus_count == 1
+        runtime.perform(Action.tick(50))
+        runtime.perform(Action.tick(49))
+        assert app.tick_count == 0
+        runtime.perform(Action.tick(1))
+        assert app.tick_count == 1
+    finally:
+        runtime.close()
+
+
 def test_runtime_focus_api() -> None:
     from xnano.beta.components.text import Text
     from xnano.beta.fields import Field

--- a/uv.lock
+++ b/uv.lock
@@ -402,7 +402,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2330,7 +2330,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -6,7 +6,7 @@
 >>> from xnano import BaseGrid, Field, Terminal
 """
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 from typing import TYPE_CHECKING
 

--- a/xnano/beta/core/controller.py
+++ b/xnano/beta/core/controller.py
@@ -1,0 +1,271 @@
+"""xnano.beta.core.controller
+
+---
+
+Paint beta grids through their complete layout pipeline.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import xnano_core.rust.native as native
+from xnano_core import core
+
+from xnano.beta.core.content import Panel, TextBlock
+from xnano.beta.core.layout import LayoutConstraint
+from xnano.beta.core.rendering import lower_content
+from xnano.beta.types import Area, Frame, Padding
+
+
+class TerminalController:
+    """Collect absolute beta paint requests for one native frame."""
+
+    def __init__(self, runtime: Any) -> None:
+        self.runtime = runtime
+        self.nodes: list[Any] = []
+
+    def _paint(
+        self,
+        content: Any,
+        area: Area,
+        *,
+        z: int = 0,
+        effect_key: str | None = None,
+    ) -> None:
+        if area.width <= 0 or area.height <= 0:
+            return
+        self.nodes.append(
+            core.CoreRenderNode(
+                x=area.x,
+                y=area.y,
+                width=area.width,
+                height=area.height,
+                content=core.CoreRenderContent.empty(),
+                constraints=[native.Constraint.fill(1)],
+                children=[lower_content(content)],
+                effect_key=effect_key,
+                z=z,
+            )
+        )
+
+    def commit(self) -> None:
+        width, height = self.runtime.size
+        node = (
+            core.CoreRenderNode.stack(0, 0, width, height, self.nodes)
+            if self.nodes
+            else core.CoreRenderNode.leaf(core.CoreRenderContent.empty())
+        )
+        self.runtime.session.render(node)
+
+    def paint_frame(self, area: Area, frame: Frame, *, z: int = 0) -> Area:
+        self._paint(
+            Panel(
+                child=TextBlock(),
+                background=frame.background,
+                border=frame.border,
+                border_color=frame.border_color,
+                border_sides=(
+                    tuple(frame.border_sides)
+                    if frame.border_sides is not None
+                    else None
+                ),
+                title=frame.title,
+                title_position=frame.title_position,
+                padding=frame.padding,
+            ),
+            area,
+            z=z,
+        )
+        padding = Padding.parse(frame.padding)
+        sides = set(frame.border_sides or ())
+        all_borders = frame.border is not None
+        left = padding.left + int(all_borders or "left" in sides)
+        right = padding.right + int(all_borders or "right" in sides)
+        top = padding.top + int(all_borders or "top" in sides)
+        bottom = padding.bottom + int(all_borders or "bottom" in sides)
+        return Area(
+            x=area.x + left,
+            y=area.y + top,
+            width=max(0, area.width - left - right),
+            height=max(0, area.height - top - bottom),
+        )
+
+    paint_chrome = paint_frame
+
+    def split_layout(
+        self,
+        area: Area,
+        direction: str,
+        gap: int,
+        constraints: Sequence[Any],
+    ) -> list[Area]:
+        lowered = []
+        for constraint in constraints:
+            if constraint.kind == "length":
+                value = native.Constraint.length(constraint.value)
+            elif constraint.kind == "percentage":
+                value = native.Constraint.percentage(constraint.value)
+            elif constraint.kind == "ratio":
+                value = native.Constraint.ratio(
+                    constraint.value, constraint.value2
+                )
+            elif constraint.kind == "min":
+                value = native.Constraint.min(constraint.value)
+            elif constraint.kind == "max":
+                value = native.Constraint.max(constraint.value)
+            else:
+                value = native.Constraint.fill(max(1, constraint.value))
+            lowered.append(value)
+        layout = native.Layout.new(
+            native.Direction.Horizontal
+            if direction == "horizontal"
+            else native.Direction.Vertical,
+            lowered,
+        )
+        if gap:
+            layout = layout.spacing(gap)
+        return [
+            Area(
+                x=rect.x,
+                y=rect.y,
+                width=rect.width,
+                height=rect.height,
+            )
+            for rect in layout.split(
+                native.Rect(area.x, area.y, area.width, area.height)
+            )
+        ]
+
+    def measure_field_slot(
+        self, value: Any, direction: str, field: Any = None
+    ) -> int:
+        if value is None:
+            return 0
+        if isinstance(value, str):
+            lines = value.splitlines() or [""]
+            return len(lines) if direction == "vertical" else max(map(len, lines))
+        get_size = getattr(value, "get_size", None)
+        if callable(get_size):
+            from xnano.beta.components.component import ComponentRenderContext
+
+            size = get_size(
+                ComponentRenderContext(
+                    area=Area(x=0, y=0, width=0, height=0),
+                    terminal=self.runtime,
+                    state=self.runtime.state,
+                    component=value,
+                )
+            )
+            return size.height if direction == "vertical" else size.width
+        return 1
+
+    def paint_field_slot(
+        self,
+        value: Any,
+        area: Area,
+        field: Any,
+        *,
+        parent_z: int = 0,
+        effect_key: str | None = None,
+        owner: Any = None,
+        owner_field_name: str | None = None,
+    ) -> None:
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            direction = field.direction or "vertical"
+            gap = field.gap or 0
+            constraints = [
+                LayoutConstraint(
+                    "length",
+                    max(1, self.measure_field_slot(item, direction, field)),
+                )
+                for item in value
+            ]
+            for item, item_area in zip(
+                value, self.split_layout(area, direction, gap, constraints)
+            ):
+                self.paint_field_slot(
+                    item,
+                    item_area,
+                    field,
+                    parent_z=parent_z,
+                    effect_key=effect_key,
+                )
+            return
+        if isinstance(getattr(type(value), "_grid_fields", None), dict):
+            value._grid_build_frame(area, self)
+            return
+        compose = getattr(value, "compose", None)
+        if callable(compose):
+            from xnano.beta.components.component import ComponentRenderContext
+
+            context = ComponentRenderContext(
+                area=area,
+                terminal=self.runtime,
+                state=self.runtime.state,
+                component=value,
+            )
+            if not getattr(value, "visible", True):
+                return
+            area = value.before_render(context, area)
+            frame = value.get_frame()
+            if frame is not None:
+                area = self.paint_frame(area, frame, z=value.z)
+            content = compose(context)
+            if content is not None:
+                self._paint(
+                    content,
+                    area,
+                    z=getattr(value, "z", parent_z),
+                    effect_key=effect_key,
+                )
+            value.after_render(context, area)
+            return
+        self._paint(
+            TextBlock(
+                text=str(value),
+                color=getattr(field, "color", None),
+                background=getattr(field, "background", None),
+                modifiers=tuple(getattr(field, "modifiers", ()) or ()),
+                align=getattr(field, "align", None),
+            ),
+            area,
+            z=parent_z,
+            effect_key=effect_key,
+        )
+
+    def paint_field_wireframe(self, area: Area) -> None:
+        self._paint(
+            TextBlock(
+                text="\n".join("·" * area.width for _ in range(area.height)),
+                color="slate-500",
+                modifiers=("dim",),
+                wrap=False,
+            ),
+            area,
+            z=9_000,
+        )
+
+    def paint_stage(self) -> None:
+        for command in self.runtime.stage._commands:
+            self._paint(
+                TextBlock(
+                    text=str(command["value"])[:1],
+                    color=command["color"],
+                    background=command["background"],
+                    modifiers=command["modifiers"],
+                    wrap=False,
+                ),
+                Area(
+                    x=command["x"],
+                    y=command["y"],
+                    width=1,
+                    height=1,
+                ),
+                z=10_000,
+            )
+        self.runtime.stage._commands.clear()
+
+
+__all__ = ("TerminalController",)

--- a/xnano/beta/core/dispatch.py
+++ b/xnano/beta/core/dispatch.py
@@ -114,8 +114,24 @@ def dispatch_event(root: Any, runtime: Any, event: Any) -> None:
             ):
                 focus = event.focus_event
                 expected = getattr(function, hooks.ON_FOCUS_KIND_ATTR, None)
-                if focus is not None and (
-                    expected is None or focus.kind == expected
+                expected_field = getattr(
+                    function, hooks.ON_FOCUS_FIELD_ATTR, None
+                )
+                expected_group = getattr(
+                    function, hooks.ON_FOCUS_GROUP_ATTR, None
+                )
+                if (
+                    focus is not None
+                    and (
+                        expected is None
+                        or focus.kind.removeprefix("field_") == expected
+                    )
+                    and (
+                        expected_field is None or focus.field == expected_field
+                    )
+                    and (
+                        expected_group is None or focus.group == expected_group
+                    )
                 ):
                     invoke_hook(handler, grid, context)
             if event.is_tick_event() and getattr(
@@ -123,7 +139,12 @@ def dispatch_event(root: Any, runtime: Any, event: Any) -> None:
                 hooks.ON_TICK_HOOK_ATTR,
                 False,
             ):
-                invoke_hook(handler, grid, context)
+                interval = getattr(function, hooks.ON_TICK_INTERVAL_ATTR, 0)
+                key = (id(grid), getattr(function, "__name__", ""))
+                last = runtime._tick_hook_times.get(key, 0)
+                if interval <= 0 or runtime._elapsed_ms - last >= interval:
+                    runtime._tick_hook_times[key] = runtime._elapsed_ms
+                    invoke_hook(handler, grid, context)
 
 
 def dispatch_idle(root: Any, runtime: Any) -> None:

--- a/xnano/beta/core/rendering.py
+++ b/xnano/beta/core/rendering.py
@@ -79,9 +79,9 @@ _BORDER_SIDES = {
 
 _ALIGNMENTS = {
     None: None,
-    "left": native.Alignment.Left,
-    "center": native.Alignment.Center,
-    "right": native.Alignment.Right,
+    "left": 0,
+    "center": 1,
+    "right": 2,
 }
 _MODIFIERS = {
     "bold": native.Modifier.BOLD,

--- a/xnano/beta/core/runtime.py
+++ b/xnano/beta/core/runtime.py
@@ -19,6 +19,7 @@ from xnano.beta.colors import ColorLike
 from xnano.beta.core.content import Panel, Stack, TextBlock
 from xnano.beta.core.frame import Frame
 from xnano.beta.core.rendering import lower_content
+from xnano.beta.core.stage import Stage
 from xnano.beta.cursor import Cursor
 from xnano.beta.device import Device
 from xnano.beta.events import event_from_core
@@ -123,6 +124,9 @@ class Runtime(Generic[StateT]):
         self._focused_group: str | None = None
         self._token: contextvars.Token[Runtime[Any] | None] | None = None
         self._frame_commands: list[dict[str, Any]] = []
+        self._stage = Stage()
+        self._elapsed_ms = 0
+        self._tick_hook_times: dict[tuple[int, str], int] = {}
         self._signals_installed = False
         self._prev_signal_handlers: dict[signal.Signals, Any] = {}
         self._cursor = Cursor(self)
@@ -290,7 +294,7 @@ class Runtime(Generic[StateT]):
     @property
     def stage(self) -> Any:
         """Current layout stage when a grid has rendered."""
-        return getattr(self._root, "stage", None)
+        return self._stage
 
     @property
     def size(self) -> tuple[int, int]:
@@ -353,6 +357,21 @@ class Runtime(Generic[StateT]):
 
             ensure_default_field_focus(self)
             dispatch_frame(self._root, self)
+        if len(items) == 1 and isinstance(
+            getattr(type(items[0]), "_grid_fields", None), dict
+        ):
+            from xnano.beta.core.controller import TerminalController
+            from xnano.beta.types import Area
+
+            self._stage.areas.clear()
+            controller = TerminalController(self)
+            items[0]._grid_build_frame(
+                Area(x=0, y=0, width=self.size[0], height=self.size[1]),
+                controller,
+            )
+            controller.paint_stage()
+            controller.commit()
+            return self._snapshot_frame()
         styled_items = tuple(
             TextBlock(
                 text=item,
@@ -396,6 +415,10 @@ class Runtime(Generic[StateT]):
             )
         node = lower_content(content)
         self._session.render(node)
+        return self._snapshot_frame()
+
+    def _snapshot_frame(self) -> Frame:
+        """Return the rendered native buffer as one public frame."""
         self._revision += 1
         buffer = self._session.buffer_snapshot()
         text = "\n".join(buffer.to_string_lines())
@@ -438,8 +461,31 @@ class Runtime(Generic[StateT]):
         )
 
         consumed = False
+        mouse = getattr(event, "mouse_event", None)
+        if mouse is not None and mouse.field is None:
+            from xnano.beta.core.dispatch import iter_grids
+            from xnano.beta.events import Event, MouseEventData
+
+            for grid in iter_grids(self._root):
+                for hit in reversed(getattr(grid, "_grid_field_hits", ())):
+                    if hit.area.contains((mouse.x, mouse.y)):
+                        field = hit.grid._grid_field_info(hit.field_name)
+                        event = Event.from_data(
+                            MouseEventData(
+                                kind=mouse.kind,
+                                x=mouse.x,
+                                y=mouse.y,
+                                button=mouse.button,
+                                field=hit.field_name,
+                                group=field.group,
+                            )
+                        )
+                        break
         keyboard = getattr(event, "keyboard_event", None)
         if keyboard is not None:
+            if keyboard.matches("ctrl+c"):
+                self.request_exit()
+                return
             if keyboard.matches("tab"):
                 consumed = cycle_field_focus(self)
             elif keyboard.matches("shift+tab"):
@@ -450,6 +496,9 @@ class Runtime(Generic[StateT]):
                     keyboard,
                 )
         clipboard = getattr(event, "clipboard_event", None)
+        tick = getattr(event, "tick_event", None)
+        if tick is not None:
+            self._elapsed_ms += tick.elapsed_ms
         component = focused_component(self)
         if clipboard is not None and component is not None:
             paste_handler = getattr(component, "handle_paste", None)

--- a/xnano/beta/grids.py
+++ b/xnano/beta/grids.py
@@ -1570,6 +1570,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
 
         self._grid_last_parent_area = area
         self._grid_last_slot_areas = {}
+        self._grid_field_hits = []
 
         fields = self._grid_fields
 

--- a/xnano/beta/terminal.py
+++ b/xnano/beta/terminal.py
@@ -262,7 +262,7 @@ class Terminal(Generic[StateT]):
         if renderables:
             runtime.set_root(renderables[0] if len(renderables) == 1 else None)
         try:
-            while runtime.pump():
+            while True:
                 runtime.render(
                     *renderables,
                     color=color,
@@ -278,6 +278,8 @@ class Terminal(Generic[StateT]):
                     gap=gap,
                     direction=direction,
                 )
+                if not runtime.pump():
+                    break
         finally:
             self.close()
 

--- a/xnano/beta/utils/focus.py
+++ b/xnano/beta/utils/focus.py
@@ -7,7 +7,7 @@ Discover, move, and synchronize focus across beta grid fields.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from xnano.beta.types import (
     FieldFocus,
@@ -79,15 +79,39 @@ def set_field_focus(
     fire_hooks: bool = True,
 ) -> bool:
     """Set the focused field and synchronize component flags."""
-    del fire_hooks
     current = getattr(terminal, "_field_focus", None)
     if current == target:
         return False
+    if current is not None and fire_hooks:
+        _dispatch_field_focus(terminal, current, "field_lost")
     setattr(terminal, "_field_focus", target)
     sync_input_focus_flags(terminal)
     if target is not None:
         setattr(terminal, "_focused_group", target.group)
+        if fire_hooks:
+            _dispatch_field_focus(terminal, target, "field_gained")
+    else:
+        setattr(terminal, "_focused_group", None)
     return True
+
+
+def _dispatch_field_focus(
+    terminal: Any,
+    target: FieldFocus,
+    kind: Literal["field_gained", "field_lost"],
+) -> None:
+    """Dispatch one field focus transition through normal beta hooks."""
+    from xnano.beta.events import Event, FocusEventData
+
+    terminal.dispatch(
+        Event.from_data(
+            FocusEventData(
+                kind=kind,
+                field=target.field_name,
+                group=target.group,
+            )
+        )
+    )
 
 
 def clear_field_focus(terminal: Any, *, fire_hooks: bool = True) -> bool:


### PR DESCRIPTION
## Summary

- route beta grids through the complete terminal controller path for borders, layout, stage painting, components, and web offscreen rendering
- restore default exit, focus, mouse-field, and tick-hook behavior
- add a Field/component compatibility matrix and bump xnano to 1.1.2

## Validation

- `uv run pytest tests/beta -q` (397 passed)
- `uv run pytest` (1450 passed, 6 skipped)
- `uv run prek run --all-files`