### PR TITLE
fix: make beta runtime updates reliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.1.2"
+pip install "xnano>=1.1.3"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.1.2"
+uv add "xnano>=1.1.3"
 ```
 
 > [!TIP]

--- a/docs/xnano/getting-started.md
+++ b/docs/xnano/getting-started.md
@@ -23,13 +23,13 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "pip"
 
     ```bash
-    pip install "xnano>=1.1.2"
+    pip install "xnano>=1.1.3"
     ```
 
 === "uv"
 
     ```bash
-    uv pip install "xnano>=1.1.2"
+    uv pip install "xnano>=1.1.3"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -38,7 +38,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "poetry"
 
     ```bash
-    poetry install "xnano>=1.1.2"
+    poetry install "xnano>=1.1.3"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -47,7 +47,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "conda"
 
     ```bash
-    conda install "xnano>=1.1.2"
+    conda install "xnano>=1.1.3"
     ```
 
 ## What is xnano?
@@ -71,7 +71,7 @@ The main featureset of the library revolves around it's rust-based terminal rend
 
     The following example is interactive and can be run directly in the browser by hitting the <kbd>Run</kbd> button.
 
-```pyodide install="xnano>=1.1.2"
+```pyodide install="xnano>=1.1.3"
 import xnano
 
 xnano.render("hello, terminal!", color="blue")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.1.2"
+version = "1.1.3"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/tests/beta/test_actions.py
+++ b/tests/beta/test_actions.py
@@ -1,0 +1,157 @@
+"""tests.beta.test_actions
+
+---
+
+Verify every public beta action against matching and nonmatching events.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from xnano.beta.actions import Action
+from xnano.beta.events import (
+    ClipboardEventData,
+    Event,
+    FocusEventData,
+    KeyboardEventData,
+    MouseEventData,
+    ResizeEventData,
+    TickEventData,
+)
+from xnano.beta.requests import Request
+
+
+@pytest.mark.parametrize(
+    ("action", "matching", "nonmatching"),
+    (
+        (
+            Action.keyboard("ctrl+s", kind="press"),
+            Event.from_data(KeyboardEventData.from_binding("ctrl+s")),
+            Event.from_data(KeyboardEventData.from_binding("ctrl+x")),
+        ),
+        (
+            Action.mouse("right", kind="release"),
+            Event.from_data(
+                MouseEventData(
+                    kind="release",
+                    x=1,
+                    y=2,
+                    button="right",
+                )
+            ),
+            Event.from_data(
+                MouseEventData(
+                    kind="press",
+                    x=1,
+                    y=2,
+                    button="left",
+                )
+            ),
+        ),
+        (
+            Action.click("save"),
+            Event.from_data(
+                MouseEventData(
+                    kind="press",
+                    x=1,
+                    y=2,
+                    button="left",
+                    field="save",
+                )
+            ),
+            Event.from_data(
+                MouseEventData(
+                    kind="release",
+                    x=1,
+                    y=2,
+                    button="left",
+                    field="save",
+                )
+            ),
+        ),
+        (
+            Action.focus("editor", kind="field_gained"),
+            Event.from_data(
+                FocusEventData(kind="field_gained", field="editor")
+            ),
+            Event.from_data(
+                FocusEventData(kind="field_lost", field="editor")
+            ),
+        ),
+        (
+            Action.clipboard("expected"),
+            Event.from_data(ClipboardEventData(text="expected")),
+            Event.from_data(ClipboardEventData(text="other")),
+        ),
+        (
+            Action.tick(16),
+            Event.from_data(TickEventData(elapsed_ms=16)),
+            Event.from_data(KeyboardEventData.from_binding("x")),
+        ),
+        (
+            Action.resize(80, 24),
+            Event.from_data(ResizeEventData(width=80, height=24)),
+            Event.from_data(ResizeEventData(width=40, height=12)),
+        ),
+        (
+            Action.request("POST", "/save"),
+            Request.from_parts("POST", "/save"),
+            Request.from_parts("GET", "/save"),
+        ),
+    ),
+    ids=(
+        "keyboard",
+        "mouse",
+        "click",
+        "focus",
+        "clipboard",
+        "tick",
+        "resize",
+        "request",
+    ),
+)
+def test_action_matches_only_its_declared_event(
+    action,
+    matching,
+    nonmatching,
+) -> None:
+    assert action.matches(matching) is True
+    assert action.matches(nonmatching) is False
+
+
+def test_action_wildcards_match_payloads_but_not_other_event_types() -> None:
+    keyboard = Event.from_data(KeyboardEventData.from_binding("z"))
+    mouse = Event.from_data(
+        MouseEventData(kind="move", x=3, y=4, button="unknown")
+    )
+    focus = Event.from_data(FocusEventData(kind="gained"))
+    clipboard = Event.from_data(ClipboardEventData(text="anything"))
+    resize = Event.from_data(ResizeEventData(width=10, height=5))
+
+    assert Action.keyboard().matches(keyboard)
+    assert Action.mouse().matches(mouse)
+    assert Action.click().matches(mouse) is False
+    assert Action.focus().matches(focus)
+    assert Action.clipboard().matches(clipboard)
+    assert Action.resize().matches(resize)
+    assert Action.keyboard().matches(mouse) is False
+
+
+def test_actions_facade_dispatches_each_keyboard_binding() -> None:
+    class Runtime:
+        performed = []
+
+        def perform(self, action) -> None:
+            self.performed.append(action)
+
+    from xnano.beta.actions import Actions
+
+    runtime = Runtime()
+    actions = Actions(runtime)
+    actions.keyboard("a", "b", kind="repeat")
+    assert [action.bindings for action in runtime.performed] == [
+        ("a",),
+        ("b",),
+    ]
+    assert all(action.kind == "repeat" for action in runtime.performed)

--- a/tests/beta/test_end_to_end.py
+++ b/tests/beta/test_end_to_end.py
@@ -1,0 +1,320 @@
+"""tests.beta.test_end_to_end
+
+---
+
+Exercise beta's public hooks and browser event path through a real runtime,
+including the repaint that makes mutations visible to users.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from xnano.beta import hooks
+from xnano.beta.actions import Action
+from xnano.beta.core import Runtime
+from xnano.beta.fields import Field
+from xnano.beta.grids import BaseGrid
+
+
+@pytest.mark.parametrize(
+    ("action", "decorator"),
+    (
+        (Action.keyboard("ctrl+s"), hooks.on_keyboard("ctrl+s")),
+        (
+            Action.mouse("right", kind="release"),
+            hooks.on_mouse("right", kind="release"),
+        ),
+        (Action.click("content"), hooks.on_click("content")),
+        (Action.clipboard("pasted"), hooks.on_clipboard),
+        (Action.resize(30, 6), hooks.on_resize),
+        (
+            Action.focus("content", kind="gained"),
+            hooks.on_focus("content", kind="gained"),
+        ),
+        (Action.tick(10), hooks.on_tick(10)),
+    ),
+    ids=(
+        "keyboard",
+        "mouse",
+        "click",
+        "clipboard",
+        "resize",
+        "focus",
+        "tick",
+    ),
+)
+def test_event_hook_mutation_is_visible_after_repaint(
+    action,
+    decorator,
+) -> None:
+    def handle_event(self) -> None:
+        self.content = "changed"
+
+    class App(BaseGrid):
+        content: str = Field(default="initial", group="content")
+
+    setattr(App, "handle_event", decorator(handle_event))
+    runtime = Runtime.offscreen(30, 6)
+    try:
+        app = App()
+        runtime.set_root(app)
+        assert "initial" in runtime.render().text
+        runtime.perform(action)
+        assert app.content == "changed"
+        assert "changed" in runtime.render().text
+    finally:
+        runtime.close()
+
+
+def test_frame_idle_state_field_and_event_hooks_repaint() -> None:
+    @dataclasses.dataclass
+    class State:
+        ready: bool = True
+
+    class App(BaseGrid):
+        count: int = Field(default=1, state=True)
+        content: str = Field(default="initial")
+        calls: list[str] = Field(default_factory=list, state=True)
+
+        @hooks.on_poll("frame")
+        def frame_hook(self) -> None:
+            if "frame" not in self.calls:
+                self.calls.append("frame")
+
+        @hooks.on_poll("idle")
+        def idle_hook(self) -> None:
+            self.calls.append("idle")
+
+        @hooks.on_state("ready")
+        def state_hook(self) -> None:
+            if "state" not in self.calls:
+                self.calls.append("state")
+
+        @hooks.on_field("count > 0")
+        def field_hook(self) -> None:
+            if "field" not in self.calls:
+                self.calls.append("field")
+                self.content = "field changed"
+
+        @hooks.on_event
+        def event_hook(self) -> None:
+            self.calls.append("event")
+
+    runtime = Runtime.offscreen(30, 6, state=State())
+    try:
+        app = App()
+        runtime.set_root(app)
+        frame = runtime.render()
+        assert "field changed" in frame.text
+        assert {"frame", "state", "field"} <= set(app.calls)
+        runtime.pump()
+        assert "idle" in app.calls
+        assert "event" in app.calls
+    finally:
+        runtime.close()
+
+
+def test_on_action_mutates_and_repaints() -> None:
+    class App(BaseGrid):
+        content: str = Field(default="initial")
+
+        @hooks.on_action(Action.keyboard("enter"))
+        def submit(self) -> None:
+            self.content = "submitted"
+
+    runtime = Runtime.offscreen(30, 6)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        runtime.perform(Action.keyboard("enter"))
+        assert "submitted" in runtime.render().text
+    finally:
+        runtime.close()
+
+
+def test_hook_filters_reject_nonmatching_events() -> None:
+    class App(BaseGrid):
+        content: str = Field(default="unchanged", group="target")
+
+        @hooks.on_keyboard("ctrl+s", kind="press")
+        def keyboard(self) -> None:
+            self.content = "keyboard"
+
+        @hooks.on_mouse("right", kind="release")
+        def mouse(self) -> None:
+            self.content = "mouse"
+
+        @hooks.on_focus("content", kind="gained")
+        def focus(self) -> None:
+            self.content = "focus"
+
+    runtime = Runtime.offscreen(30, 6)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        runtime.perform(Action.keyboard("ctrl+x"))
+        runtime.perform(Action.mouse("left", kind="press"))
+        runtime.perform(Action.focus("other", kind="lost"))
+        assert app.content == "unchanged"
+        assert "unchanged" in runtime.render().text
+    finally:
+        runtime.close()
+
+
+def test_request_action_dispatches_route_and_repaints() -> None:
+    from xnano.beta.requests import on_post_request
+
+    class App(BaseGrid):
+        content: str = Field(default="waiting")
+
+        @on_post_request("/run")
+        def run_request(self) -> None:
+            self.content = "request handled"
+
+    runtime = Runtime.offscreen(30, 6)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        runtime.perform(Action.request("POST", "/run"))
+        assert "request handled" in runtime.render().text
+    finally:
+        runtime.close()
+
+
+def test_interactive_components_receive_runtime_keyboard_and_repaint() -> None:
+    from xnano.beta.components import Dropdown, Input, Options, Table
+
+    class App(BaseGrid, direction="vertical"):
+        input: Input = Field(
+            default_factory=Input,
+            group="input",
+            autofocus=True,
+            height=1,
+        )
+        dropdown: Dropdown = Field(
+            default_factory=lambda: Dropdown(items=("one", "two")),
+            group="dropdown",
+            height=1,
+        )
+        options: Options = Field(
+            default_factory=lambda: Options(
+                items=("alpha", "beta"),
+                searchable=False,
+            ),
+            group="options",
+            height=3,
+        )
+        table: Table = Field(
+            default_factory=lambda: Table(
+                data=[{"name": "first"}, {"name": "second"}],
+                focusable=True,
+            ),
+            group="table",
+            height=3,
+        )
+
+    runtime = Runtime.offscreen(40, 10)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+
+        runtime.perform(Action.keyboard("a"))
+        assert app.input.value == "a"
+        assert "a" in runtime.render().text
+
+        assert runtime.focus("dropdown")
+        runtime.perform(Action.keyboard("down"))
+        assert app.dropdown.open is True
+        runtime.perform(Action.keyboard("down"))
+        assert app.dropdown.value == "two"
+        runtime.perform(Action.keyboard("enter"))
+        assert app.dropdown.open is False
+        assert "two" in runtime.render().text
+
+        assert runtime.focus("options")
+        runtime.perform(Action.keyboard("down"))
+        assert app.options.value == "beta"
+        assert "beta" in runtime.render().text
+
+        assert runtime.focus("table")
+        runtime.perform(Action.keyboard("down"))
+        assert app.table.value == {"name": "second"}
+        assert "second" in runtime.render().text
+    finally:
+        runtime.close()
+
+
+def test_button_and_link_activation_bubble_to_hooks_and_repaint() -> None:
+    from xnano.beta.components import Button, Link
+
+    class App(BaseGrid, direction="vertical"):
+        button: Button = Field(
+            default_factory=lambda: Button(label="Submit"),
+            group="button",
+            autofocus=True,
+        )
+        link: Link = Field(
+            default_factory=lambda: Link(
+                "Documentation",
+                url="https://example.com",
+            ),
+            group="link",
+        )
+        status: str = Field(default="waiting")
+
+        @hooks.on_keyboard("enter")
+        def activate(self, ctx) -> None:
+            self.status = ctx.focused_group or "none"
+
+    runtime = Runtime.offscreen(40, 8)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        runtime.perform(Action.keyboard("enter"))
+        assert app.status == "button"
+        assert "button" in runtime.render().text
+
+        assert runtime.focus("link")
+        runtime.perform(Action.keyboard("enter"))
+        assert app.status == "link"
+        assert "link" in runtime.render().text
+    finally:
+        runtime.close()
+
+
+def test_browser_event_dispatch_mutates_and_repaints() -> None:
+    from xnano.beta.server.native import _browser_event
+
+    class App(BaseGrid):
+        content: str = Field(default="initial")
+
+        @hooks.on_keyboard("x")
+        def edit(self) -> None:
+            self.content = "browser changed"
+
+    runtime = Runtime.offscreen(30, 6)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        runtime.dispatch(
+            _browser_event(
+                {
+                    "type": "keyboard",
+                    "binding": "x",
+                    "kind": "press",
+                    "character": "x",
+                }
+            )
+        )
+        assert "browser changed" in runtime.render().text
+    finally:
+        runtime.close()

--- a/tests/beta/test_field_component_matrix.py
+++ b/tests/beta/test_field_component_matrix.py
@@ -35,12 +35,11 @@ from xnano.beta.core import Runtime
 from xnano.beta.fields import Field, GridFieldInfo
 from xnano.beta.grids import BaseGrid
 
-
-_COMPONENTS: tuple[tuple[str, Callable[[], Any]], ...] = (
-    ("bar", lambda: Bar(data=[1, 3, 2])),
-    ("button", lambda: Button(label="Run")),
-    ("chart", lambda: Chart(series={"cpu": [1, 3, 2]})),
-    ("dropdown", lambda: Dropdown(items=("one", "two"))),
+_COMPONENTS: tuple[tuple[str, Callable[[], Any], str], ...] = (
+    ("bar", lambda: Bar(data=[1, 3, 2]), "█"),
+    ("button", lambda: Button(label="Run"), "Run"),
+    ("chart", lambda: Chart(series={"cpu": [1, 3, 2]}), "•"),
+    ("dropdown", lambda: Dropdown(items=("one", "two")), "one"),
     (
         "image",
         lambda: Image(
@@ -50,16 +49,25 @@ _COMPONENTS: tuple[tuple[str, Callable[[], Any]], ...] = (
                 frames=(ImageFrame(bytes((255, 0, 0, 0, 0, 0)), 50),),
             )
         ),
+        "▀",
     ),
-    ("input", lambda: Input("query")),
-    ("link", lambda: Link("docs", url="https://example.com")),
-    ("loader", lambda: Loader(value=0.5, style="bar")),
-    ("markdown", lambda: Markdown("**ready**")),
-    ("options", lambda: Options(items=("one", "two"))),
-    ("scrollbar", lambda: Scrollbar(content_length=20, viewport_length=5)),
-    ("select", lambda: Select(items=("one", "two"))),
-    ("table", lambda: Table(data=[{"name": "api", "status": "ok"}])),
-    ("text", lambda: Text("ready")),
+    ("input", lambda: Input("query"), "query"),
+    ("link", lambda: Link("docs", url="https://example.com"), "docs"),
+    ("loader", lambda: Loader(value=0.5, style="bar"), "█"),
+    ("markdown", lambda: Markdown("**ready**"), "ready"),
+    ("options", lambda: Options(items=("one", "two")), "one"),
+    (
+        "scrollbar",
+        lambda: Scrollbar(content_length=20, viewport_length=5),
+        "█",
+    ),
+    ("select", lambda: Select(items=("one", "two")), "one"),
+    (
+        "table",
+        lambda: Table(data=[{"name": "api", "status": "ok"}]),
+        "api",
+    ),
+    ("text", lambda: Text("ready"), "ready"),
 )
 
 _FIELD_PROFILES: tuple[tuple[str, dict[str, Any]], ...] = (
@@ -109,7 +117,7 @@ _FIELD_PROFILES: tuple[tuple[str, dict[str, Any]], ...] = (
 
 
 @pytest.mark.parametrize(
-    ("component_name", "factory"),
+    ("component_name", "factory", "expected_text"),
     _COMPONENTS,
     ids=[item[0] for item in _COMPONENTS],
 )
@@ -121,6 +129,7 @@ _FIELD_PROFILES: tuple[tuple[str, dict[str, Any]], ...] = (
 def test_every_component_renders_in_every_field_profile(
     component_name: str,
     factory: Callable[[], Any],
+    expected_text: str,
     profile_name: str,
     field_options: dict[str, Any],
 ) -> None:
@@ -134,7 +143,17 @@ def test_every_component_renders_in_every_field_profile(
         frame = runtime.render()
         assert frame.width == 48, (component_name, profile_name)
         assert frame.height == 12, (component_name, profile_name)
-        assert runtime.stage.get_area("content") is not None
+        area = runtime.stage.get_area("content")
+        assert area is not None
+        assert area.width > 0 and area.height > 0
+        if profile_name != "interactive":
+            assert expected_text in frame.text, (component_name, profile_name)
+        if profile_name == "chrome":
+            assert "Field" in frame.text
+            assert "╭" in frame.text
+        elif profile_name == "interactive":
+            assert "·" in frame.text
+            assert runtime.focused_group == "main"
     finally:
         runtime.close()
 
@@ -147,11 +166,7 @@ def test_every_field_parameter_is_explicitly_covered() -> None:
         "strict",
         "init",
         "visible",
-        *{
-            name
-            for _, profile in _FIELD_PROFILES
-            for name in profile
-        },
+        *{name for _, profile in _FIELD_PROFILES for name in profile},
     }
     parameters = set(inspect.signature(Field).parameters)
     assert covered == parameters
@@ -201,5 +216,41 @@ def test_field_options_work_together_on_container_values() -> None:
         assert "Rows" in frame.text
         assert "·" in frame.text
         assert runtime.stage.get_area("items") is not None
+    finally:
+        runtime.close()
+
+
+def test_visibility_state_init_factory_and_strict_change_real_behavior() -> (
+    None
+):
+    made: list[str] = []
+
+    class App(BaseGrid):
+        shown: str = Field(default="shown")
+        hidden: str = Field(default="must not render", visible=False)
+        internal: str = Field(default="state only", state=True)
+        generated: str = Field(
+            default_factory=lambda: (made.append("made"), "generated")[1]
+        )
+        fixed: str = Field(default="fixed", init=False)
+        count: int = Field(default=1, state=True, strict=True)
+
+    app = App(shown="override", generated="override factory")
+    assert made == []
+    assert app.fixed == "fixed"
+    with pytest.raises(TypeError):
+        App(fixed="override")  # ty: ignore[unknown-argument]
+    with pytest.raises((TypeError, ValueError)):
+        app.count = "invalid"  # ty: ignore[invalid-assignment]
+
+    runtime = Runtime.offscreen(40, 8)
+    try:
+        runtime.set_root(app)
+        frame = runtime.render()
+        assert "override" in frame.text
+        assert "override factory" in frame.text
+        assert "must not render" not in frame.text
+        assert "state only" not in frame.text
+        assert "fixed" in frame.text
     finally:
         runtime.close()

--- a/tests/beta/test_requests.py
+++ b/tests/beta/test_requests.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
+import http.client
+
+import pytest
+
 from xnano.beta.fields import Field
 from xnano.beta.grids import BaseGrid
 from xnano.beta.requests import (
     Request,
     Response,
     dispatch_request,
+    on_connect_request,
+    on_delete_request,
     on_get_request,
+    on_head_request,
+    on_options_request,
+    on_patch_request,
     on_post_request,
+    on_put_request,
+    on_query_request,
+    on_trace_request,
     request,
 )
+from xnano.beta.server.requests import start_request_server
 
 
 def test_request_parsing_and_json() -> None:
@@ -76,3 +89,83 @@ def test_dispatch_request_with_runtime_context() -> None:
 def test_request_decorator_factory() -> None:
     decorator = request("PATCH", "/thing")
     assert callable(decorator)
+
+
+@pytest.mark.parametrize(
+    ("method", "decorator"),
+    (
+        ("GET", on_get_request),
+        ("HEAD", on_head_request),
+        ("POST", on_post_request),
+        ("PUT", on_put_request),
+        ("DELETE", on_delete_request),
+        ("CONNECT", on_connect_request),
+        ("OPTIONS", on_options_request),
+        ("TRACE", on_trace_request),
+        ("PATCH", on_patch_request),
+        ("QUERY", on_query_request),
+    ),
+)
+def test_every_request_hook_dispatches_with_context(
+    method: str,
+    decorator,
+) -> None:
+    def handle(self, ctx) -> Response:
+        self.called = method
+        assert ctx.request.method == method
+        return Response(body=method)
+
+    class App(BaseGrid):
+        called: str = Field(default="", state=True)
+
+    setattr(App, "handle", decorator("/route")(handle))
+    app = App()
+    request_obj = Request.from_parts(method, "/route")
+    response = dispatch_request(
+        app,
+        method,
+        "/route",
+        request_obj=request_obj,
+        runtime=app,
+    )
+    assert isinstance(response, Response)
+    assert response.as_bytes() == method.encode()
+    assert app.called == method
+
+
+def test_request_server_preserves_http_body_query_status_and_404() -> None:
+    class App(BaseGrid):
+        @on_post_request("/submit")
+        def submit(self, ctx) -> Response:
+            assert ctx.request.query["mode"] == ("test",)
+            assert ctx.request.json() == {"value": 3}
+            return Response.json({"accepted": True}, status=202)
+
+    server = start_request_server(App, host="127.0.0.1", port=0)
+    connection = http.client.HTTPConnection(
+        "127.0.0.1",
+        server.server_address[1],
+        timeout=2,
+    )
+    try:
+        connection.request(
+            "POST",
+            "/submit?mode=test",
+            body=b'{"value": 3}',
+            headers={"content-type": "application/json"},
+        )
+        response = connection.getresponse()
+        assert response.status == 202
+        assert response.getheader("content-type", "").startswith(
+            "application/json"
+        )
+        assert response.read() == b'{"accepted": true}'
+
+        connection.request("GET", "/missing")
+        response = connection.getresponse()
+        assert response.status == 404
+        assert response.read() == b"Not Found"
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()

--- a/tests/beta/test_runtime.py
+++ b/tests/beta/test_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import signal
 
+import xnano.beta.core.runtime
 from xnano.beta.core import Frame, Runtime
 from xnano.beta.core.runtime import (
     _ACTIVE_RUNTIME,
@@ -112,6 +113,83 @@ def test_runtime_honors_focus_filters_and_tick_intervals() -> None:
         assert app.tick_count == 1
     finally:
         runtime.close()
+
+
+def test_runtime_pump_ticks_mutates_and_repaints_grid(
+    monkeypatch,
+) -> None:
+    from xnano.beta import hooks
+    from xnano.beta.fields import Field
+    from xnano.beta.grids import BaseGrid
+
+    now = [100.0]
+    monkeypatch.setattr(
+        xnano.beta.core.runtime.time,
+        "monotonic",
+        lambda: now[0],
+    )
+
+    class App(BaseGrid):
+        name: str = Field(default="John Doe", border="rounded")
+
+        @hooks.on_tick(1000)
+        def on_tick_hook(self) -> None:
+            self.name += "a"
+
+    runtime = Runtime.offscreen(20, 4)
+    try:
+        app = App()
+        runtime.set_root(app)
+        assert "John Doe" in runtime.render().text
+        now[0] += 0.999
+        runtime.pump()
+        assert app.name == "John Doe"
+        now[0] += 0.001
+        runtime.pump()
+        assert app.name == "John Doea"
+        frame = runtime.render()
+        assert "John Doea" in frame.text
+        assert "╭──────────────────╮" in frame.text
+    finally:
+        runtime.close()
+
+
+def test_live_runtime_pump_uses_bounded_poll_and_ticks(
+    monkeypatch,
+) -> None:
+    from xnano.beta import hooks
+    from xnano.beta.grids import BaseGrid
+
+    class Session:
+        timeout_ms: int | None = None
+
+        def poll_event(self, timeout_ms: int):
+            self.timeout_ms = timeout_ms
+            return None
+
+    class App(BaseGrid):
+        ticked: bool = False
+
+        @hooks.on_tick
+        def on_tick_hook(self) -> None:
+            self.ticked = True
+
+    now = [100.0]
+    monkeypatch.setattr(
+        xnano.beta.core.runtime.time,
+        "monotonic",
+        lambda: now[0],
+    )
+    session = Session()
+    runtime = Runtime(
+        session,  # ty: ignore[invalid-argument-type]
+        live=True,
+        tick_interval=16,
+    )
+    runtime.set_root(App())
+    runtime.pump()
+    assert session.timeout_ms == 16
+    assert runtime._root.ticked is True
 
 
 def test_runtime_focus_api() -> None:

--- a/tests/beta/test_terminal.py
+++ b/tests/beta/test_terminal.py
@@ -32,3 +32,36 @@ def test_terminal_focus_aliases() -> None:
     assert terminal.focused_group == "name"
     terminal.blur()
     assert terminal.focused_group is None
+
+
+def test_terminal_run_polls_hooks_and_repaints_mutation(monkeypatch) -> None:
+    from xnano.beta import hooks
+    from xnano.beta.fields import Field
+    from xnano.beta.grids import BaseGrid
+
+    class App(BaseGrid):
+        label: str = Field(default="initial", border="rounded")
+        ticks: int = Field(default=0, state=True)
+
+        @hooks.on_tick
+        def update(self, ctx) -> None:
+            self.ticks += 1
+            self.label = "updated"
+            if self.ticks == 2:
+                ctx.terminal.request_exit()
+
+    terminal = Terminal.offscreen(cols=30, rows=6)
+    app = App()
+    frames = []
+    render = terminal.runtime.render
+
+    def capture_render(*args, **kwargs):
+        frame = render(*args, **kwargs)
+        frames.append(frame)
+        return frame
+
+    monkeypatch.setattr(terminal.runtime, "render", capture_render)
+    terminal.run(app)
+    assert app.ticks == 2
+    assert any("updated" in frame.text for frame in frames)
+    assert any("╭" in frame.text for frame in frames)

--- a/tests/beta/test_web.py
+++ b/tests/beta/test_web.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import http.client
+import json
+import threading
+
 
 def test_browser_events_use_public_beta_events() -> None:
     from xnano.beta.server.native import _browser_event
@@ -61,3 +65,66 @@ def test_grid_factory_class() -> None:
     second = factory()
     assert isinstance(first, _Counter)
     assert first is not second
+
+
+def test_native_web_http_event_changes_subsequent_frame() -> None:
+    from xnano.beta import hooks
+    from xnano.beta.server.native import NativeWebServer
+
+    class App(BaseGrid):
+        label: str = Field(default="initial")
+
+        @hooks.on_keyboard("x")
+        def change(self) -> None:
+            self.label = "changed by browser"
+
+    server = NativeWebServer(
+        ("127.0.0.1", 0),
+        App,
+        width=30,
+        height=6,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection(
+        "127.0.0.1",
+        server.server_address[1],
+        timeout=2,
+    )
+    try:
+        connection.request("GET", "/xnano/frame")
+        response = connection.getresponse()
+        initial = json.loads(response.read())
+        assert response.status == 200
+        assert "initial" in initial["text"]
+
+        payload = json.dumps(
+            {
+                "type": "keyboard",
+                "binding": "x",
+                "kind": "press",
+                "character": "x",
+            }
+        )
+        connection.request(
+            "POST",
+            "/xnano/event",
+            body=payload,
+            headers={"content-type": "application/json"},
+        )
+        response = connection.getresponse()
+        response.read()
+        assert response.status == 204
+
+        connection.request("GET", "/xnano/frame")
+        response = connection.getresponse()
+        changed = json.loads(response.read())
+        assert response.status == 200
+        assert changed["revision"] > initial["revision"]
+        assert "changed by browser" in changed["text"]
+        assert "initial" not in changed["text"]
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)

--- a/uv.lock
+++ b/uv.lock
@@ -2330,7 +2330,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -6,7 +6,7 @@
 >>> from xnano import BaseGrid, Field, Terminal
 """
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 from typing import TYPE_CHECKING
 

--- a/xnano/beta/core/controller.py
+++ b/xnano/beta/core/controller.py
@@ -7,7 +7,7 @@ Paint beta grids through their complete layout pipeline.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import collections.abc
 from typing import Any
 
 import xnano_core.rust.native as native
@@ -99,7 +99,7 @@ class TerminalController:
         area: Area,
         direction: str,
         gap: int,
-        constraints: Sequence[Any],
+        constraints: collections.abc.Sequence[Any],
     ) -> list[Area]:
         lowered = []
         for constraint in constraints:
@@ -145,7 +145,9 @@ class TerminalController:
             return 0
         if isinstance(value, str):
             lines = value.splitlines() or [""]
-            return len(lines) if direction == "vertical" else max(map(len, lines))
+            return (
+                len(lines) if direction == "vertical" else max(map(len, lines))
+            )
         get_size = getattr(value, "get_size", None)
         if callable(get_size):
             from xnano.beta.components.component import ComponentRenderContext
@@ -172,7 +174,9 @@ class TerminalController:
         owner: Any = None,
         owner_field_name: str | None = None,
     ) -> None:
-        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        if isinstance(value, collections.abc.Sequence) and not isinstance(
+            value, (str, bytes)
+        ):
             direction = field.direction or "vertical"
             gap = field.gap or 0
             constraints = [

--- a/xnano/beta/core/runtime.py
+++ b/xnano/beta/core/runtime.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import atexit
 import contextvars
 import signal
+import time
 from typing import Any, Generic, Sequence, TypeVar
 
 from xnano_core.core import CoreSession
@@ -112,6 +113,7 @@ class Runtime(Generic[StateT]):
         state: StateT | None = None,
         title: str | None = None,
         surface: str = "terminal",
+        tick_interval: int = 16,
     ) -> None:
         self._session = session
         self._live = live
@@ -127,6 +129,8 @@ class Runtime(Generic[StateT]):
         self._stage = Stage()
         self._elapsed_ms = 0
         self._tick_hook_times: dict[tuple[int, str], int] = {}
+        self._tick_interval = max(1, tick_interval)
+        self._last_tick_ms = time.monotonic() * 1000
         self._signals_installed = False
         self._prev_signal_handlers: dict[signal.Signals, Any] = {}
         self._cursor = Cursor(self)
@@ -141,11 +145,17 @@ class Runtime(Generic[StateT]):
         *,
         state: StateT | None = None,
         title: str | None = None,
-        tick_interval: int | None = None,
+        tick_interval: int = 16,
     ) -> "Runtime[StateT]":
         """Create a runtime backed by the active terminal."""
-        session = CoreSession.init(tick_rate_ms=tick_interval)
-        return cls(session, live=True, state=state, title=title)
+        session = CoreSession.init(tick_rate_ms=None)
+        return cls(
+            session,
+            live=True,
+            state=state,
+            title=title,
+            tick_interval=tick_interval,
+        )
 
     @classmethod
     def offscreen(
@@ -239,6 +249,11 @@ class Runtime(Generic[StateT]):
         try:
             self._session.restore()
         finally:
+            # Runtime owns cursor/device/action proxies that point back to it,
+            # so the Python object can remain in a reference cycle after
+            # close. Release the unsendable PyO3 session now, on its owner
+            # thread, instead of leaving its destructor to a later GC pass.
+            del self._session
             self._restore_signal_handlers()
 
     def __enter__(self) -> "Runtime[StateT]":
@@ -442,13 +457,25 @@ class Runtime(Generic[StateT]):
         """Poll and dispatch at most one event."""
         if self._should_exit:
             return False
-        native_event = self._session.poll_event(max(0, int(timeout * 1000)))
+        timeout_ms = max(0, int(timeout * 1000))
+        if self._live and timeout_ms == 0:
+            timeout_ms = self._tick_interval
+        native_event = self._session.poll_event(timeout_ms)
         if native_event is not None:
             self.dispatch(event_from_core(native_event))
         elif self._root is not None:
             from xnano.beta.core.dispatch import dispatch_idle
 
             dispatch_idle(self._root, self)
+        if self._root is not None:
+            from xnano.beta.events import Event, TickEventData
+
+            now = time.monotonic() * 1000
+            elapsed_ms = max(0, int(now - self._last_tick_ms))
+            self._last_tick_ms = now
+            self.dispatch(
+                Event.from_data(TickEventData(elapsed_ms=elapsed_ms))
+            )
         return not self._should_exit
 
     def dispatch(self, event: Any) -> None:

--- a/xnano/beta/server/native.py
+++ b/xnano/beta/server/native.py
@@ -8,12 +8,13 @@ Render beta applications offscreen and expose their cell frames to browsers.
 from __future__ import annotations
 
 import html
+import http.server
 import json
 import urllib.parse
 from typing import Any, Callable
 
 from xnano.beta.core.runtime import Runtime
-from xnano.beta.server.requests import RequestServer, _RequestHandler
+from xnano.beta.server.requests import _RequestHandler
 
 _CLIENT_HTML = """<!doctype html>
 <meta charset="utf-8">
@@ -61,7 +62,7 @@ paint(); setInterval(paint,50);
 </script>"""
 
 
-class NativeWebServer(RequestServer):
+class NativeWebServer(http.server.HTTPServer):
     """Serve one application from an owned offscreen runtime.
 
     Attributes:
@@ -78,7 +79,7 @@ class NativeWebServer(RequestServer):
         >>> server.server_close()
     """
 
-    runtime: Runtime[Any]
+    runtime: Runtime[Any] | None
 
     def __init__(
         self,
@@ -93,19 +94,39 @@ class NativeWebServer(RequestServer):
         self.factory = factory
         self.root = factory()
         self.title = title
-        self.runtime = Runtime.offscreen(
-            width,
-            height,
-            state=state,
-            title=title,
-        )
-        self.runtime.set_root(self.root)
-        super().__init__(address, self.root, runtime=self.runtime)
-        self.RequestHandlerClass = _NativeWebHandler
+        self.grid = self.root
+        self.runtime = None
+        self._state = state
+        self._width = width
+        self._height = height
+        super().__init__(address, _NativeWebHandler)
+
+    def _ensure_runtime(self) -> Runtime[Any]:
+        """Create the unsendable native session on the serving thread."""
+        if self.runtime is None:
+            self.runtime = Runtime.offscreen(
+                self._width,
+                self._height,
+                state=self._state,
+                title=self.title,
+            )
+            self.runtime.set_root(self.root)
+        return self.runtime
+
+    def serve_forever(self, poll_interval: float = 0.5) -> None:
+        """Serve requests and release the runtime on its owner thread."""
+        try:
+            super().serve_forever(poll_interval)
+        finally:
+            if self.runtime is not None:
+                self.runtime.close()
+                self.runtime = None
 
     def server_close(self) -> None:
         """Close both the HTTP listener and offscreen runtime."""
-        self.runtime.close()
+        if self.runtime is not None:
+            self.runtime.close()
+            self.runtime = None
         super().server_close()
 
 
@@ -130,7 +151,7 @@ class _NativeWebHandler(_RequestHandler):
             self.wfile.write(payload)
             return
         if parsed.path == "/xnano/frame":
-            frame = self.server.runtime.render()
+            frame = self.server._ensure_runtime().render()
             payload = json.dumps(
                 {
                     "text": frame.text,
@@ -148,12 +169,14 @@ class _NativeWebHandler(_RequestHandler):
             self.end_headers()
             self.wfile.write(payload)
             return
+        self.server._ensure_runtime()
         self._dispatch_request()
 
     def do_POST(self) -> None:
         """Dispatch browser input or a declared POST route."""
         parsed = urllib.parse.urlsplit(self.path)
         if parsed.path != "/xnano/event":
+            self.server._ensure_runtime()
             self._dispatch_request()
             return
         try:
@@ -171,7 +194,7 @@ class _NativeWebHandler(_RequestHandler):
         ):
             self.send_error(400, "Invalid browser event")
             return
-        self.server.runtime.dispatch(event)
+        self.server._ensure_runtime().dispatch(event)
         self.send_response(204)
         self.end_headers()
 

--- a/xnano/beta/server/requests.py
+++ b/xnano/beta/server/requests.py
@@ -41,7 +41,7 @@ class RequestServer(http.server.ThreadingHTTPServer):
         runtime: Any | None = None,
     ) -> None:
         self.grid = grid() if isinstance(grid, type) else grid
-        self.runtime = runtime
+        self.runtime = runtime if runtime is not None else self.grid
         super().__init__(address, _RequestHandler)
 
 

--- a/xnano/beta/terminal.py
+++ b/xnano/beta/terminal.py
@@ -56,7 +56,7 @@ class Terminal(Generic[StateT]):
         *,
         state: StateT | None = None,
         title: str | None = None,
-        tick_interval: int | None = None,
+        tick_interval: int = 16,
     ) -> None:
         self._state = state
         self._title = title


### PR DESCRIPTION
## Summary

- drive beta tick hooks from a bounded monotonic runtime clock so mutations repaint without waiting for terminal input
- preserve HTTP hook responses and keep web offscreen sessions on their owning thread
- release native sessions during close to prevent cross-thread PyO3 destruction
- add behavioral end-to-end coverage for hooks, actions, fields, components, terminal loops, requests, and browser events
- bump xnano to 1.1.3 and update installation references

## Validation

- `uv run pytest -q` (1450 passed, 6 skipped)
- `uv run pytest tests/beta -q -W error::pytest.PytestUnraisableExceptionWarning`
- `uv run prek run --all-files`