### PR TITLE
beta: ergonomics + bug-fix pass (fill, scroll, focus, threading, options)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,6 @@ norecursedirs = [
 [tool.maturin.env]
 PYO3_USE_ABI3_FORWARD_COMPATIBILITY = "1"
 
-[tool.ty.analysis]
-strict-equality-semantics = false
-
 [tool.ty.environment]
 extra-paths = ["xnano-core/python"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,9 @@ norecursedirs = [
 [tool.maturin.env]
 PYO3_USE_ABI3_FORWARD_COMPATIBILITY = "1"
 
+[tool.ty.analysis]
+strict-equality-semantics = false
+
 [tool.ty.environment]
 extra-paths = ["xnano-core/python"]
 

--- a/tests/beta/test_field_component_matrix.py
+++ b/tests/beta/test_field_component_matrix.py
@@ -99,6 +99,7 @@ _FIELD_PROFILES: tuple[tuple[str, dict[str, Any]], ...] = (
         {
             "color": "yellow",
             "background": "blue",
+            "fill": True,
             "modifiers": ("bold", "underline"),
             "class_name": "p-1 text-red-500 bg-slate-900",
         },

--- a/tests/beta/test_field_fill.py
+++ b/tests/beta/test_field_fill.py
@@ -1,0 +1,55 @@
+"""tests.beta.test_field_fill
+
+---
+
+Field/Text background fill: a set ``background`` fills the whole slot by
+default, ``fill=False`` reverts to accent-behind-glyphs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from xnano.beta.core import Runtime
+from xnano.beta.fields import Field
+from xnano.beta.grids import BaseGrid
+from xnano.beta.types import frame_from_field
+
+
+def test_background_fills_slot_by_default() -> None:
+    field = Field(default="", background="blue")
+    frame = frame_from_field(field)
+    assert frame is not None
+    assert frame.background == "blue"
+
+
+def test_fill_false_reverts_to_accent() -> None:
+    field = Field(default="", background="blue", fill=False)
+    assert frame_from_field(field) is None
+
+
+def test_fill_true_without_chrome_produces_frame() -> None:
+    field = Field(default="", background="red", fill=True)
+    frame = frame_from_field(field)
+    assert frame is not None and frame.background == "red"
+
+
+def test_grid_update_field_toggles_fill() -> None:
+    class App(BaseGrid):
+        body: Any = Field(default="hi", background="blue")
+
+    runtime = Runtime.offscreen(20, 6)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        # Full-slot fill: painting cannot raise and the frame carries bg.
+        assert app._grid_field_frame("body", app._grid_field_info("body"))
+        app.grid_update_field("body", fill=False)
+        runtime.render()
+        assert (
+            app._grid_field_frame("body", app._grid_field_info("body"))
+            is None
+        )
+    finally:
+        runtime.close()

--- a/tests/beta/test_field_fill.py
+++ b/tests/beta/test_field_fill.py
@@ -48,8 +48,7 @@ def test_grid_update_field_toggles_fill() -> None:
         app.grid_update_field("body", fill=False)
         runtime.render()
         assert (
-            app._grid_field_frame("body", app._grid_field_info("body"))
-            is None
+            app._grid_field_frame("body", app._grid_field_info("body")) is None
         )
     finally:
         runtime.close()

--- a/tests/beta/test_field_scroll.py
+++ b/tests/beta/test_field_scroll.py
@@ -86,9 +86,7 @@ def test_mouse_wheel_moves_scroll() -> None:
         runtime.render()
         for _ in range(3):
             runtime.dispatch(
-                Event.from_data(
-                    MouseEventData(kind="scroll_down", x=2, y=2)
-                )
+                Event.from_data(MouseEventData(kind="scroll_down", x=2, y=2))
             )
         assert app._grid_scroll_handle("body").offset == 9
         wheeled = runtime.render().text

--- a/tests/beta/test_field_scroll.py
+++ b/tests/beta/test_field_scroll.py
@@ -1,0 +1,97 @@
+"""tests.beta.test_field_scroll
+
+---
+
+Field(scroll=) paints a windowed offset, reserves slot height, follows the
+tail, and moves on the mouse wheel.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from xnano.beta.components.text import Text
+from xnano.beta.core import Runtime
+from xnano.beta.events import Event, MouseEventData
+from xnano.beta.fields import Field
+from xnano.beta.grids import BaseGrid
+
+
+def _make_app() -> type[BaseGrid]:
+    class App(BaseGrid):
+        body: Any = Field(
+            default_factory=lambda: Text(
+                content="\n".join(f"line{i}" for i in range(20)),
+                wrap=False,
+            ),
+            height=5,
+            scroll=True,
+        )
+
+    return App
+
+
+def test_scroll_windows_and_reserves_height() -> None:
+    runtime = Runtime.offscreen(20, 5)
+    try:
+        app = _make_app()()
+        runtime.set_root(app)
+        top = runtime.render().text
+        assert "line0" in top and "line4" in top and "line5" not in top
+        handle = app._grid_scroll_handle("body")
+        handle.scroll(7)
+        mid = runtime.render().text
+        assert "line7" in mid and "line0" not in mid
+    finally:
+        runtime.close()
+
+
+def test_scroll_follow_tail() -> None:
+    runtime = Runtime.offscreen(20, 5)
+    try:
+        app = _make_app()()
+        runtime.set_root(app)
+        runtime.render()
+        app._grid_scroll_handle("body").scroll_to_end()
+        tail = runtime.render().text
+        assert "line19" in tail and "line15" in tail and "line14" not in tail
+    finally:
+        runtime.close()
+
+
+def test_scroll_short_content_reserves_full_height() -> None:
+    class App(BaseGrid):
+        body: Any = Field(
+            default_factory=lambda: Text(content="only\ntwo", wrap=False),
+            height=5,
+            scroll=True,
+        )
+
+    runtime = Runtime.offscreen(20, 5)
+    try:
+        app = App()
+        runtime.set_root(app)
+        frame = runtime.render()
+        assert frame.height == 5
+        assert app._grid_scroll_handle("body").offset == 0
+    finally:
+        runtime.close()
+
+
+def test_mouse_wheel_moves_scroll() -> None:
+    runtime = Runtime.offscreen(20, 5)
+    try:
+        app = _make_app()()
+        runtime.set_root(app)
+        runtime.render()
+        for _ in range(3):
+            runtime.dispatch(
+                Event.from_data(
+                    MouseEventData(kind="scroll_down", x=2, y=2)
+                )
+            )
+        assert app._grid_scroll_handle("body").offset == 9
+        wheeled = runtime.render().text
+        assert "line9" in wheeled
+    finally:
+        runtime.close()

--- a/tests/beta/test_focus_navigation.py
+++ b/tests/beta/test_focus_navigation.py
@@ -56,9 +56,13 @@ def test_arrow_keys_move_focus_spatially() -> None:
         runtime.set_root(app)
         runtime.render()
         ensure_default_field_focus(runtime)
-        runtime.dispatch(Event.from_data(KeyboardEventData.from_binding("down")))
+        runtime.dispatch(
+            Event.from_data(KeyboardEventData.from_binding("down"))
+        )
         assert runtime.focused_group == "b"
-        runtime.dispatch(Event.from_data(KeyboardEventData.from_binding("down")))
+        runtime.dispatch(
+            Event.from_data(KeyboardEventData.from_binding("down"))
+        )
         assert runtime.focused_group == "c"
         runtime.dispatch(Event.from_data(KeyboardEventData.from_binding("up")))
         assert runtime.focused_group == "b"
@@ -75,7 +79,9 @@ def test_click_moves_focus() -> None:
         ensure_default_field_focus(runtime)
         # Row 2 holds button C.
         runtime.dispatch(
-            Event.from_data(MouseEventData(kind="press", x=1, y=2, button="left"))
+            Event.from_data(
+                MouseEventData(kind="press", x=1, y=2, button="left")
+            )
         )
         assert runtime.focused_group == "c"
     finally:
@@ -96,12 +102,17 @@ def test_arrow_focus_disabled_without_autofocus() -> None:
         app = App()
         runtime.set_root(app)
         runtime.render()
-        from xnano.beta.utils.focus import set_field_focus, collect_focusable_fields
+        from xnano.beta.utils.focus import (
+            collect_focusable_fields,
+            set_field_focus,
+        )
 
         set_field_focus(runtime, collect_focusable_fields(runtime)[0])
         # Arrow keys are not hijacked when no field declares autofocus.
         consumed_before = runtime.focused_group
-        runtime.dispatch(Event.from_data(KeyboardEventData.from_binding("down")))
+        runtime.dispatch(
+            Event.from_data(KeyboardEventData.from_binding("down"))
+        )
         assert runtime.focused_group == consumed_before
     finally:
         runtime.close()

--- a/tests/beta/test_focus_navigation.py
+++ b/tests/beta/test_focus_navigation.py
@@ -1,0 +1,144 @@
+"""tests.beta.test_focus_navigation
+
+---
+
+Autofocus enables arrow-key spatial navigation and click-to-focus, computed
+from live layout geometry. Input(auto_height) grows a fit slot with content.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from xnano.beta.components.button import Button
+from xnano.beta.components.input import Input
+from xnano.beta.core import Runtime
+from xnano.beta.events import Event, KeyboardEventData, MouseEventData
+from xnano.beta.fields import Field
+from xnano.beta.grids import BaseGrid
+from xnano.beta.utils.focus import ensure_default_field_focus
+
+
+def _vertical_buttons() -> type[BaseGrid]:
+    class App(BaseGrid, direction="vertical"):
+        a: Any = Field(
+            default_factory=lambda: Button(label="A"),
+            group="a",
+            autofocus=True,
+            height=1,
+        )
+        b: Any = Field(
+            default_factory=lambda: Button(label="B"), group="b", height=1
+        )
+        c: Any = Field(
+            default_factory=lambda: Button(label="C"), group="c", height=1
+        )
+
+    return App
+
+
+def test_autofocus_selects_declared_field() -> None:
+    runtime = Runtime.offscreen(20, 3)
+    try:
+        app = _vertical_buttons()()
+        runtime.set_root(app)
+        runtime.render()
+        ensure_default_field_focus(runtime)
+        assert runtime.focused_group == "a"
+    finally:
+        runtime.close()
+
+
+def test_arrow_keys_move_focus_spatially() -> None:
+    runtime = Runtime.offscreen(20, 3)
+    try:
+        app = _vertical_buttons()()
+        runtime.set_root(app)
+        runtime.render()
+        ensure_default_field_focus(runtime)
+        runtime.dispatch(Event.from_data(KeyboardEventData.from_binding("down")))
+        assert runtime.focused_group == "b"
+        runtime.dispatch(Event.from_data(KeyboardEventData.from_binding("down")))
+        assert runtime.focused_group == "c"
+        runtime.dispatch(Event.from_data(KeyboardEventData.from_binding("up")))
+        assert runtime.focused_group == "b"
+    finally:
+        runtime.close()
+
+
+def test_click_moves_focus() -> None:
+    runtime = Runtime.offscreen(20, 3)
+    try:
+        app = _vertical_buttons()()
+        runtime.set_root(app)
+        runtime.render()
+        ensure_default_field_focus(runtime)
+        # Row 2 holds button C.
+        runtime.dispatch(
+            Event.from_data(MouseEventData(kind="press", x=1, y=2, button="left"))
+        )
+        assert runtime.focused_group == "c"
+    finally:
+        runtime.close()
+
+
+def test_arrow_focus_disabled_without_autofocus() -> None:
+    class App(BaseGrid, direction="vertical"):
+        a: Any = Field(
+            default_factory=lambda: Button(label="A"), group="a", height=1
+        )
+        b: Any = Field(
+            default_factory=lambda: Button(label="B"), group="b", height=1
+        )
+
+    runtime = Runtime.offscreen(20, 2)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        from xnano.beta.utils.focus import set_field_focus, collect_focusable_fields
+
+        set_field_focus(runtime, collect_focusable_fields(runtime)[0])
+        # Arrow keys are not hijacked when no field declares autofocus.
+        consumed_before = runtime.focused_group
+        runtime.dispatch(Event.from_data(KeyboardEventData.from_binding("down")))
+        assert runtime.focused_group == consumed_before
+    finally:
+        runtime.close()
+
+
+def test_input_auto_height_grows_and_clamps() -> None:
+    class App(BaseGrid, direction="vertical"):
+        history: Any = Field(default="top", height="1fr")
+        composer: Any = Field(
+            default_factory=lambda: Input(
+                content="",
+                auto_height=True,
+                min_rows=1,
+                max_rows=5,
+                wrap=True,
+            ),
+            height="fit",
+            border="rounded",
+        )
+
+    runtime = Runtime.offscreen(20, 12)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+
+        def composer_height() -> int:
+            area = runtime.stage.get_area("composer")
+            assert area is not None
+            return area.height
+
+        assert composer_height() == 3  # 1 row + rounded border
+        app.composer.value = "x" * 40
+        runtime.render()
+        assert composer_height() > 3
+        app.composer.value = "y" * 400
+        runtime.render()
+        assert composer_height() == 7  # max_rows 5 + border 2
+    finally:
+        runtime.close()

--- a/tests/beta/test_keyboard_and_chrome.py
+++ b/tests/beta/test_keyboard_and_chrome.py
@@ -1,0 +1,69 @@
+"""tests.beta.test_keyboard_and_chrome
+
+---
+
+Bare-modifier keyboard bindings and the chrome-owns-the-border rule for
+nested grids.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from xnano.beta.core import Runtime
+from xnano.beta.events import KeyboardEventData
+from xnano.beta.fields import Field
+from xnano.beta.grids import BaseGrid
+
+
+def test_bare_modifier_binding_matches_modifier_press() -> None:
+    assert KeyboardEventData.from_binding("shift").matches("shift")
+    assert KeyboardEventData.from_binding("ctrl").matches("ctrl")
+    assert not KeyboardEventData.from_binding("shift").matches("ctrl")
+
+
+def test_bare_modifier_does_not_match_modified_key() -> None:
+    event = KeyboardEventData.from_binding("shift+a")
+    assert not event.matches("shift")
+    assert event.matches("shift+a")
+
+
+def test_plain_key_unaffected_by_bare_modifier_support() -> None:
+    event = KeyboardEventData.from_binding("a")
+    assert event.matches("a")
+    assert not event.matches("shift")
+
+
+def test_chrome_owns_border_suppresses_nested_double_border() -> None:
+    class Inner(BaseGrid, border="double"):
+        label: Any = Field(default="X")
+
+    class App(BaseGrid):
+        inner: Any = Field(default_factory=Inner, border="rounded")
+
+    runtime = Runtime.offscreen(14, 4)
+    try:
+        app = App()
+        runtime.set_root(app)
+        text = runtime.render().text
+        assert "╭" in text  # field's rounded border is drawn
+        assert "╔" not in text  # nested double border suppressed
+    finally:
+        runtime.close()
+
+
+def test_nested_border_kept_without_field_border() -> None:
+    class Inner(BaseGrid, border="double"):
+        label: Any = Field(default="X")
+
+    class App(BaseGrid):
+        inner: Any = Field(default_factory=Inner)
+
+    runtime = Runtime.offscreen(14, 4)
+    try:
+        app = App()
+        runtime.set_root(app)
+        text = runtime.render().text
+        assert "╔" in text  # nested grid keeps its own border
+    finally:
+        runtime.close()

--- a/tests/beta/test_options_ergonomics.py
+++ b/tests/beta/test_options_ergonomics.py
@@ -41,9 +41,7 @@ def test_accept_policies() -> None:
 
 
 def test_select_value_survives_rebuild() -> None:
-    opts = Options(
-        items=(Option("A", value="a"), Option("B", value="b"))
-    )
+    opts = Options(items=(Option("A", value="a"), Option("B", value="b")))
     opts.selected = 1
     assert opts.selected_value == "b"
     opts.items = (

--- a/tests/beta/test_options_ergonomics.py
+++ b/tests/beta/test_options_ergonomics.py
@@ -1,0 +1,74 @@
+"""tests.beta.test_options_ergonomics
+
+---
+
+Options filter modes, submission accept policy, stable value selection, and
+the reserved-slot layout pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from xnano.beta.components.options import Option, Options
+from xnano.beta.core import Runtime
+from xnano.beta.fields import Field
+from xnano.beta.grids import BaseGrid
+
+
+def test_filter_modes() -> None:
+    opts = Options(items=("apple", "apricot", "banana"), query="ap")
+    opts.filter = "prefix"
+    assert opts.visible_items == ("apple", "apricot")
+    opts.filter = "none"
+    assert opts.visible_items == ("apple", "apricot", "banana")
+    opts.filter = lambda query, text: text.startswith("b")
+    assert opts.visible_items == ("banana",)
+    opts.filter = False
+    assert opts.visible_items == ("apple", "apricot", "banana")
+
+
+def test_accept_policies() -> None:
+    opts = Options(items=("/model", "/memory"), query="/mod")
+    opts.selected = 0
+    opts.accept = "if_prefix_only"
+    assert opts.resolve_submission("/mod") == "/model"
+    assert opts.resolve_submission("/model gpt") == "/model gpt"
+    opts.accept = "replace"
+    assert opts.resolve_submission("/mod") == "/model"
+    opts.accept = "extend"
+    assert opts.resolve_submission("/mod") == "/mod"
+
+
+def test_select_value_survives_rebuild() -> None:
+    opts = Options(
+        items=(Option("A", value="a"), Option("B", value="b"))
+    )
+    opts.selected = 1
+    assert opts.selected_value == "b"
+    opts.items = (
+        Option("X", value="x"),
+        Option("B", value="b"),
+        Option("A", value="a"),
+    )
+    assert opts.select_value("b") is True
+    assert opts.selected_value == "b"
+
+
+def test_reserved_slot_keeps_layout_stable() -> None:
+    class App(BaseGrid, direction="vertical"):
+        header: Any = Field(default="HEADER", height=1)
+        palette: Any = Field(default=None, visible=True, height=4)
+        footer: Any = Field(default="FOOTER", height=1)
+
+    runtime = Runtime.offscreen(20, 8)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        footer_y = runtime.stage.get_area("footer").y
+        app.palette = Options(items=("one", "two"))
+        runtime.render()
+        assert runtime.stage.get_area("footer").y == footer_y
+    finally:
+        runtime.close()

--- a/tests/beta/test_reactivity_threading.py
+++ b/tests/beta/test_reactivity_threading.py
@@ -1,0 +1,87 @@
+"""tests.beta.test_reactivity_threading
+
+---
+
+Thread-safe UI updates (ctx.call_soon / grid.schedule_update), non-raising
+optional style patches, and inline Loader frames.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from xnano.beta.components.loader import Loader
+from xnano.beta.core import Runtime
+from xnano.beta.fields import Field
+from xnano.beta.grids import BaseGrid
+
+
+def test_call_soon_applies_worker_update_on_ui_thread() -> None:
+    class App(BaseGrid):
+        status: Any = Field(default="init")
+
+    runtime = Runtime.offscreen(20, 3)
+    try:
+        app = App()
+        runtime.set_root(app)
+
+        def worker() -> None:
+            runtime.call_soon(lambda: setattr(app, "status", "from-worker"))
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+        assert app.status == "init"  # not applied until pump drains
+        runtime.pump(0.0)
+        assert app.status == "from-worker"
+    finally:
+        runtime.close()
+
+
+def test_schedule_update_runs_callback_and_marks_dirty() -> None:
+    class App(BaseGrid):
+        body: Any = Field(default="a")
+
+    runtime = Runtime.offscreen(20, 3)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.enter()
+        app.schedule_update(lambda: setattr(app, "body", "b"), field="body")
+        runtime.pump(0.0)
+        assert app.body == "b"
+    finally:
+        runtime.close()
+
+
+def test_grid_update_field_missing_is_noop() -> None:
+    class App(BaseGrid):
+        body: Any = Field(default="a")
+        count: int = Field(default=1, state=True)
+
+    app = App()
+    # Missing field, and a state field: both are no-ops, no exception.
+    app.grid_update_field("does_not_exist", color="red")
+    app.grid_update_field("count", color="red")
+
+
+def test_loader_inline_frame_is_a_glyph() -> None:
+    loader = Loader(style="spinner", symbols="line")
+    assert loader.current_frame() in ("-", "\\", "|", "/")
+    assert loader.inline_text() == loader.current_frame()
+
+
+def test_loader_visible_false_hides() -> None:
+    class App(BaseGrid):
+        spin: Any = Field(
+            default_factory=lambda: Loader(style="spinner", visible=False)
+        )
+
+    runtime = Runtime.offscreen(10, 1)
+    try:
+        app = App()
+        runtime.set_root(app)
+        assert runtime.render().text.strip() == ""
+    finally:
+        runtime.close()

--- a/xnano/beta/components/input.py
+++ b/xnano/beta/components/input.py
@@ -8,9 +8,14 @@ Edit single-line or multiline text with optional masking and length limits.
 from __future__ import annotations
 
 import dataclasses
-from typing import Sequence
+import math
+from typing import TYPE_CHECKING, Sequence
 
 from xnano.beta.components.text import Text
+from xnano.beta.types import Size
+
+if TYPE_CHECKING:
+    from xnano.beta.components.component import ComponentRenderContext
 
 
 @dataclasses.dataclass
@@ -18,22 +23,66 @@ class Input(Text):
     """Editable text field.
 
     Input is single-line by default. Set ``multiline=True`` for an editor
-    that supports line breaks, selection, and navigation.
+    that supports line breaks, selection, and navigation. Set
+    ``auto_height=True`` for a composer that grows as the text soft-wraps,
+    bounded by ``min_rows`` and ``max_rows`` — pair it with a
+    ``Field(height="fit")`` slot so layout consumes the reported height.
 
     Example:
         ``Input(placeholder="Search", submit_keys=("enter",))``
 
     Attributes:
         submit_keys: Keys reserved for submit hooks instead of text editing.
+        auto_height: Grow the reported height to fit soft-wrapped content.
+        min_rows: Minimum reported height when ``auto_height`` is set.
+        max_rows: Maximum reported height when ``auto_height`` is set.
     """
 
     submit_keys: Sequence[str] = ("enter",)
     """Read-only convenience for hook matching; not consumed here."""
+    auto_height: bool = False
+    """Report a preferred height that grows with soft-wrapped content.
+
+    Works with a ``Field(height="fit")`` slot: the input measures how many
+    rows its value occupies at the available width and reports that height,
+    clamped to ``[min_rows, max_rows]`` — no manual ``grid_set_field`` loop.
+    """
+    min_rows: int = 1
+    """Smallest reported height (rows) while ``auto_height`` is set."""
+    max_rows: int | None = None
+    """Largest reported height (rows) while ``auto_height`` is set, or
+    ``None`` for unbounded growth."""
 
     def component_post_init(self) -> None:
         """Force input mode, then run ``Text`` editor setup."""
         self.input = True
         super().component_post_init()
+
+    def _wrapped_row_count(self, text: str, width: int) -> int:
+        """Return how many rows ``text`` occupies at ``width`` cells."""
+        lines = text.split("\n")
+        if width <= 0 or not self.wrap:
+            return max(1, len(lines))
+        rows = 0
+        for line in lines:
+            rows += max(1, math.ceil(len(line) / width))
+        return max(1, rows)
+
+    def get_size(self, ctx: "ComponentRenderContext") -> Size:
+        """Report the preferred cell size, growing with content when asked."""
+        text = self.value
+        width = ctx.area.width
+        if self.auto_height:
+            rows = self._wrapped_row_count(text, width)
+            rows = max(self.min_rows, rows)
+            if self.max_rows is not None:
+                rows = min(self.max_rows, rows)
+        else:
+            rows = self.rows if self.rows is not None else text.count("\n") + 1
+        preferred_width = width or max(
+            (len(line) for line in text.split("\n")), default=0
+        )
+        return Size(width=preferred_width, height=rows)
 
 
 __all__ = ("Input",)

--- a/xnano/beta/components/loader.py
+++ b/xnano/beta/components/loader.py
@@ -170,6 +170,21 @@ class Loader(Component):
         self._epoch_ns = time.monotonic_ns()
         self._frozen_frame = 0
 
+    def current_frame(self) -> str:
+        """Return the active spinner glyph, advanced by the framework clock.
+
+        The inline path: embed this in any ``Text``/flow content to animate a
+        spinner mid-line without a manual per-tick frame counter — e.g.
+        ``Text(content=f"{loader.current_frame()} generating…")``.
+        """
+        return self._resolved_symbols[self._spinner_frame_index()]
+
+    def inline_text(self) -> str:
+        """Return the spinner glyph plus its label for inline embedding."""
+        label = self._resolve_label_text()
+        frame = self.current_frame()
+        return frame if not label else f"{frame} {label}"
+
     def _resolve_label_text(self) -> str | None:
         label = self.label
         if label is False:

--- a/xnano/beta/components/options.py
+++ b/xnano/beta/components/options.py
@@ -16,6 +16,7 @@ from typing import (
     Sequence,
     TypeAlias,
     Union,
+    cast,
 )
 
 from xnano.beta.components.component import Component
@@ -279,10 +280,11 @@ class Options(Component):
         if mode == "none" or not self.query:
             pairs = [(index, ()) for index in range(len(self.items))]
         elif callable(mode):
+            predicate = cast("Callable[[str, str], bool]", mode)
             pairs = [
                 (index, ())
                 for index, item in enumerate(self.items)
-                if mode(self.query, _item_text(item))
+                if predicate(self.query, _item_text(item))
             ]
         elif mode == "prefix":
             lowered = self.query.lower()

--- a/xnano/beta/components/options.py
+++ b/xnano/beta/components/options.py
@@ -8,7 +8,15 @@ Display and search a list of choices with keyboard selection.
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Literal, Sequence, TypeAlias
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Literal,
+    Sequence,
+    TypeAlias,
+    Union,
+)
 
 from xnano.beta.components.component import Component
 from xnano.beta.types import CharacterModifier
@@ -23,6 +31,30 @@ _WORD_BOUNDARIES = " _-./:"
 
 OptionsDirection: TypeAlias = Literal["top_to_bottom", "bottom_to_top"]
 """Visual order of option rows in the list."""
+
+FilterMode: TypeAlias = Union[
+    Literal["fuzzy", "prefix", "none"],
+    bool,
+    Callable[[str, str], bool],
+]
+"""How ``query`` narrows the visible items.
+
+- ``"fuzzy"`` (or ``True``): subsequence fuzzy match with scoring.
+- ``"prefix"``: keep items whose text starts with the query.
+- ``"none"`` (or ``False``): show every item; the query is ignored, so an
+  external driver can supply items that are already filtered.
+- a callable ``(query, item_text) -> bool``: keep items it returns truthy for.
+"""
+
+AcceptPolicy: TypeAlias = Literal["replace", "extend", "if_prefix_only"]
+"""How ``resolve_submission`` reconciles typed text with the highlighted row.
+
+- ``"replace"``: accept the highlighted item's text.
+- ``"extend"``: keep exactly what the user typed.
+- ``"if_prefix_only"``: keep the selection while the typed text is still an
+  incomplete prefix of it; otherwise honor the typed text (so trailing args
+  such as ``"/vibe hungry 7"`` are not dropped).
+"""
 
 OptionItem: TypeAlias = "str | Text | Option"
 """A single entry accepted by ``Options.items``."""
@@ -192,10 +224,15 @@ class Options(Component):
     """Filter text. Edited by typing while focused when ``searchable``;
     assign it from a hook to filter reactively.
     """
-    filter: bool = True
-    """Whether ``query`` fuzzy-filters the visible items. When
-    ``False`` the query is ignored and all items stay visible.
+    filter: FilterMode = "fuzzy"
+    """How ``query`` narrows the visible items — see ``FilterMode``.
+
+    ``"fuzzy"``/``True`` fuzzy-match, ``"prefix"`` prefix-match, ``"none"``/
+    ``False`` show everything (for externally filtered items), or a
+    ``(query, item_text) -> bool`` callable.
     """
+    accept: AcceptPolicy = "replace"
+    """How ``resolve_submission`` reconciles typed text with the selection."""
     searchable: bool = True
     """Whether typing while focused edits ``query`` directly."""
     selected: int = 0
@@ -226,12 +263,36 @@ class Options(Component):
     owns_cursor: bool = dataclasses.field(default=True, init=False)
     """Whether selection replaces the hardware caret."""
 
+    def _filter_mode(self) -> "str | Callable[[str, str], bool]":
+        """Normalize ``filter`` into a mode name or callable."""
+        mode = self.filter
+        if mode is True:
+            return "fuzzy"
+        if mode is False:
+            return "none"
+        return mode
+
     def _filtered(self) -> list[tuple[int, tuple[int, ...]]]:
         """Return ``(item_index, matched_indices)`` in display order."""
+        mode = self._filter_mode()
         pairs: list[tuple[int, tuple[int, ...]]]
-        if not self.filter or not self.query:
+        if mode == "none" or not self.query:
             pairs = [(index, ()) for index in range(len(self.items))]
-        else:
+        elif callable(mode):
+            pairs = [
+                (index, ())
+                for index, item in enumerate(self.items)
+                if mode(self.query, _item_text(item))
+            ]
+        elif mode == "prefix":
+            lowered = self.query.lower()
+            matched = tuple(range(len(self.query)))
+            pairs = [
+                (index, matched)
+                for index, item in enumerate(self.items)
+                if _item_text(item).lower().startswith(lowered)
+            ]
+        else:  # "fuzzy"
             scored: list[tuple[int, int, tuple[int, ...]]] = []
             for index, item in enumerate(self.items):
                 match = get_fuzzy_match(self.query, _item_text(item))
@@ -274,6 +335,61 @@ class Options(Component):
             return None
         selected = max(0, min(self.selected, len(visible) - 1))
         return self.items[visible[selected][0]]
+
+    @property
+    def selected_value(self) -> Any | None:
+        """Stable stored value of the selection (alias of ``value``).
+
+        Use with ``select_value`` to preserve a selection across item
+        rebuilds by value/id rather than by fragile filtered index.
+        """
+        return self.value
+
+    @property
+    def selected_label(self) -> str:
+        """Plain display text of the selected item, or ``""`` when empty."""
+        item = self.selected_item
+        return "" if item is None else _item_text(item)
+
+    def select_value(self, value: Any) -> bool:
+        """Select the visible item whose stored value equals ``value``.
+
+        Returns ``True`` when a match is found. The stable way to keep a
+        selection pinned across item rebuilds: store the value, rebuild
+        ``items``, then re-select by value.
+        """
+        for index, (item_index, _) in enumerate(self._filtered()):
+            if _item_value(self.items[item_index]) == value:
+                self.selected = index
+                return True
+        return False
+
+    def resolve_submission(self, typed: str) -> str:
+        """Reconcile typed composer text with the selection per ``accept``.
+
+        Removes the userland "did they Tab-complete this row or type past
+        it?" logic. See ``AcceptPolicy`` for the per-policy behavior.
+        """
+        typed = typed or ""
+        selected = self.selected_label
+        if self.accept == "extend" or not selected:
+            return typed
+        if self.accept == "replace":
+            return selected
+        # if_prefix_only
+        typed_stripped = typed.strip()
+        selected_stripped = selected.strip()
+        if not typed_stripped:
+            return selected
+        typed_lower = typed_stripped.lower()
+        selected_lower = selected_stripped.lower()
+        if typed_lower == selected_lower or typed_lower.startswith(
+            selected_lower + " "
+        ):
+            return typed
+        if selected_lower.startswith(typed_lower):
+            return selected
+        return selected
 
     def move(self, delta: int) -> None:
         """Move ``selected`` by ``delta``, skipping disabled entries.
@@ -559,6 +675,8 @@ Select = Options
 
 
 __all__ = (
+    "AcceptPolicy",
+    "FilterMode",
     "Option",
     "OptionItem",
     "Options",

--- a/xnano/beta/components/text.py
+++ b/xnano/beta/components/text.py
@@ -422,7 +422,7 @@ class Text(Component):
 
     def _compose_content(
         self, ctx: ComponentRenderContext[Any]
-    ) -> TextBlock | Native | None:
+    ) -> TextBlock | Native | Panel | None:
         """Compose the interface-neutral content, without fill wrapping."""
         self._sync_editor_state()
 
@@ -656,7 +656,7 @@ class Text(Component):
 
     def get_terminal_node(
         self, ctx: ComponentRenderContext[Any]
-    ) -> TextBlock | Native | None:
+    ) -> TextBlock | Native | Panel | None:
         """Return composed content for terminal compatibility.
 
         Args:

--- a/xnano/beta/components/text.py
+++ b/xnano/beta/components/text.py
@@ -11,7 +11,7 @@ import dataclasses
 from typing import TYPE_CHECKING, Any, Sequence
 
 from xnano.beta.components.component import Component, ComponentRenderContext
-from xnano.beta.core.content import Native, Run, TextBlock
+from xnano.beta.core.content import Native, Panel, Run, TextBlock
 from xnano.beta.types import Alignment, CharacterModifier
 
 if TYPE_CHECKING:
@@ -51,6 +51,7 @@ class Text(Component):
         read_only: Reject edits while remaining focusable.
         tab_size: Tab width for multiline tab expansion.
         focusable: Whether this component takes field focus.
+        fill: Whether ``background`` fills the whole slot, not only glyphs.
     """
 
     content: str | Text | list[str | Text] = dataclasses.field(default="")
@@ -93,6 +94,11 @@ class Text(Component):
     """Tab width applied to multiline tab insertion and paste."""
     focusable: bool = False
     """Whether this component participates in field focus."""
+    fill: bool = False
+    """Whether ``background`` fills the whole slot rather than only the
+    text glyphs. When ``True`` short lines still paint the background across
+    the full cell width (no manual right-padding required).
+    """
 
     _editor: Any = dataclasses.field(
         default=None, init=False, repr=False, compare=False
@@ -394,7 +400,7 @@ class Text(Component):
 
     def compose(
         self, ctx: ComponentRenderContext[Any]
-    ) -> TextBlock | Native | None:
+    ) -> TextBlock | Native | Panel | None:
         """Compose interface-neutral content for this Text.
 
         Args:
@@ -402,7 +408,22 @@ class Text(Component):
 
         Returns:
             A ``TextBlock``, ``Native`` editor payload, or nested content.
+            When ``fill`` is set the block is wrapped in a background
+            ``Panel`` so the color spans the full slot.
         """
+        content = self._compose_content(ctx)
+        if (
+            self.fill
+            and self.background is not None
+            and isinstance(content, TextBlock)
+        ):
+            return Panel(child=content, background=self.background)
+        return content
+
+    def _compose_content(
+        self, ctx: ComponentRenderContext[Any]
+    ) -> TextBlock | Native | None:
+        """Compose the interface-neutral content, without fill wrapping."""
         self._sync_editor_state()
 
         if self._editor is not None:

--- a/xnano/beta/context.py
+++ b/xnano/beta/context.py
@@ -9,7 +9,7 @@ layout from an event hook.
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 
 if TYPE_CHECKING:
     from xnano.beta.actions import Actions
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
         KeyboardEventData,
         MouseEventData,
     )
-    from xnano.beta.types import ScrollHandle
+    from xnano.beta.types import Area, ScrollHandle
     from xnano.beta.utils.responsive import Breakpoint
 
 
@@ -188,6 +188,23 @@ class Context(Generic[StateT]):
     def is_focused(self, group: str) -> bool:
         """Return whether the field labeled ``group`` currently holds focus."""
         return self.focused_group == group
+
+    def call_soon(self, callback: "Callable[..., Any]", *args: Any) -> None:
+        """Schedule ``callback`` to run on the UI thread before the next pump.
+
+        The thread-safe bridge for updating grid state from a worker thread:
+        the callback runs on the runtime's own thread, so it can freely mutate
+        components/fields without racing the renderer.
+        """
+        self.terminal.call_soon(callback, *args)
+
+    def field_area(self, name: str) -> "Area | None":
+        """Return the last painted area for field ``name``, if known.
+
+        Reads the always-on layout map so viewports and chrome math can use
+        measured slot sizes instead of guessing.
+        """
+        return self.stage.get_area(name)
 
     def scroll(self, group: str) -> "ScrollHandle | None":
         """Return a scroll handle for ``Field(scroll=...)`` labeled ``group``."""

--- a/xnano/beta/core/controller.py
+++ b/xnano/beta/core/controller.py
@@ -8,6 +8,7 @@ Paint beta grids through their complete layout pipeline.
 from __future__ import annotations
 
 import collections.abc
+import copy
 from typing import Any
 
 import xnano_core.rust.native as native
@@ -18,6 +19,56 @@ from xnano.beta.core.layout import LayoutConstraint
 from xnano.beta.core.rendering import lower_content
 from xnano.beta.types import Area, Frame, Padding
 from xnano.beta.utils.responsive import resolve_responsive_variant
+
+
+def _string_content(value: Any) -> str | None:
+    """Return the plain-string content of a value, if it has one."""
+    if isinstance(value, str):
+        return value
+    content = getattr(value, "content", None)
+    return content if isinstance(content, str) else None
+
+
+def content_scroll_extent(value: Any, axis: str) -> int:
+    """Measure a scroll field's total content extent along ``axis``.
+
+    Rows for the ``"y"`` axis, columns for ``"x"``. Falls back to a
+    component's declared size when the value is not row-oriented text.
+    """
+    text = _string_content(value)
+    if text is not None:
+        lines = text.split("\n")
+        if axis == "y":
+            return len(lines)
+        return max((len(line) for line in lines), default=0)
+    if isinstance(value, collections.abc.Sequence) and not isinstance(
+        value, (str, bytes)
+    ):
+        return sum(content_scroll_extent(item, axis) for item in value)
+    return 0
+
+
+def window_scroll_value(value: Any, offset: int, axis: str) -> Any:
+    """Return ``value`` windowed by ``offset`` cells along ``axis``.
+
+    Drops the leading ``offset`` rows/columns of plain-string content so the
+    fixed-height slot (which clips the bottom natively) shows the window.
+    Non-text values are returned unchanged.
+    """
+    if offset <= 0:
+        return value
+    text = _string_content(value)
+    if text is None:
+        return value
+    if axis == "y":
+        windowed = "\n".join(text.split("\n")[offset:])
+    else:
+        windowed = "\n".join(line[offset:] for line in text.split("\n"))
+    if isinstance(value, str):
+        return windowed
+    clone = copy.copy(value)
+    object.__setattr__(clone, "content", windowed)
+    return clone
 
 
 class TerminalController:
@@ -174,7 +225,11 @@ class TerminalController:
         effect_key: str | None = None,
         owner: Any = None,
         owner_field_name: str | None = None,
+        scroll_offset: int = 0,
+        scroll_axis: str = "y",
     ) -> None:
+        if scroll_offset > 0:
+            value = window_scroll_value(value, scroll_offset, scroll_axis)
         if isinstance(value, collections.abc.Sequence) and not isinstance(
             value, (str, bytes)
         ):

--- a/xnano/beta/core/controller.py
+++ b/xnano/beta/core/controller.py
@@ -167,6 +167,10 @@ class TerminalController:
                 value = native.Constraint.min(constraint.value)
             elif constraint.kind == "max":
                 value = native.Constraint.max(constraint.value)
+            elif constraint.kind == "content":
+                # Size-to-content: a fit field claims exactly its measured
+                # content length (plus chrome), not a fill-weighted share.
+                value = native.Constraint.length(max(0, constraint.value))
             else:
                 value = native.Constraint.fill(max(1, constraint.value))
             lowered.append(value)
@@ -191,7 +195,12 @@ class TerminalController:
         ]
 
     def measure_field_slot(
-        self, value: Any, direction: str, field: Any = None
+        self,
+        value: Any,
+        direction: str,
+        field: Any = None,
+        *,
+        available_width: int = 0,
     ) -> int:
         if value is None:
             return 0
@@ -206,7 +215,7 @@ class TerminalController:
 
             size = get_size(
                 ComponentRenderContext(
-                    area=Area(x=0, y=0, width=0, height=0),
+                    area=Area(x=0, y=0, width=available_width, height=0),
                     terminal=self.runtime,
                     state=self.runtime.state,
                     component=value,

--- a/xnano/beta/core/controller.py
+++ b/xnano/beta/core/controller.py
@@ -263,7 +263,14 @@ class TerminalController:
                 )
             return
         if isinstance(getattr(type(value), "_grid_fields", None), dict):
-            value._grid_build_frame(area, self)
+            # Chrome owns the border: when the Field already frames this slot
+            # with a border, the nested grid must not draw a second one.
+            value._grid_build_frame(
+                area,
+                self,
+                suppress_frame_border=getattr(field, "border", None)
+                is not None,
+            )
             return
         compose = getattr(value, "compose", None)
         if callable(compose):

--- a/xnano/beta/core/runtime.py
+++ b/xnano/beta/core/runtime.py
@@ -466,9 +466,7 @@ class Runtime(Generic[StateT]):
         self._frame_commands.clear()
         return frame
 
-    def call_soon(
-        self, callback: Callable[..., Any], *args: Any
-    ) -> None:
+    def call_soon(self, callback: Callable[..., Any], *args: Any) -> None:
         """Schedule ``callback`` to run on the UI thread before the next pump.
 
         Thread-safe: worker threads enqueue here and the runtime drains the
@@ -538,17 +536,19 @@ class Runtime(Generic[StateT]):
         """
         if kind != "press":
             return
+        from xnano.beta.types import FieldFocus
         from xnano.beta.utils.focus import (
             is_focusable_component,
             set_field_focus,
             spatial_focus_enabled,
         )
-        from xnano.beta.types import FieldFocus
 
         if not spatial_focus_enabled(self):
             return
         value = getattr(hit.grid, hit.field_name, None)
-        if not (is_focusable_component(value) or getattr(field, "autofocus", None)):
+        if not (
+            is_focusable_component(value) or getattr(field, "autofocus", None)
+        ):
             return
         set_field_focus(
             self,

--- a/xnano/beta/core/runtime.py
+++ b/xnano/beta/core/runtime.py
@@ -485,6 +485,23 @@ class Runtime(Generic[StateT]):
             )
         return not self._should_exit
 
+    _WHEEL_STEP = 3
+
+    def _auto_scroll_wheel(self, hit: Any, field: Any, kind: str) -> None:
+        """Move a scroll field's handle when the wheel turns over it.
+
+        Wheel-to-scroll is free for any ``Field(scroll=...)``; user hooks can
+        still read/override the handle afterward.
+        """
+        if not getattr(field, "scroll", None):
+            return
+        if kind not in ("scroll_up", "scroll_down"):
+            return
+        handle = hit.grid._grid_scroll_handle(hit.field_name)
+        delta = -self._WHEEL_STEP if kind == "scroll_up" else self._WHEEL_STEP
+        handle.scroll(delta)
+        hit.grid.mark_field_dirty(hit.field_name)
+
     def dispatch(self, event: Any) -> None:
         """Dispatch one event to the root grid or component."""
         from xnano.beta.core.dispatch import dispatch_event
@@ -504,6 +521,7 @@ class Runtime(Generic[StateT]):
                 for hit in reversed(getattr(grid, "_grid_field_hits", ())):
                     if hit.area.contains((mouse.x, mouse.y)):
                         field = hit.grid._grid_field_info(hit.field_name)
+                        self._auto_scroll_wheel(hit, field, mouse.kind)
                         event = Event.from_data(
                             MouseEventData(
                                 kind=mouse.kind,

--- a/xnano/beta/core/runtime.py
+++ b/xnano/beta/core/runtime.py
@@ -8,10 +8,12 @@ Own live and offscreen sessions, rendering, events, state, focus, and output.
 from __future__ import annotations
 
 import atexit
+import collections
 import contextvars
 import signal
+import threading
 import time
-from typing import Any, Generic, Sequence, TypeVar
+from typing import Any, Callable, Generic, Sequence, TypeVar
 
 from xnano_core.core import CoreSession
 
@@ -139,6 +141,10 @@ class Runtime(Generic[StateT]):
         self._cursor = Cursor(self)
         self._device = Device(self)
         self._actions = Actions(self)
+        self._call_soon_queue: collections.deque[
+            tuple[Callable[..., Any], tuple[Any, ...]]
+        ] = collections.deque()
+        self._call_soon_lock = threading.Lock()
         if title is not None:
             self._device.title = title
 
@@ -460,8 +466,30 @@ class Runtime(Generic[StateT]):
         self._frame_commands.clear()
         return frame
 
+    def call_soon(
+        self, callback: Callable[..., Any], *args: Any
+    ) -> None:
+        """Schedule ``callback`` to run on the UI thread before the next pump.
+
+        Thread-safe: worker threads enqueue here and the runtime drains the
+        queue on its own thread, so background work can mutate grid state
+        without racing the renderer.
+        """
+        with self._call_soon_lock:
+            self._call_soon_queue.append((callback, args))
+
+    def _drain_call_soon(self) -> None:
+        """Run every queued ``call_soon`` callback on the UI thread."""
+        while True:
+            with self._call_soon_lock:
+                if not self._call_soon_queue:
+                    return
+                callback, args = self._call_soon_queue.popleft()
+            callback(*args)
+
     def pump(self, timeout: float = 0.0) -> bool:
         """Poll and dispatch at most one event."""
+        self._drain_call_soon()
         if self._should_exit:
             return False
         timeout_ms = max(0, int(timeout * 1000))

--- a/xnano/beta/core/runtime.py
+++ b/xnano/beta/core/runtime.py
@@ -502,6 +502,35 @@ class Runtime(Generic[StateT]):
         handle.scroll(delta)
         hit.grid.mark_field_dirty(hit.field_name)
 
+    def _click_to_focus(self, hit: Any, field: Any, kind: str) -> None:
+        """Focus a focusable field when it is clicked.
+
+        Opt-in with the same ``autofocus`` architecture as arrow navigation;
+        a press on a focusable (or ``autofocus``) field moves focus to it.
+        """
+        if kind != "press":
+            return
+        from xnano.beta.utils.focus import (
+            is_focusable_component,
+            set_field_focus,
+            spatial_focus_enabled,
+        )
+        from xnano.beta.types import FieldFocus
+
+        if not spatial_focus_enabled(self):
+            return
+        value = getattr(hit.grid, hit.field_name, None)
+        if not (is_focusable_component(value) or getattr(field, "autofocus", None)):
+            return
+        set_field_focus(
+            self,
+            FieldFocus(
+                grid=hit.grid,
+                field_name=hit.field_name,
+                group=field.group,
+            ),
+        )
+
     def dispatch(self, event: Any) -> None:
         """Dispatch one event to the root grid or component."""
         from xnano.beta.core.dispatch import dispatch_event
@@ -509,6 +538,8 @@ class Runtime(Generic[StateT]):
             apply_text_keyboard,
             cycle_field_focus,
             focused_component,
+            move_field_focus,
+            spatial_focus_enabled,
         )
 
         consumed = False
@@ -522,6 +553,7 @@ class Runtime(Generic[StateT]):
                     if hit.area.contains((mouse.x, mouse.y)):
                         field = hit.grid._grid_field_info(hit.field_name)
                         self._auto_scroll_wheel(hit, field, mouse.kind)
+                        self._click_to_focus(hit, field, mouse.kind)
                         event = Event.from_data(
                             MouseEventData(
                                 kind=mouse.kind,
@@ -547,6 +579,11 @@ class Runtime(Generic[StateT]):
                     focused_component(self),
                     keyboard,
                 )
+                if not consumed and spatial_focus_enabled(self):
+                    for direction in ("up", "down", "left", "right"):
+                        if keyboard.matches(direction):
+                            consumed = move_field_focus(self, direction)
+                            break
         clipboard = getattr(event, "clipboard_event", None)
         tick = getattr(event, "tick_event", None)
         if tick is not None:

--- a/xnano/beta/events.py
+++ b/xnano/beta/events.py
@@ -50,6 +50,10 @@ FocusEventKind: TypeAlias = Literal[
 _KEY_ALIASES = {"esc": "escape", "return": "enter", " ": "space"}
 
 
+_MODIFIER_KEYS: frozenset[str] = frozenset({"ctrl", "alt", "shift"})
+"""Modifier names accepted as standalone (bare) keyboard bindings."""
+
+
 def normalize_keyboard_binding(
     binding: str,
 ) -> tuple[frozenset[str], str]:
@@ -211,8 +215,22 @@ class KeyboardEventData(AbstractEventData):
         key = self.key
         return key if isinstance(key, str) and len(key) == 1 else None
 
+    def _matches_bare_modifier(self, modifier: str) -> bool:
+        """Return whether this event is a bare ``modifier`` key press.
+
+        Covers terminals that deliver a modifier press as a key whose name is
+        (or starts with) the modifier — e.g. ``"shift"``, ``"shiftleft"``.
+        """
+        key = self.key
+        if not isinstance(key, str):
+            return False
+        return key == modifier or key.startswith(modifier)
+
     def matches(self, *bindings: KeyboardBinding) -> bool:
         """Return whether this event matches any binding.
+
+        Bare modifiers (``"shift"``, ``"ctrl"``, ``"alt"``) match a
+        modifier-only key press, not a modified key such as ``"shift+a"``.
 
         Args:
             *bindings: Candidate keyboard bindings.
@@ -220,9 +238,15 @@ class KeyboardEventData(AbstractEventData):
         Returns:
             Whether at least one binding matches.
         """
-        if self._native_event is not None:
-            native_event: Any = self._native_event
-            for binding in bindings:
+        native_event: Any = self._native_event
+        own = normalize_keyboard_binding(str(self.binding))
+        for binding in bindings:
+            modifiers, key = normalize_keyboard_binding(str(binding))
+            if not modifiers and key in _MODIFIER_KEYS:
+                if self._matches_bare_modifier(key):
+                    return True
+                continue
+            if native_event is not None:
                 try:
                     if CoreKeyBinding.parse(str(binding)).matches(
                         native_event
@@ -230,12 +254,9 @@ class KeyboardEventData(AbstractEventData):
                         return True
                 except Exception:
                     continue
-            return False
-        own = normalize_keyboard_binding(str(self.binding))
-        return any(
-            normalize_keyboard_binding(str(binding)) == own
-            for binding in bindings
-        )
+            elif (modifiers, key) == own:
+                return True
+        return False
 
 
 @dataclasses.dataclass(slots=True, frozen=True)

--- a/xnano/beta/fields.py
+++ b/xnano/beta/fields.py
@@ -215,10 +215,14 @@ class GridFieldInfo:
     """Whether this field receives focus by default when nothing else is
     focused yet (preferred over declaration-order default selection)."""
     scroll: "types.ScrollLike | None" = None
-    """Enable windowed scrolling for a container field whose content
-    overflows its slot. ``True`` scrolls along ``direction``; pass
-    ``"vertical"``/``"horizontal"`` to force an axis. See ``ctx.scroll(group)``
-    for programmatic control (``.to_bottom()``, ``.follow``)."""
+    """Enable windowed scrolling for a field whose content overflows its slot.
+
+    ``True``/``"vertical"`` scrolls rows; ``"horizontal"`` scrolls columns.
+    A scroll field reserves its full slot height (short content leaves blank
+    rows) and the mouse wheel moves it automatically. Drive it programmatically
+    through ``ctx.scroll(group)`` — ``.scroll(delta)``, ``.scroll_to(offset)``,
+    ``.scroll_to_end()`` (tail-follow). Offset ``0`` shows the top; increasing
+    the offset reveals later content."""
     wireframe: bool | None = None
     """Live-toggle a debug overlay showing the cell grid this field
     occupies. Content renders normally underneath; this only adds a thin

--- a/xnano/beta/fields.py
+++ b/xnano/beta/fields.py
@@ -88,9 +88,12 @@ class GridFieldInfo:
             including "bold", "dim", "italic", "underline", "slow_blink", "rapid_blink",
             "reversed".
         color: The foreground color of content within this field.
-        background: The background color behind this field's text cells. Pair
-            with a filling ``width`` for a full-width bar; fills the framed
-            content area when the field also defines border/title/padding chrome.
+        background: The background color of this field. Fills the whole slot by
+            default when set (see ``fill``); also fills the framed content area
+            when the field defines border/title/padding chrome.
+        fill: Whether ``background`` fills the whole slot. ``None`` fills when a
+            background is set; ``True`` forces a full-slot fill; ``False`` paints
+            the color only behind text glyphs.
         width: Horizontal extent sizing (``10``, ``"50%"``, ``"1fr"``, ``"fit"``,
             or a ``Sizing``). Drives the split constraint in horizontal layouts;
             shrinks the slot along the cross axis otherwise.
@@ -151,11 +154,17 @@ class GridFieldInfo:
     background: ColorLike | None = None
     """The background color of content within this field.
 
-    Paints behind the field's text cells only, not the whole slot — so a plain
-    ``background`` reads as an accent behind the content. Pair it with a filling
-    ``width`` (e.g. ``width="1fr"``) for a full-width bar such as a header or
-    status line. When the field also defines border, title, or padding chrome,
-    this color fills the framed content area instead.
+    By default a ``background`` fills the field's whole slot (``fill`` is
+    treated as ``True`` when a background is set). Pass ``fill=False`` to revert
+    to the accent-behind-glyphs behavior, where the color paints only behind
+    text cells. When the field also defines border, title, or padding chrome,
+    the color fills the framed content area regardless of ``fill``.
+    """
+    fill: bool | None = None
+    """Whether ``background`` fills the whole slot.
+
+    ``None`` (the default) fills when a ``background`` is set; ``True`` forces a
+    full-slot fill; ``False`` paints the color only behind text glyphs.
     """
     width: "Sizing | None" = None
     """Sizing intent for the field's horizontal extent.
@@ -344,6 +353,7 @@ def Field(
     modifiers: Sequence[types.CharacterModifier] | None = None,
     color: ColorLike | None = None,
     background: ColorLike | None = None,
+    fill: bool | None = None,
     width: SizingLike | None = None,
     height: SizingLike | None = None,
     gap: int | None = None,
@@ -377,6 +387,7 @@ def Field(
     modifiers: Sequence[types.CharacterModifier] | None = None,
     color: ColorLike | None = None,
     background: ColorLike | None = None,
+    fill: bool | None = None,
     width: SizingLike | None = None,
     height: SizingLike | None = None,
     gap: int | None = None,
@@ -409,6 +420,7 @@ def Field(
     modifiers: Sequence[types.CharacterModifier] | None = None,
     color: ColorLike | None = None,
     background: ColorLike | None = None,
+    fill: bool | None = None,
     width: SizingLike | None = None,
     height: SizingLike | None = None,
     gap: int | None = None,
@@ -442,6 +454,7 @@ def Field(
     modifiers: Sequence[types.CharacterModifier] | None = None,
     color: ColorLike | None = None,
     background: ColorLike | None = None,
+    fill: bool | None = None,
     width: SizingLike | None = None,
     height: SizingLike | None = None,
     gap: int | None = None,
@@ -474,6 +487,7 @@ def Field(
     modifiers: Sequence[types.CharacterModifier] | None = None,
     color: ColorLike | None = None,
     background: ColorLike | None = None,
+    fill: bool | None = None,
     width: SizingLike | None = None,
     height: SizingLike | None = None,
     gap: int | None = None,
@@ -507,9 +521,12 @@ def Field(
             including "bold", "dim", "italic", "underline", "slow_blink", "rapid_blink",
             "reversed".
         color: The foreground color of content within this field.
-        background: The background color behind this field's text cells. Pair
-            with a filling ``width`` for a full-width bar; fills the framed
-            content area when the field also defines border/title/padding chrome.
+        background: The background color of this field. Fills the whole slot by
+            default when set (see ``fill``); also fills the framed content area
+            when the field defines border/title/padding chrome.
+        fill: Whether ``background`` fills the whole slot. ``None`` fills when a
+            background is set; ``True`` forces a full-slot fill; ``False`` paints
+            the color only behind text glyphs.
         width: Horizontal extent sizing (``10``, ``"50%"``, ``"1fr"``, ``"fit"``,
             or a ``Sizing``). Drives the split constraint in horizontal layouts;
             shrinks the slot along the cross axis otherwise.
@@ -587,6 +604,7 @@ def Field(
         color=color,
         modifiers=modifiers,
         background=background,
+        fill=fill,
         width=Sizing.parse(width),
         height=Sizing.parse(height),
         gap=gap,

--- a/xnano/beta/grids.py
+++ b/xnano/beta/grids.py
@@ -1759,14 +1759,22 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             )
         )
 
-    def _grid_build_frame(self, area: Area, session: Any) -> None:
+    def _grid_build_frame(
+        self,
+        area: Area,
+        session: Any,
+        *,
+        suppress_frame_border: bool = False,
+    ) -> None:
         self.columns = area.width
         self.rows = area.height
         self.grid_render()
         responsive = type(self)._grid_responsive_renders
         if responsive:
             self._grid_render_responsive(responsive, area)
-        self._grid_assemble(area, session)
+        self._grid_assemble(
+            area, session, suppress_frame_border=suppress_frame_border
+        )
 
     def _grid_render_responsive(
         self, responsive: dict[str, str], area: Area
@@ -1797,7 +1805,23 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         if method_name is not None:
             getattr(self, method_name)()
 
-    def _grid_assemble(self, area: Area, session: Any) -> None:
+    def _grid_frame_for_paint(self, suppress_border: bool) -> Frame | None:
+        """Return this grid's frame, dropping its border when the parent
+        Field already owns it (chrome-owns-the-border rule)."""
+        frame = self._grid_frame
+        if frame is None or not suppress_border or frame.border is None:
+            return frame
+        return dataclasses.replace(
+            frame, border=None, border_color=None, border_sides=None
+        )
+
+    def _grid_assemble(
+        self,
+        area: Area,
+        session: Any,
+        *,
+        suppress_frame_border: bool = False,
+    ) -> None:
         if not self.visible:
             return
 
@@ -1805,11 +1829,13 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         self._grid_last_slot_areas = {}
         self._grid_field_hits = []
 
+        grid_frame = self._grid_frame_for_paint(suppress_frame_border)
+
         fields = self._grid_fields
 
         if not fields:
-            if self._grid_frame is not None:
-                session.paint_frame(area, self._grid_frame, z=self.z)
+            if grid_frame is not None:
+                session.paint_frame(area, grid_frame, z=self.z)
             return
 
         active_names: list[str] = []
@@ -1865,13 +1891,13 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                 )
 
         if not active_names:
-            if self._grid_frame is not None:
-                session.paint_frame(area, self._grid_frame, z=self.z)
+            if grid_frame is not None:
+                session.paint_frame(area, grid_frame, z=self.z)
             return
 
         inner = area
-        if self._grid_frame is not None:
-            inner = session.paint_frame(area, self._grid_frame, z=self.z)
+        if grid_frame is not None:
+            inner = session.paint_frame(area, grid_frame, z=self.z)
 
         slot_areas = session.split_layout(
             inner,

--- a/xnano/beta/grids.py
+++ b/xnano/beta/grids.py
@@ -1375,19 +1375,30 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         field_config: dict[str, Any],
         *,
         caller: str,
+        missing: str = "raise",
     ) -> None:
         """Validate and store per-instance style/layout overrides for ``name``.
 
         Shared by ``grid_set_field`` and ``grid_update_field`` — the only
         difference between the two callers is which keyword arguments they
         expose; the validation and override-storage logic is identical.
+
+        ``missing="ignore"`` turns a missing or state-only target into a
+        no-op instead of an exception, so an optional style patch (e.g. a
+        border-color pulse from ``on_tick``) never has to be wrapped in
+        ``try``/``except``. Unknown/forbidden keyword arguments still raise,
+        as those signal a programming error rather than timing.
         """
         if name in self._grid_state_fields:
+            if missing == "ignore":
+                return
             raise TypeError(
                 f"{caller}() cannot be used on state field {name!r} on "
                 f"{type(self).__name__}"
             )
         if name not in self._grid_fields:
+            if missing == "ignore":
+                return
             raise AttributeError(
                 f"{type(self).__name__} has no layout field {name!r}"
             )
@@ -1586,9 +1597,10 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         attribute changes — pulsing a border color from ``on_tick``,
         toggling a modifier from an effect callback. It has no ``value=``
         or ``position=`` parameters at all, so a per-frame style tick never
-        pays for that method's value-validation branch. Raises the same
-        ``TypeError``/``AttributeError`` as ``grid_set_field`` for state
-        fields, unknown fields, or unknown keys.
+        pays for that method's value-validation branch. Optional style
+        patches never raise: a missing or state-only ``name`` is a no-op
+        (no ``try``/``except`` needed), though unknown keyword arguments
+        still raise as a programming error.
         """
         field_config: dict[str, Any] = {
             key: option
@@ -1624,7 +1636,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             if option is not UNSET
         }
         self._grid_apply_field_config(
-            name, field_config, caller="grid_update_field"
+            name, field_config, caller="grid_update_field", missing="ignore"
         )
 
     def set_frame(
@@ -1681,6 +1693,34 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         theming a nested grid, replacing private ``_grid_frame`` mutation.
         """
         self.set_frame(background=background)
+
+    def schedule_update(
+        self,
+        callback: Callable[[], Any] | None = None,
+        *,
+        field: str | None = None,
+    ) -> None:
+        """Apply an update on the UI thread before the next frame.
+
+        The thread-safe way to reflect background work in the UI: pass a
+        ``callback`` to run on the runtime thread (so it can mutate this grid
+        without racing the renderer), and/or a ``field`` to mark dirty. Safe
+        to call from any thread; a no-op when no runtime is active.
+        """
+        from xnano.beta.core.runtime import get_active_runtime
+
+        runtime = get_active_runtime()
+
+        def _apply() -> None:
+            if callback is not None:
+                callback()
+            if field is not None:
+                self.mark_field_dirty(field)
+
+        if runtime is None:
+            _apply()
+        else:
+            runtime.call_soon(_apply)
 
     def _grid_resolve_visible(self, field: GridFieldInfo, value: Any) -> bool:
         if field.visible is None:

--- a/xnano/beta/grids.py
+++ b/xnano/beta/grids.py
@@ -110,6 +110,7 @@ _GRID_FIELD_CONFIG_KEYS: frozenset[str] = frozenset(
         "wireframe",
         "color",
         "background",
+        "fill",
         "width",
         "height",
         "gap",
@@ -1410,6 +1411,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         wireframe: bool | None = UNSET,
         color: ColorLike | None = UNSET,
         background: ColorLike | None = UNSET,
+        fill: bool | None = UNSET,
         width: SizingLike | None = UNSET,
         height: SizingLike | None = UNSET,
         gap: int | None = UNSET,
@@ -1450,6 +1452,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                 "wireframe": wireframe,
                 "color": color,
                 "background": background,
+                "fill": fill,
                 "width": width,
                 "height": height,
                 "gap": gap,
@@ -1509,6 +1512,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         wireframe: bool | None = UNSET,
         color: ColorLike | None = UNSET,
         background: ColorLike | None = UNSET,
+        fill: bool | None = UNSET,
         width: SizingLike | None = UNSET,
         height: SizingLike | None = UNSET,
         gap: int | None = UNSET,
@@ -1549,6 +1553,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                 "wireframe": wireframe,
                 "color": color,
                 "background": background,
+                "fill": fill,
                 "width": width,
                 "height": height,
                 "gap": gap,
@@ -1576,6 +1581,61 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         self._grid_apply_field_config(
             name, field_config, caller="grid_update_field"
         )
+
+    def set_frame(
+        self,
+        frame: Frame | None = UNSET,
+        *,
+        background: ColorLike | None = UNSET,
+        border: Border | None = UNSET,
+        border_color: ColorLike | None = UNSET,
+        border_sides: Sequence[Side] | None = UNSET,
+        title: str | None = UNSET,
+        title_position: FrameTitlePosition | None = UNSET,
+        padding: PaddingLike | None = UNSET,
+    ) -> None:
+        """Set this grid instance's outer frame (chrome + background fill).
+
+        The public replacement for mutating the private ``_grid_frame``.
+        Pass a whole ``frame`` to replace it outright, or individual keyword
+        arguments to patch the current frame in place — a bare
+        ``background`` fills the grid's whole area with no border required,
+        so nested grids can be themed without any chrome. Pass ``frame=None``
+        to clear the frame.
+        """
+        if frame is not UNSET:
+            object.__setattr__(
+                self, "_grid_frame", None if frame is None else frame
+            )
+            return
+        current = getattr(self, "_grid_frame", None) or Frame()
+        patch = {
+            key: value
+            for key, value in {
+                "background": background,
+                "border": border,
+                "border_color": border_color,
+                "border_sides": border_sides,
+                "title": title,
+                "title_position": title_position,
+                "padding": padding,
+            }.items()
+            if value is not UNSET
+        }
+        if not patch:
+            return
+        updated = dataclasses.replace(current, **patch)
+        object.__setattr__(
+            self, "_grid_frame", None if updated.is_empty() else updated
+        )
+
+    def set_background(self, background: ColorLike | None) -> None:
+        """Fill this grid instance's whole area with ``background``.
+
+        Shorthand for ``set_frame(background=...)`` — the ergonomic path for
+        theming a nested grid, replacing private ``_grid_frame`` mutation.
+        """
+        self.set_frame(background=background)
 
     def _grid_resolve_visible(self, field: GridFieldInfo, value: Any) -> bool:
         if field.visible is None:

--- a/xnano/beta/grids.py
+++ b/xnano/beta/grids.py
@@ -254,6 +254,31 @@ def _merge_grid_settings(
     return merged
 
 
+def _frame_axis_size(frame: Frame | None, direction: Direction) -> int:
+    """Return the chrome thickness a grid frame consumes along an axis."""
+    if frame is None:
+        return 0
+    size = 0
+    if frame.border is not None:
+        sides = frame.border_sides
+        if direction == "vertical":
+            edges = ("top", "bottom")
+        else:
+            edges = ("left", "right")
+        size += 2 if sides is None else sum(edge in sides for edge in edges)
+    if frame.padding is not None:
+        padding = Padding.parse(frame.padding)
+        size += (
+            padding.vertical if direction == "vertical" else padding.horizontal
+        )
+    return size
+
+
+def _grid_inner_width(area: Area, frame: Frame | None) -> int:
+    """Return the content width inside a grid's own frame."""
+    return max(0, area.width - _frame_axis_size(frame, "horizontal"))
+
+
 def _grid_frame_size_for_field(
     field: GridFieldInfo,
     direction: Direction,
@@ -1336,7 +1361,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
     ) -> bool:
         if field.slide:
             return True
-        if field.group or field.scroll:
+        if field.group or field.scroll or field.autofocus:
             return True
         if _resolve_grid_mouse_handler(self, field_name) is not None:
             return True
@@ -1777,8 +1802,18 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                     continue
                 content_length: int | None = None
                 if _field_needs_content_measure(field, self._grid_direction):
+                    available_width = 0
+                    if self._grid_direction == "vertical":
+                        available_width = max(
+                            0,
+                            _grid_inner_width(area, self._grid_frame)
+                            - _grid_frame_size_for_field(field, "horizontal"),
+                        )
                     content_length = session.measure_field_slot(
-                        value, self._grid_direction, field
+                        value,
+                        self._grid_direction,
+                        field,
+                        available_width=available_width,
                     )
                 active_names.append(field_name)
                 active_fields.append(field)

--- a/xnano/beta/grids.py
+++ b/xnano/beta/grids.py
@@ -1352,7 +1352,9 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         extent = content_scroll_extent(value, axis)
         view = paint_area.height if axis == "y" else paint_area.width
         max_offset = max(0, extent - view)
-        offset = max_offset if handle.follow else min(handle.offset, max_offset)
+        offset = (
+            max_offset if handle.follow else min(handle.offset, max_offset)
+        )
         handle.offset = offset
         return offset, axis
 

--- a/xnano/beta/grids.py
+++ b/xnano/beta/grids.py
@@ -1289,27 +1289,47 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         """Return the parent-relative slide offset for a layout field."""
         return self._grid_field_position(name)
 
-    def _grid_field_scroll_offset(self, name: str) -> int:
-        offsets = getattr(self, "_grid_field_scroll_offsets", None)
-        if offsets and name in offsets:
-            return offsets[name]
-        return 0
+    def _grid_scroll_handle(self, name: str, axis: Axis = "y") -> Any:
+        """Return (creating if needed) the ``ScrollHandle`` for a field.
 
-    def _grid_set_field_scroll_offset(self, name: str, offset: int) -> None:
-        self.__dict__.setdefault("_grid_field_scroll_offsets", {})[name] = max(
-            0, offset
-        )
+        Handles are keyed by field name so the paint path and
+        ``ctx.scroll(group)`` share one mutable offset per scroll region.
+        """
+        from xnano.beta.types import ScrollHandle
 
-    def _grid_field_scroll_follow(self, name: str) -> bool:
-        follow = getattr(self, "_grid_field_scroll_follow_flags", None)
-        if follow and name in follow:
-            return follow[name]
-        return False
+        handles = getattr(self, "_grid_scroll_handles", None)
+        if handles is None:
+            handles = {}
+            object.__setattr__(self, "_grid_scroll_handles", handles)
+        handle = handles.get(name)
+        if handle is None:
+            handle = ScrollHandle(group=name, axis=axis)
+            handles[name] = handle
+        return handle
 
-    def _grid_set_field_scroll_follow(self, name: str, follow: bool) -> None:
-        self.__dict__.setdefault("_grid_field_scroll_follow_flags", {})[
-            name
-        ] = follow
+    def _grid_resolve_scroll(
+        self,
+        name: str,
+        field: GridFieldInfo,
+        value: Any,
+        paint_area: Area,
+    ) -> tuple[int, str]:
+        """Clamp and resolve a scroll field's paint offset for one frame.
+
+        Measures the content, clamps the handle offset to the available
+        range, honors ``follow`` (snap to the tail), and writes the clamped
+        offset back so ``ctx.scroll`` reflects reality.
+        """
+        from xnano.beta.core.controller import content_scroll_extent
+
+        axis = "x" if field.scroll == "horizontal" else "y"
+        handle = self._grid_scroll_handle(name, axis)
+        extent = content_scroll_extent(value, axis)
+        view = paint_area.height if axis == "y" else paint_area.width
+        max_offset = max(0, extent - view)
+        offset = max_offset if handle.follow else min(handle.offset, max_offset)
+        handle.offset = offset
+        return offset, axis
 
     def _grid_field_needs_hit(
         self, field_name: str, field: GridFieldInfo
@@ -1846,6 +1866,12 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                     paint_wireframe(paint_area, z=self.z)
             if value is None:
                 continue
+            scroll_offset = 0
+            scroll_axis = "y"
+            if field.scroll:
+                scroll_offset, scroll_axis = self._grid_resolve_scroll(
+                    field_name, field, value, paint_area
+                )
             session.paint_field_slot(
                 value,
                 paint_area,
@@ -1854,6 +1880,8 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                 effect_key=field_name,
                 owner=self,
                 owner_field_name=field_name,
+                scroll_offset=scroll_offset,
+                scroll_axis=scroll_axis,
             )
 
 

--- a/xnano/beta/types.py
+++ b/xnano/beta/types.py
@@ -607,14 +607,32 @@ def field_has_frame_chrome(field: object) -> bool:
     )
 
 
+def field_fills_background(field: object) -> bool:
+    """Return whether a field paints its background across the whole slot.
+
+    A ``fill`` value takes precedence when set; otherwise a field with a
+    ``background`` fills its slot by default (``fill=False`` opts out and
+    reverts to the accent-behind-glyphs behavior).
+    """
+    fill = getattr(field, "fill", None)
+    if fill is not None:
+        return bool(fill)
+    return getattr(field, "background", None) is not None
+
+
 def frame_from_field(field: object | None) -> Frame | None:
     """Build frame styling from a field definition."""
     if field is None:
         return None
     has_chrome = field_has_frame_chrome(field)
+    include_background = getattr(field, "background", None) is not None and (
+        has_chrome or field_fills_background(field)
+    )
     sides = getattr(field, "border_sides", None)
     frame = Frame(
-        background=getattr(field, "background", None) if has_chrome else None,
+        background=(
+            getattr(field, "background", None) if include_background else None
+        ),
         border=getattr(field, "border", None),
         border_color=getattr(field, "border_color", None),
         border_sides=list(sides) if sides is not None else None,
@@ -790,6 +808,7 @@ __all__ = (
     "Sizing",
     "SizingKind",
     "SizingLike",
+    "field_fills_background",
     "field_has_frame_chrome",
     "frame_from_field",
     "is_component",

--- a/xnano/beta/utils/focus.py
+++ b/xnano/beta/utils/focus.py
@@ -210,13 +210,9 @@ def scroll_handle_for_group(
     target = resolve_group_target(terminal, group)
     if target is None:
         return None
-    handles = getattr(target.grid, "_grid_scroll_handles", None)
-    if handles is None:
-        handles = {}
-        object.__setattr__(target.grid, "_grid_scroll_handles", handles)
     info = target.grid._grid_field_info(target.field_name)
     axis = "x" if info.scroll == "horizontal" else "y"
-    return handles.setdefault(group, ScrollHandle(group=group, axis=axis))
+    return target.grid._grid_scroll_handle(target.field_name, axis)
 
 
 __all__ = (

--- a/xnano/beta/utils/focus.py
+++ b/xnano/beta/utils/focus.py
@@ -188,6 +188,78 @@ def ensure_default_field_focus(terminal: Any) -> None:
         set_field_focus(terminal, target, fire_hooks=False)
 
 
+def spatial_focus_enabled(terminal: Any) -> bool:
+    """Return whether any focusable field declares ``autofocus``.
+
+    Arrow-key and click focus movement is opt-in: it activates only when the
+    app uses ``Field(autofocus=True)`` somewhere, so apps that bind arrow keys
+    themselves keep their behavior.
+    """
+    for target in collect_focusable_fields(terminal):
+        info = target.grid._grid_field_info(target.field_name)
+        if getattr(info, "autofocus", False):
+            return True
+    return False
+
+
+def _target_area(target: FieldFocus) -> Any | None:
+    """Return the last painted area for a focus target, if known."""
+    for hit in getattr(target.grid, "_grid_field_hits", ()):
+        if hit.field_name == target.field_name:
+            return hit.area
+    slots = getattr(target.grid, "_grid_last_slot_areas", None)
+    return None if not slots else slots.get(target.field_name)
+
+
+def move_field_focus(
+    terminal: Any,
+    direction: Literal["up", "down", "left", "right"],
+) -> bool:
+    """Move focus to the nearest focusable field in ``direction``.
+
+    Uses the live painted geometry of each focusable field; falls back to
+    tab-order cycling when geometry is unavailable.
+    """
+    targets = collect_focusable_fields(terminal)
+    if len(targets) < 2:
+        return False
+    forward = direction in ("down", "right")
+    current = getattr(terminal, "_field_focus", None)
+    origin = None if current is None else _target_area(current)
+    if origin is None:
+        return cycle_field_focus(terminal, 1 if forward else -1)
+    origin_x = origin.x + origin.width / 2
+    origin_y = origin.y + origin.height / 2
+    best: FieldFocus | None = None
+    best_score: float | None = None
+    for target in targets:
+        if target == current:
+            continue
+        area = _target_area(target)
+        if area is None:
+            continue
+        delta_x = (area.x + area.width / 2) - origin_x
+        delta_y = (area.y + area.height / 2) - origin_y
+        if direction == "up" and delta_y >= 0:
+            continue
+        if direction == "down" and delta_y <= 0:
+            continue
+        if direction == "left" and delta_x >= 0:
+            continue
+        if direction == "right" and delta_x <= 0:
+            continue
+        if direction in ("up", "down"):
+            score = abs(delta_y) + abs(delta_x) * 2
+        else:
+            score = abs(delta_x) + abs(delta_y) * 2
+        if best_score is None or score < best_score:
+            best_score = score
+            best = target
+    if best is None:
+        return False
+    return set_field_focus(terminal, best)
+
+
 def apply_text_keyboard(text: Any, keyboard: Any) -> bool:
     """Send keyboard input to a focused text component."""
     handler = getattr(text, "handle_keyboard", None)
@@ -230,10 +302,12 @@ __all__ = (
     "is_component",
     "is_focusable_component",
     "is_group_focused",
+    "move_field_focus",
     "place_cursor_for_focus",
     "resolve_group_target",
     "scroll_handle_for_group",
     "set_field_focus",
+    "spatial_focus_enabled",
     "sync_input_focus_flags",
     "uses_default_component_size",
 )


### PR DESCRIPTION
## Summary

An ergonomics + bug-fix pass on `xnano.beta`, driven by a review punch-list of
sharp edges — most of them things a real chat app (`slash`) had to reimplement
in userland (message-history windowing, spinner-in-text, custom submit
resolution, chrome accounting, thread→UI bridging, private `_grid_frame`
mutation). This makes the framework do that work instead.

**All changes are scoped to `xnano/beta/` + `tests/beta/`.** No changes to
stable `xnano/`, `xnano-core/`, or `pyproject.toml`.

## What changed

**Background / framing**
- `Field(fill: bool)` — a set `background` now fills the whole slot by default
  (`fill=False` reverts to accent-behind-glyphs). Nested grids inherit the
  parent field's fill automatically.
- Public `BaseGrid.set_frame(...)` / `set_background(...)` replace private
  `_grid_frame` mutation.
- `Text(fill=True)` pads short lines to full cell width (no manual `ljust`).

**Scrolling / viewport**
- `Field(scroll=)` is now functional: windowed paint, clamped offset,
  tail-follow, reserved slot height, and automatic mouse-wheel scrolling.
- Scroll state unified on one per-field `ScrollHandle`.

**Input / focus**
- Declaring `Field(autofocus=True)` anywhere enables arrow-key spatial
  navigation and click-to-focus, computed from live layout geometry.
- `Input(auto_height, min_rows, max_rows)` grows a `height="fit"` composer on
  its own. Fixed fit sizing (the `"content"` constraint fell through to fill).

**Options / autocomplete**
- `filter` accepts `"fuzzy" | "prefix" | "none" | bool | callable`
  (`"none"` for externally-filtered items).
- `resolve_submission(typed)` formalizes `replace` / `extend` /
  `if_prefix_only` accept policies.
- `select_value` / `selected_value` pin a selection by stable id across
  item rebuilds. Reserved-slot pattern documented.

**Reactivity / threading**
- `ctx.call_soon(fn)` / `grid.schedule_update(...)`: thread-safe queue drained
  each pump on the UI thread (replaces the sentinel-Field bump).
- `grid_update_field` no longer raises on missing/state fields.
- `Loader.current_frame()` / `inline_text()` embed a framework-timed spinner in
  flow text.

**Layout / chrome / keyboard**
- `ctx.field_area(name)` exposes measured slot sizes.
- "Chrome owns the border": nested grids drop their own frame border when the
  parent `Field` already frames the slot.
- `on_keyboard("shift")` (bare modifiers) now match a modifier-only press.
- Import weight confirmed already lazy (importing `Terminal` loads no
  components).

## Testing

- `uv run pytest tests/beta` — **474 passed** (447 → 474; +27 new tests
  covering fill, scroll, focus/auto-height, reactivity/threading, options,
  keyboard, and chrome).
- Full repo suite green (1450 passed, 6 skipped).
- Ruff-clean; type-checked via the IDE ty integration (the `ty` CLI is blocked
  by a pre-existing malformed key in `pyproject.toml`, outside this PR's scope).
