### PR TITLE
beta: grid_render(ctx), color→foreground alias, str Text defaults (v1.1.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.1.6"
+pip install "xnano>=1.1.7"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.1.6"
+uv add "xnano>=1.1.7"
 ```
 
 > [!TIP]

--- a/docs/xnano/getting-started.md
+++ b/docs/xnano/getting-started.md
@@ -23,13 +23,13 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "pip"
 
     ```bash
-    pip install "xnano>=1.1.6"
+    pip install "xnano>=1.1.7"
     ```
 
 === "uv"
 
     ```bash
-    uv pip install "xnano>=1.1.6"
+    uv pip install "xnano>=1.1.7"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -38,7 +38,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "poetry"
 
     ```bash
-    poetry install "xnano>=1.1.6"
+    poetry install "xnano>=1.1.7"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -47,7 +47,7 @@ You can install xnano on Python 3.10+ using your favorite package manager.
 === "conda"
 
     ```bash
-    conda install "xnano>=1.1.6"
+    conda install "xnano>=1.1.7"
     ```
 
 ## What is xnano?
@@ -71,7 +71,7 @@ The main featureset of the library revolves around it's rust-based terminal rend
 
     The following example is interactive and can be run directly in the browser by hitting the <kbd>Run</kbd> button.
 
-```pyodide install="xnano>=1.1.6"
+```pyodide install="xnano>=1.1.7"
 import xnano
 
 xnano.render("hello, terminal!", color="blue")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.1.6"
+version = "1.1.7"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/tests/beta/components/test_bar.py
+++ b/tests/beta/components/test_bar.py
@@ -61,7 +61,7 @@ def test_colors_length_must_match_data() -> None:
 
 
 def test_default_blocks_compose_sparkline_content() -> None:
-    bar = Bar(data=[1, 3, 2], color="cyan")
+    bar = Bar(data=[1, 3, 2], foreground="cyan")
     content = bar.compose(_ctx())
     assert isinstance(content, SparklineContent)
     assert list(content.data) == [1, 3, 2]
@@ -113,7 +113,7 @@ def test_deprecated_sparkline_alias() -> None:
 def test_runtime_offscreen_render_smoke() -> None:
     runtime = Runtime.offscreen(30, 5)
     try:
-        frame = runtime.render(Bar(data=[1, 4, 2, 8, 3], color="green"))
+        frame = runtime.render(Bar(data=[1, 4, 2, 8, 3], foreground="green"))
         assert isinstance(frame.text, str)
         assert len(frame.text) > 0
     finally:

--- a/tests/beta/components/test_button.py
+++ b/tests/beta/components/test_button.py
@@ -53,7 +53,7 @@ def test_custom_left_right_chrome() -> None:
 def test_compose_idle_uses_base_colors() -> None:
     button = Button(
         label="Ok",
-        color="green",
+        foreground="green",
         background="black",
     )
     content = button.compose(_ctx())
@@ -68,7 +68,7 @@ def test_compose_idle_uses_base_colors() -> None:
 def test_compose_focused_uses_focused_colors_and_panel() -> None:
     button = Button(
         label="Ok",
-        color="green",
+        foreground="green",
         focused_color="black",
         focused_background="yellow",
     )
@@ -136,7 +136,7 @@ def test_get_label_text_from_text_like() -> None:
 def test_button_offscreen_smoke_render() -> None:
     from xnano.beta.core.runtime import Runtime
 
-    button = Button(label="Submit", color="cyan")
+    button = Button(label="Submit", foreground="cyan")
     runtime = Runtime.offscreen(width=40, height=6)
     try:
         frame = runtime.render(button)

--- a/tests/beta/components/test_text.py
+++ b/tests/beta/components/test_text.py
@@ -38,9 +38,9 @@ def _kbd(**kwargs: Any) -> Any:
 
 
 def test_plain_construction() -> None:
-    text = Text("hello", color="cyan")
+    text = Text("hello", foreground="cyan")
     assert text.content == "hello"
-    assert text.color == "cyan"
+    assert text.foreground == "cyan"
     assert text.input is False
     assert text.focusable is False
     assert text.mask is None
@@ -50,7 +50,7 @@ def test_plain_construction() -> None:
 
 
 def test_nested_spans() -> None:
-    text = Text([Text("ok", color="green"), Text(" ready")])
+    text = Text([Text("ok", foreground="green"), Text(" ready")])
     assert not text._is_leaf()
     children = text._as_children()
     assert len(children) == 2
@@ -190,7 +190,7 @@ def test_markup_cache_reuses_lines() -> None:
 
 
 def test_compose_plain() -> None:
-    text = Text("hello", color="cyan")
+    text = Text("hello", foreground="cyan")
     content = text.compose(_ctx())
     assert isinstance(content, TextBlock)
     assert content.text == "hello"
@@ -200,7 +200,7 @@ def test_compose_plain() -> None:
 def test_offscreen_render_smoke() -> None:
     runtime = Runtime.offscreen(40, 10)
     try:
-        frame = runtime.render(Text("hello", color="cyan"))
+        frame = runtime.render(Text("hello", foreground="cyan"))
         assert "hello" in frame.text
     finally:
         runtime.close()

--- a/tests/beta/test_color_alias_and_text_default.py
+++ b/tests/beta/test_color_alias_and_text_default.py
@@ -1,0 +1,75 @@
+"""tests.beta.test_color_alias_and_text_default
+
+---
+
+Covers the ``color`` -> ``foreground`` deprecation alias on components and
+``Field``, plus coercing a plain ``str`` default on a ``Text`` field into a
+``Text`` component so it renders as that text.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from xnano.beta.components.text import Text
+from xnano.beta.fields import Field
+from xnano.beta.grids import BaseGrid
+from xnano.beta.terminal import Terminal
+
+
+def test_color_alias_sets_foreground_and_warns() -> None:
+    with pytest.warns(DeprecationWarning):
+        # Deprecated ``color`` alias, exercised on purpose.
+        text = Text(
+            "hello",
+            color="cyan",  # ty: ignore[unknown-argument]
+        )
+    assert text.foreground == "cyan"
+    # Deprecated ``color`` property still reads back the foreground.
+    assert text.color == "cyan"  # ty: ignore[unresolved-attribute]
+
+
+def test_foreground_is_canonical_without_warning() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        text = Text("hello", foreground="magenta")
+    assert text.foreground == "magenta"
+
+
+def test_foreground_wins_when_both_passed() -> None:
+    with pytest.warns(DeprecationWarning):
+        text = Text(
+            "hello",
+            foreground="red",
+            color="blue",  # ty: ignore[unknown-argument]
+        )
+    assert text.foreground == "red"
+
+
+def test_field_color_alias_warns_and_sets_foreground() -> None:
+    with pytest.warns(DeprecationWarning):
+        field = Field(default="", color="green")
+    # ``Field`` is typed to return its default for class-attr use, so the
+    # static type here is ``str``; the alias resolves at runtime.
+    assert field.color == "green"  # ty: ignore[unresolved-attribute]
+
+
+def test_str_default_on_text_field_renders() -> None:
+    class App(BaseGrid):
+        # Task 3: a plain str default is coerced to ``Text`` at runtime;
+        # the static type is intentionally left unmodeled.
+        label: Text = Field(  # ty: ignore[invalid-assignment]
+            default="hello world"
+        )
+
+    grid = App()
+    assert isinstance(grid.label, Text)
+
+    terminal = Terminal.offscreen(cols=40, rows=4)
+    terminal.attach_grid(grid)
+    frame = terminal.render()
+    terminal.close()
+
+    assert "hello world" in frame.text

--- a/tests/beta/test_field_component_matrix.py
+++ b/tests/beta/test_field_component_matrix.py
@@ -97,7 +97,7 @@ _FIELD_PROFILES: tuple[tuple[str, dict[str, Any]], ...] = (
     (
         "style",
         {
-            "color": "yellow",
+            "foreground": "yellow",
             "background": "blue",
             "fill": True,
             "modifiers": ("bold", "underline"),
@@ -172,6 +172,9 @@ def test_every_field_parameter_is_explicitly_covered() -> None:
         "strict",
         "init",
         "visible",
+        # Deprecated alias for ``foreground`` (covered via the ``style``
+        # profile); kept in the signature for backward compatibility.
+        "color",
         *{name for _, profile in _FIELD_PROFILES for name in profile},
     }
     parameters = set(inspect.signature(Field).parameters)
@@ -195,7 +198,7 @@ def test_field_options_work_together_on_container_values() -> None:
     class App(BaseGrid):
         items: list[str] = Field(
             default_factory=lambda: ["one", "two", "three"],
-            color="yellow",
+            foreground="yellow",
             background="blue",
             width="fit",
             height="fit",

--- a/tests/beta/test_grid_render_ctx.py
+++ b/tests/beta/test_grid_render_ctx.py
@@ -1,0 +1,56 @@
+"""tests.beta.test_grid_render_ctx
+
+---
+
+``grid_render`` may optionally take a ``Context``, dispatched by arity like
+``grid_post_init`` — both the zero-arg and one-arg forms must render without
+a ``TypeError``.
+"""
+
+from __future__ import annotations
+
+from xnano.beta.context import Context
+from xnano.beta.fields import Field
+from xnano.beta.grids import BaseGrid
+from xnano.beta.terminal import Terminal
+
+
+def test_grid_render_receives_ctx_and_state() -> None:
+    seen: list[object] = []
+
+    class App(BaseGrid):
+        label: str = Field(default="")
+
+        def grid_render(  # ty: ignore[invalid-method-override]
+            self, ctx: Context
+        ) -> None:
+            seen.append(ctx.state)
+            self.label = f"model: {ctx.state['model']}"
+
+    grid = App()
+    state = {"model": "opus"}
+    terminal = Terminal.offscreen(cols=40, rows=4, state=state)
+    terminal.attach_grid(grid)
+    terminal.render()
+    terminal.close()
+
+    assert seen and seen[0] == state
+    assert grid.label == "model: opus"
+
+
+def test_grid_render_zero_arg_form_still_works() -> None:
+    calls: list[str] = []
+
+    class App(BaseGrid):
+        label: str = Field(default="")
+
+        def grid_render(self) -> None:
+            calls.append("called")
+
+    grid = App()
+    terminal = Terminal.offscreen(cols=40, rows=4)
+    terminal.attach_grid(grid)
+    terminal.render()
+    terminal.close()
+
+    assert calls

--- a/tests/beta/test_options_ergonomics.py
+++ b/tests/beta/test_options_ergonomics.py
@@ -64,9 +64,13 @@ def test_reserved_slot_keeps_layout_stable() -> None:
         app = App()
         runtime.set_root(app)
         runtime.render()
-        footer_y = runtime.stage.get_area("footer").y
+        first_footer = runtime.stage.get_area("footer")
+        assert first_footer is not None
+        footer_y = first_footer.y
         app.palette = Options(items=("one", "two"))
         runtime.render()
-        assert runtime.stage.get_area("footer").y == footer_y
+        second_footer = runtime.stage.get_area("footer")
+        assert second_footer is not None
+        assert second_footer.y == footer_y
     finally:
         runtime.close()

--- a/uv.lock
+++ b/uv.lock
@@ -2330,7 +2330,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -6,7 +6,7 @@
 >>> from xnano import BaseGrid, Field, Terminal
 """
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 
 from typing import TYPE_CHECKING
 

--- a/xnano/beta/components/bar.py
+++ b/xnano/beta/components/bar.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Literal, Sequence, TypeAlias
 from xnano.beta.components.component import Component
 from xnano.beta.core.content import CellCanvas, CellSpan, SparklineBar
 from xnano.beta.core.content import Sparkline as SparklineContent
+from xnano.beta.utils.deprecation import color_alias_dataclass
 
 if TYPE_CHECKING:
     from xnano.beta.colors import ColorLike
@@ -86,6 +87,7 @@ def resolve_bar_glyphs(glyphs: BarGlyphs) -> tuple[str, ...]:
     return symbols
 
 
+@color_alias_dataclass
 @dataclasses.dataclass
 class Bar(Component):
     """Compact inline bar chart for a sequence of samples.
@@ -99,7 +101,8 @@ class Bar(Component):
 
     Attributes:
         data: Sequence of sample values.
-        color: Default bar foreground color.
+        foreground: Default bar foreground color (deprecated alias:
+            ``color``).
         colors: Optional per-bar foreground colors.
         background: Widget background color.
         max_value: Explicit y-axis ceiling; ``None`` auto-scales.
@@ -111,8 +114,8 @@ class Bar(Component):
 
     data: Sequence[int | float] = dataclasses.field(default_factory=tuple)
     """Sequence of sample values."""
-    color: "ColorLike | None" = None
-    """Default bar foreground color."""
+    foreground: "ColorLike | None" = None
+    """Default bar foreground color (deprecated alias: ``color``)."""
     colors: Sequence["ColorLike"] | None = None
     """Optional per-bar foreground colors, one per ``data`` entry."""
     background: "ColorLike | None" = None
@@ -196,7 +199,7 @@ class Bar(Component):
             data=data,
             bars=bars,
             max_value=max_value,
-            color=self.color,
+            color=self.foreground,
             background=self.background,
             absent_value_color=self.absent_color,
             absent_value_symbol=self.absent_glyph,
@@ -219,7 +222,7 @@ class Bar(Component):
         for index, value in enumerate(values):
             if value <= 0:
                 glyph = absent
-                color = self.absent_color or self.color
+                color = self.absent_color or self.foreground
             else:
                 level = int(round((value / ceiling) * top))
                 level = max(0, min(top, level))
@@ -227,7 +230,7 @@ class Bar(Component):
                 if self.colors is not None:
                     color = self.colors[index]
                 else:
-                    color = self.color
+                    color = self.foreground
             spans.append(
                 CellSpan(
                     glyph,

--- a/xnano/beta/components/button.py
+++ b/xnano/beta/components/button.py
@@ -12,6 +12,7 @@ import dataclasses
 from typing import TYPE_CHECKING, Any, Sequence
 
 from xnano.beta.components.component import Component
+from xnano.beta.utils.deprecation import color_alias_dataclass
 
 if TYPE_CHECKING:
     from xnano.beta.colors import ColorLike
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
     from xnano.beta.events import KeyboardEventData
 
 
+@color_alias_dataclass
 @dataclasses.dataclass
 class Button(Component):
     """Focusable styled text button.
@@ -44,7 +46,7 @@ class Button(Component):
         disabled: When ``True``, paints disabled colors and ignores
             activation.
         focusable: Whether this button participates in field focus.
-        color: Idle foreground color.
+        foreground: Idle foreground color (deprecated alias: ``color``).
         background: Idle background color.
         focused_color: Foreground while focused.
         focused_background: Background while focused.
@@ -62,8 +64,8 @@ class Button(Component):
     """When ``True``, paints disabled colors and ignores activation."""
     focusable: bool = True
     """Whether this button participates in field focus (tab order)."""
-    color: ColorLike | None = None
-    """Idle foreground color."""
+    foreground: ColorLike | None = None
+    """Idle foreground color (deprecated alias: ``color``)."""
     background: ColorLike | None = None
     """Idle background color."""
     focused_color: ColorLike | None = "black"
@@ -101,7 +103,7 @@ class Button(Component):
             return (self.disabled_color, self.disabled_background)
         if self.focused:
             return (self.focused_color, self.focused_background)
-        return (self.color, self.background)
+        return (self.foreground, self.background)
 
     def handle_keyboard(self, keyboard: "KeyboardEventData") -> bool:
         """Leave keyboard activation to the grid's event hooks.

--- a/xnano/beta/components/dropdown.py
+++ b/xnano/beta/components/dropdown.py
@@ -188,7 +188,9 @@ class Dropdown(Options):
                     ),
                 ),
             )
-        color = self.highlight_color if self._input_focused else self.color
+        color = (
+            self.highlight_color if self._input_focused else self.foreground
+        )
         background = (
             self.highlight_background
             if self._input_focused

--- a/xnano/beta/components/loader.py
+++ b/xnano/beta/components/loader.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Literal, Sequence, TypeAlias
 
 from xnano.beta.components.component import Component
 from xnano.beta.core.content import Gauge, LineGauge, TextBlock
+from xnano.beta.utils.deprecation import color_alias_dataclass
 
 if TYPE_CHECKING:
     from xnano.beta.colors import ColorLike
@@ -70,6 +71,7 @@ def resolve_loader_symbols(symbols: LoaderSymbols) -> tuple[str, ...]:
     return frames
 
 
+@color_alias_dataclass
 @dataclasses.dataclass
 class Loader(Component):
     """Determinate progress indicator or indeterminate spinner.
@@ -87,7 +89,8 @@ class Loader(Component):
         label: Overlay text, auto percentage, nested Text, or hidden.
         symbols: Spinner frames or a named preset.
         interval: Milliseconds between spinner frames.
-        color: Primary foreground / filled color.
+        foreground: Primary foreground / filled color (deprecated alias:
+            ``color``).
         background: Widget background color.
         filled_color: Line style filled-portion color.
         unfilled_color: Line style unfilled-portion color.
@@ -106,12 +109,12 @@ class Loader(Component):
     """Spinner frames or a named preset."""
     interval: int = 80
     """Milliseconds between spinner frames."""
-    color: "ColorLike" = "green"
-    """Primary foreground / filled color."""
+    foreground: "ColorLike" = "green"
+    """Primary foreground / filled color (deprecated alias: ``color``)."""
     background: "ColorLike | None" = None
     """Widget background color."""
     filled_color: "ColorLike | None" = None
-    """Line style filled-portion color (defaults to ``color``)."""
+    """Line style filled-portion color (defaults to ``foreground``)."""
     unfilled_color: "ColorLike | None" = None
     """Line style unfilled-portion color."""
     running: bool = True
@@ -220,7 +223,7 @@ class Loader(Component):
         text = frame if not label else f"{frame} {label}"
         return TextBlock(
             text=text,
-            color=self.color,
+            color=self.foreground,
             background=self.background,
             z=self.z,
             visible=self.visible,
@@ -233,8 +236,8 @@ class Loader(Component):
             return LineGauge(
                 progress=ratio,
                 label=label,
-                color=self.color,
-                filled_color=self.filled_color or self.color,
+                color=self.foreground,
+                filled_color=self.filled_color or self.foreground,
                 unfilled_color=self.unfilled_color,
                 background=self.background,
                 z=self.z,
@@ -243,7 +246,7 @@ class Loader(Component):
         return Gauge(
             progress=ratio,
             label=label,
-            color=self.color,
+            color=self.foreground,
             background=self.background,
             z=self.z,
             visible=self.visible,
@@ -267,8 +270,8 @@ class Loader(Component):
                 return LineGauge(
                     progress=0.0,
                     label=pulse_label,
-                    color=self.color,
-                    filled_color=self.filled_color or self.color,
+                    color=self.foreground,
+                    filled_color=self.filled_color or self.foreground,
                     unfilled_color=self.unfilled_color,
                     background=self.background,
                     z=self.z,
@@ -277,7 +280,7 @@ class Loader(Component):
             return Gauge(
                 progress=0.0,
                 label=pulse_label,
-                color=self.color,
+                color=self.foreground,
                 background=self.background,
                 z=self.z,
                 visible=self.visible,

--- a/xnano/beta/components/options.py
+++ b/xnano/beta/components/options.py
@@ -21,6 +21,7 @@ from typing import (
 
 from xnano.beta.components.component import Component
 from xnano.beta.types import CharacterModifier
+from xnano.beta.utils.deprecation import color_alias_dataclass
 
 if TYPE_CHECKING:
     from xnano.beta.colors import ColorLike
@@ -176,6 +177,7 @@ def _item_disabled(item: OptionItem) -> bool:
     return False
 
 
+@color_alias_dataclass
 @dataclasses.dataclass
 class Options(Component):
     """Always-visible, filterable choice list.
@@ -207,7 +209,8 @@ class Options(Component):
         searchable: Whether typing while focused edits ``query``.
         selected: Selection index within the *filtered* view.
         direction: Visual order of option rows.
-        color: Default foreground color for unselected rows.
+        foreground: Default foreground color for unselected rows
+            (deprecated alias: ``color``).
         background: Default background color for unselected rows.
         highlight_color: Foreground of the selected row.
         highlight_background: Background of the selected row.
@@ -240,8 +243,9 @@ class Options(Component):
     """Selection index within the *filtered* view."""
     direction: OptionsDirection = "top_to_bottom"
     """Visual order of option rows in the list."""
-    color: ColorLike | None = None
-    """Default foreground color for unselected rows."""
+    foreground: ColorLike | None = None
+    """Default foreground color for unselected rows (deprecated alias:
+    ``color``)."""
     background: ColorLike | None = None
     """Default background color for unselected rows."""
     highlight_color: ColorLike = "black"
@@ -618,7 +622,7 @@ class Options(Component):
         return Items(
             items=entries,
             selected=selected,
-            color=self.color,
+            color=self.foreground,
             background=self.background,
             highlight_color=self.highlight_color,
             highlight_background=self.highlight_background,

--- a/xnano/beta/components/text.py
+++ b/xnano/beta/components/text.py
@@ -13,12 +13,14 @@ from typing import TYPE_CHECKING, Any, Sequence
 from xnano.beta.components.component import Component, ComponentRenderContext
 from xnano.beta.core.content import Native, Panel, Run, TextBlock
 from xnano.beta.types import Alignment, CharacterModifier
+from xnano.beta.utils.deprecation import color_alias_dataclass
 
 if TYPE_CHECKING:
     from xnano.beta.colors import ColorLike
     from xnano.beta.events import KeyboardEventData
 
 
+@color_alias_dataclass
 @dataclasses.dataclass
 class Text(Component):
     """Display styled, marked-up, highlighted, or editable text.
@@ -32,7 +34,7 @@ class Text(Component):
 
     Attributes:
         content: Plain string, nested ``Text``, or list of either.
-        color: Foreground color.
+        foreground: Foreground color (deprecated alias: ``color``).
         background: Background color.
         modifiers: Character modifiers such as bold or underline.
         align: Horizontal alignment at the paragraph level.
@@ -56,8 +58,8 @@ class Text(Component):
 
     content: str | Text | list[str | Text] = dataclasses.field(default="")
     """Plain string, nested ``Text``, or a list of either."""
-    color: ColorLike | None = None
-    """Foreground color."""
+    foreground: ColorLike | None = None
+    """Foreground color (deprecated alias: ``color``)."""
     background: ColorLike | None = None
     """Background color."""
     modifiers: tuple[CharacterModifier, ...] = ()
@@ -297,7 +299,7 @@ class Text(Component):
                 if isinstance(self.placeholder.content, str):
                     return (
                         self.placeholder.content,
-                        self.placeholder.color or "gray",
+                        self.placeholder.foreground or "gray",
                         True,
                     )
             else:
@@ -343,7 +345,7 @@ class Text(Component):
             text_str = ""
         return Run(
             text=text_str,
-            color=self.color,
+            color=self.foreground,
             background=self.background,
             modifiers=tuple(self.modifiers),
         )
@@ -372,7 +374,7 @@ class Text(Component):
                     (
                         Run(
                             text=segment,
-                            color=child.color,
+                            color=child.foreground,
                             background=child.background,
                             modifiers=tuple(child.modifiers),
                         ),
@@ -385,7 +387,7 @@ class Text(Component):
         if isinstance(self.content, str):
             return TextBlock(
                 text=self.content,
-                color=self.color,
+                color=self.foreground,
                 background=self.background,
                 modifiers=tuple(self.modifiers),
             )
@@ -393,7 +395,7 @@ class Text(Component):
         spans = [child._to_span_node() for child in children]
         return TextBlock(
             lines=(tuple(spans),),
-            color=self.color,
+            color=self.foreground,
             background=self.background,
             modifiers=tuple(self.modifiers),
         )
@@ -429,7 +431,7 @@ class Text(Component):
         if self._editor is not None:
             return TextBlock(
                 text=self.value,
-                color=self.color,
+                color=self.foreground,
                 background=self.background,
                 modifiers=self.modifiers,
                 align=self.align,
@@ -442,7 +444,7 @@ class Text(Component):
         if markup_lines is not None:
             return TextBlock(
                 lines=markup_lines,
-                color=self.color,
+                color=self.foreground,
                 background=self.background,
                 modifiers=self.modifiers,
                 align=self.align,
@@ -453,7 +455,7 @@ class Text(Component):
 
         if isinstance(self.content, str):
             text_str = self.content
-            color = self.color
+            color = self.foreground
             modifiers = self.modifiers
             if self.input:
                 text_str, color_override, is_placeholder = (
@@ -489,14 +491,14 @@ class Text(Component):
                     runs.append(
                         Run(
                             text=child.content,
-                            color=child.color,
+                            color=child.foreground,
                             background=child.background,
                             modifiers=tuple(child.modifiers),
                         )
                     )
             return TextBlock(
                 lines=(tuple(runs),),
-                color=self.color,
+                color=self.foreground,
                 background=self.background,
                 modifiers=tuple(self.modifiers),
                 align=self.align,
@@ -512,7 +514,7 @@ class Text(Component):
             lines.extend(child._build_line_nodes_from_leaf_children([child]))
         return TextBlock(
             lines=tuple(lines),
-            color=self.color,
+            color=self.foreground,
             background=self.background,
             modifiers=self.modifiers,
             align=self.align,

--- a/xnano/beta/core/demo.py
+++ b/xnano/beta/core/demo.py
@@ -819,7 +819,7 @@ class SignalBox(BaseGrid, direction="vertical"):
         elif tab == "Spark":
             self.view = Bar(
                 data=tuple(value * 100 for value in series),
-                color=_SIGNAL_B,
+                foreground=_SIGNAL_B,
                 glyphs="braille",
             )
         else:
@@ -922,7 +922,7 @@ class DeckBox(BaseGrid, direction="vertical"):
         elif tab == "Code":
             self.view = Text(
                 content=f"{header}\n\n{_DECK_CODE}",
-                color="#d8d2cc",
+                foreground="#d8d2cc",
             )
         else:
             self.view = Text(
@@ -932,7 +932,7 @@ class DeckBox(BaseGrid, direction="vertical"):
                     "tabs and effects. Focus a box, then cycle its tabs\n"
                     "and replay an effect — every keybind does something."
                 ),
-                color="#e6ded6",
+                foreground="#e6ded6",
                 wrap=True,
             )
 
@@ -953,7 +953,7 @@ class LogBox(BaseGrid, direction="vertical"):
         visible = max(1, self.rows)
         lines = getattr(self, "_lines", None) or []
         tail = lines[-visible:] or ["ready."]
-        self.view = Text(content="\n".join(tail), color="#b0a6c8")
+        self.view = Text(content="\n".join(tail), foreground="#b0a6c8")
 
 
 # ── Columns ─────────────────────────────────────────────────────────────────
@@ -1092,7 +1092,7 @@ class Showcase(BaseGrid, direction="vertical", gap=0):
     header: Text = Field(
         default_factory=lambda: Text(
             content="  xnano · showcase",
-            color="#d8bfa8",
+            foreground="#d8bfa8",
             modifiers=("bold",),
         ),
         height=1,
@@ -1196,7 +1196,7 @@ class Showcase(BaseGrid, direction="vertical", gap=0):
         spinner = self._status_loader.current_frame()
         self.header = Text(
             content=f"  {spinner} xnano · showcase",
-            color="#d8bfa8",
+            foreground="#d8bfa8",
             modifiers=("bold",),
         )
         self.footer = Text(
@@ -1204,7 +1204,7 @@ class Showcase(BaseGrid, direction="vertical", gap=0):
                 f"  focus:{focused or '-':<8} {state}   "
                 "[ ]/1-3 tabs · arrows focus · E effect · P pause · Q quit"
             ),
-            color="#7a7290",
+            foreground="#7a7290",
         )
 
 

--- a/xnano/beta/core/runtime.py
+++ b/xnano/beta/core/runtime.py
@@ -316,7 +316,7 @@ class Runtime(Generic[StateT]):
         return self._actions
 
     @property
-    def stage(self) -> Any:
+    def stage(self) -> Stage:
         """Current layout stage when a grid has rendered."""
         return self._stage
 

--- a/xnano/beta/fields.py
+++ b/xnano/beta/fields.py
@@ -24,6 +24,7 @@ from xnano.beta import types
 from xnano.beta.colors import ColorLike
 from xnano.beta.tailwind import Style
 from xnano.beta.types import FrameTitlePosition, Sizing, SizingLike
+from xnano.beta.utils.deprecation import warn_color_alias
 
 if TYPE_CHECKING:
     from xnano.beta.tailwind import TailwindClass
@@ -31,6 +32,8 @@ if TYPE_CHECKING:
 
 _T = TypeVar("_T")
 UNSET: Any = object()
+_COLOR_UNSET: Any = object()
+"""Sentinel marking the deprecated ``color`` alias as not supplied."""
 
 
 ClassNameLike: TypeAlias = Union[
@@ -87,7 +90,9 @@ class GridFieldInfo:
         modifiers: Modifiers to apply to all characters within this field. This can be a list
             including "bold", "dim", "italic", "underline", "slow_blink", "rapid_blink",
             "reversed".
-        color: The foreground color of content within this field.
+        foreground: The foreground color of content within this field.
+        color: Deprecated alias for ``foreground``; passing it emits a
+            ``DeprecationWarning`` and sets the foreground.
         background: The background color of this field. Fills the whole slot by
             default when set (see ``fill``); also fills the framed content area
             when the field defines border/title/padding chrome.
@@ -355,7 +360,8 @@ def Field(
     init: bool = True,
     visible: bool | None = None,
     modifiers: Sequence[types.CharacterModifier] | None = None,
-    color: ColorLike | None = None,
+    foreground: ColorLike | None = None,
+    color: ColorLike | None = _COLOR_UNSET,
     background: ColorLike | None = None,
     fill: bool | None = None,
     width: SizingLike | None = None,
@@ -389,7 +395,8 @@ def Field(
     init: bool = True,
     visible: bool | None = None,
     modifiers: Sequence[types.CharacterModifier] | None = None,
-    color: ColorLike | None = None,
+    foreground: ColorLike | None = None,
+    color: ColorLike | None = _COLOR_UNSET,
     background: ColorLike | None = None,
     fill: bool | None = None,
     width: SizingLike | None = None,
@@ -422,7 +429,8 @@ def Field(
     init: bool = True,
     visible: bool | None = None,
     modifiers: Sequence[types.CharacterModifier] | None = None,
-    color: ColorLike | None = None,
+    foreground: ColorLike | None = None,
+    color: ColorLike | None = _COLOR_UNSET,
     background: ColorLike | None = None,
     fill: bool | None = None,
     width: SizingLike | None = None,
@@ -456,7 +464,8 @@ def Field(
     init: bool = True,
     visible: bool | None = None,
     modifiers: Sequence[types.CharacterModifier] | None = None,
-    color: ColorLike | None = None,
+    foreground: ColorLike | None = None,
+    color: ColorLike | None = _COLOR_UNSET,
     background: ColorLike | None = None,
     fill: bool | None = None,
     width: SizingLike | None = None,
@@ -489,7 +498,8 @@ def Field(
     init: bool = True,
     visible: bool | None = None,
     modifiers: Sequence[types.CharacterModifier] | None = None,
-    color: ColorLike | None = None,
+    foreground: ColorLike | None = None,
+    color: ColorLike | None = _COLOR_UNSET,
     background: ColorLike | None = None,
     fill: bool | None = None,
     width: SizingLike | None = None,
@@ -524,7 +534,9 @@ def Field(
         modifiers: Modifiers to apply to all characters within this field. This can be a list
             including "bold", "dim", "italic", "underline", "slow_blink", "rapid_blink",
             "reversed".
-        color: The foreground color of content within this field.
+        foreground: The foreground color of content within this field.
+        color: Deprecated alias for ``foreground``; passing it emits a
+            ``DeprecationWarning`` and sets the foreground.
         background: The background color of this field. Fills the whole slot by
             default when set (see ``fill``); also fills the framed content area
             when the field defines border/title/padding chrome.
@@ -562,6 +574,10 @@ def Field(
         A new ``GridFieldInfo`` instance with all display/layout metadata,
         including the normalized ``class_name`` tokens.
     """
+    if color is not _COLOR_UNSET:
+        warn_color_alias(stacklevel=2)
+        if foreground is None:
+            foreground = color
     tokens: tuple[str, ...] | None = None
     if class_name is not None:
         from xnano.beta.tailwind import (
@@ -571,8 +587,8 @@ def Field(
 
         tokens = normalize_tailwind_classes(class_name)
         resolved = resolve_tailwind_classes(tokens)
-        if color is None:
-            color = resolved.color
+        if foreground is None:
+            foreground = resolved.color
         if background is None:
             background = resolved.background
         if border is None:
@@ -605,7 +621,7 @@ def Field(
         strict=strict,
         init=init,
         visible=visible,
-        color=color,
+        color=foreground,
         modifiers=modifiers,
         background=background,
         fill=fill,

--- a/xnano/beta/grids.py
+++ b/xnano/beta/grids.py
@@ -20,6 +20,7 @@ from typing import (
     ClassVar,
     Sequence,
     TypedDict,
+    get_args,
     overload,
 )
 
@@ -559,6 +560,32 @@ def _layout_constraint_for_field(
     return _GridLayoutConstraint("fill", 1)
 
 
+def _coerce_text_field(value: str, annotation: Any) -> Any:
+    """Coerce a ``str`` to ``Text`` when the field is annotated ``Text``.
+
+    A field typed as ``Text`` (bare or in a union such as ``str | Text``)
+    may take a plain string default/value; it is wrapped in ``Text(value)``
+    so the renderer sees a component. Any other annotation leaves the
+    string untouched.
+
+    Args:
+        value: The plain string being assigned.
+        annotation: The field's type annotation, if any.
+
+    Returns:
+        A ``Text`` wrapping ``value`` when the annotation names ``Text``,
+        otherwise the original string.
+    """
+    if annotation is None:
+        return value
+    from xnano.beta.components.text import Text
+
+    candidates = get_args(annotation) or (annotation,)
+    if any(candidate is Text for candidate in candidates):
+        return Text(value)
+    return value
+
+
 class _FactoryDefault:
     """Signature placeholder shown for a field with a default factory."""
 
@@ -1086,6 +1113,10 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         field = self._grid_state_fields.get(name)
         if field is not None and field.strict:
             value = self._grid_validate_field(name, value, field=field)
+        elif isinstance(value, str) and name in self._grid_fields:
+            value = _coerce_text_field(
+                value, self._grid_field_annotations.get(name)
+            )
         object.__setattr__(self, name, value)
         # Live FieldState dirty bit + host notification (skip private attrs
         # and fields not yet tracked during construction).
@@ -1101,11 +1132,50 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         runtime = get_active_runtime()
         return None if runtime is None else runtime.state
 
+    def _grid_call_render(self) -> None:
+        """Invoke ``grid_render`` with the arity the subclass declared.
+
+        Overrides may take zero extra parameters or a single ``Context``
+        (like ``grid_post_init`` and every ``@on_*`` hook). ``invoke_hook``
+        dispatches by cached arity; the ``Context`` is built the same way
+        ``dispatch_post_init`` builds it. With no live runtime (bare
+        offscreen paint) fall back to the no-argument call.
+        """
+        from xnano.beta.core.runtime import get_active_runtime
+        from xnano.beta.utils.dispatch import invoke_hook
+        from xnano.beta.utils.introspection import (
+            get_function_extra_parameter_count,
+        )
+
+        runtime = get_active_runtime()
+        if runtime is None or (
+            get_function_extra_parameter_count(type(self).grid_render) == 0
+        ):
+            self.grid_render()
+            return
+        from xnano.beta.context import Context
+        from xnano.beta.core.dispatch import _CONTEXT_EVENT
+
+        context = Context(
+            event=_CONTEXT_EVENT, terminal=runtime, state=runtime.state
+        )
+        invoke_hook(self.grid_render, None, context)
+
     def grid_render(self) -> None:
         """Called each frame before layout.
 
         Override to refresh field values every frame. Initial values can be set
         with ``Field(default=...)``, ``default_factory``, or ``__post_init__``.
+
+        Override with either signature — the extra ``Context`` parameter is
+        optional, dispatched by arity like ``grid_post_init``:
+
+            def grid_render(self) -> None: ...
+            def grid_render(self, ctx: Context[MyState]) -> None: ...
+
+        A static type checker sees the one-parameter form as an invalid
+        override; add ``# ty: ignore[invalid-method-override]`` on the
+        override line.
         """
 
     @responsive_noop
@@ -1770,7 +1840,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
     ) -> None:
         self.columns = area.width
         self.rows = area.height
-        self.grid_render()
+        self._grid_call_render()
         responsive = type(self)._grid_responsive_renders
         if responsive:
             self._grid_render_responsive(responsive, area)

--- a/xnano/beta/markdown.py
+++ b/xnano/beta/markdown.py
@@ -619,7 +619,7 @@ class MarkdownViewport(Markdown):
                 Run(
                     text=text,
                     modifiers=("dim",),
-                    color=self.color,
+                    color=self.foreground,
                     background=self.background,
                 ),
             ),
@@ -780,7 +780,7 @@ class MarkdownViewport(Markdown):
                 node = lower_content(
                     TextBlock(
                         lines=tuple(window),
-                        color=self.color,
+                        color=self.foreground,
                         background=self.background,
                         modifiers=self.modifiers,
                         align=self.align,

--- a/xnano/beta/utils/deprecation.py
+++ b/xnano/beta/utils/deprecation.py
@@ -1,0 +1,105 @@
+"""xnano.beta.utils.deprecation
+
+---
+
+Shared deprecation helpers for beta APIs. Currently provides the
+``color`` -> ``foreground`` field-parameter migration used by any
+dataclass or callable that pairs a foreground color with a
+``background``.
+"""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from typing import Any, Callable, TypeVar
+
+_ClassT = TypeVar("_ClassT", bound=type)
+_CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
+
+_COLOR_MESSAGE = (
+    "The 'color' parameter is deprecated; use 'foreground' instead."
+)
+
+
+def warn_color_alias(stacklevel: int = 3) -> None:
+    """Emit the standard ``color`` deprecation warning.
+
+    Args:
+        stacklevel: Frames to skip so the warning points at caller code.
+    """
+    warnings.warn(_COLOR_MESSAGE, DeprecationWarning, stacklevel=stacklevel)
+
+
+def resolve_color_alias(
+    foreground: Any,
+    color: Any,
+    *,
+    unset: Any = None,
+    stacklevel: int = 3,
+) -> Any:
+    """Return the foreground value, honoring the deprecated ``color`` alias.
+
+    ``foreground`` wins when both are supplied. Passing ``color`` emits a
+    ``DeprecationWarning``.
+
+    Args:
+        foreground: Canonical foreground argument.
+        color: Deprecated alias argument.
+        unset: Sentinel meaning "argument not supplied".
+        stacklevel: Frames to skip so the warning points at caller code.
+
+    Returns:
+        The resolved foreground value (may be ``unset``).
+    """
+    if color is not unset:
+        warn_color_alias(stacklevel=stacklevel)
+        if foreground is unset:
+            return color
+    return foreground
+
+
+def color_alias_dataclass(cls: _ClassT) -> _ClassT:
+    """Add a deprecated ``color`` alias for a dataclass ``foreground`` field.
+
+    The class must already declare a ``foreground`` field. The decorator
+    wraps ``__init__`` to accept a ``color`` keyword (deprecated,
+    ``foreground`` wins when both are given) and installs a ``color``
+    property mapped to ``foreground`` so existing ``self.color`` code and
+    external reads keep working.
+
+    Args:
+        cls: The dataclass to augment.
+
+    Returns:
+        The same class, augmented in place.
+    """
+    original_init = cls.__init__
+
+    @functools.wraps(original_init)
+    def __init__(self: Any, *args: Any, **kwargs: Any) -> None:
+        if "color" in kwargs:
+            warn_color_alias(stacklevel=2)
+            color = kwargs.pop("color")
+            kwargs.setdefault("foreground", color)
+        original_init(self, *args, **kwargs)
+
+    cls.__init__ = __init__  # ty: ignore[invalid-assignment]
+
+    def _get_color(self: Any) -> Any:
+        return self.foreground
+
+    def _set_color(self: Any, value: Any) -> None:
+        self.foreground = value
+
+    cls.color = property(  # ty: ignore[unresolved-attribute]
+        _get_color, _set_color
+    )
+    return cls
+
+
+__all__ = (
+    "color_alias_dataclass",
+    "resolve_color_alias",
+    "warn_color_alias",
+)


### PR DESCRIPTION
Beta-only changes (plus the v1.1.7 version bump).

## Grids
- `grid_render` may now optionally receive a `Context[...]` argument. Frame renders route through a single `_grid_call_render` chokepoint that detects (via the cached signature-arity helper) whether the subclass's `grid_render` accepts a context, and passes one built the same way the hook path (`dispatch_post_init`) builds it. Grids with a plain `grid_render(self)` are unaffected. Fixes the `TypeError: grid_render() missing 1 required positional argument: 'ctx'` seen when a grid declared `grid_render(self, ctx)`.
- A `Text`-typed field now coerces a `str` default into `Text(...)`, so `field: Text = Field(default="...")` works.

## Fields / components
- Renamed the `color` parameter to `foreground` on the classes that also expose `background`: `Text`, `Button`, `Bar`, `Loader`, `Options`, and the `Field()` constructor. `foreground` is canonical; `color=` keeps working as a deprecated alias that sets foreground and emits a `DeprecationWarning`; `foreground` wins if both are passed. Lone-`color` components (Link, Scrollbar, Chart, …) are untouched.
- Fixed an alias-resolution bug where a `color=`-only call was silently dropped because `foreground` defaulted to `None`.

## Typing
- Narrowed `Runtime.stage` from `Any` to `Stage` (the only case in `beta/core` that was `Any` purely to dodge an import cycle).

## Version
- Bump to **1.1.7** (`pyproject.toml`, `xnano/__init__.py`, docs, README).

## Tests
- New `tests/beta/test_grid_render_ctx.py` and `tests/beta/test_color_alias_and_text_default.py`; existing beta tests migrated off `color=`.
- `uv run pytest tests/beta -q` → 502 passed; `uv run ty check` → clean; `prek` hooks pass.