### PR TITLE
beta: field z/overlay, mouse events, input & Options ergonomics (#82)

### DIFF
--- a/tests/beta/components/test_dropdown.py
+++ b/tests/beta/components/test_dropdown.py
@@ -23,6 +23,7 @@ def _kbd(**kwargs: Any) -> Any:
         def __init__(self) -> None:
             self.kind = kwargs.get("kind", "press")
             self.character = character
+            self.modifiers = list(kwargs.get("modifiers", ()))
 
         def matches(self, *bindings: str) -> bool:
             return any(binding in matches for binding in bindings)

--- a/tests/beta/components/test_options.py
+++ b/tests/beta/components/test_options.py
@@ -27,6 +27,7 @@ def _kbd(**kwargs: Any) -> Any:
         def __init__(self) -> None:
             self.kind = kwargs.get("kind", "press")
             self.character = character
+            self.modifiers = list(kwargs.get("modifiers", ()))
 
         def matches(self, *bindings: str) -> bool:
             return any(binding in matches for binding in bindings)
@@ -244,7 +245,7 @@ def test_home_end_skip_disabled_edges() -> None:
 
 
 def test_typing_edits_query_and_resets_selection() -> None:
-    options = Options(items=_ITEMS, selected=3)
+    options = Options(items=_ITEMS, selected=3, searchable=True)
     assert options.handle_keyboard(_kbd(character="d")) is True
     assert options.query == "d"
     assert options.selected == 0
@@ -288,7 +289,7 @@ def test_select_alias_is_options() -> None:
 
 
 def test_compose_searchable_stacks_query_row() -> None:
-    options = Options(items=_ITEMS, query="da")
+    options = Options(items=_ITEMS, query="da", searchable=True)
     content = options.compose(_ctx())
     assert isinstance(content, Stack)
     assert isinstance(content.children[1], Items)

--- a/tests/beta/components/test_text.py
+++ b/tests/beta/components/test_text.py
@@ -20,11 +20,13 @@ def _kbd(**kwargs: Any) -> Any:
     character = kwargs.get("character")
     matches = set(kwargs.get("matches", ()))
     kind = kwargs.get("kind", "press")
+    modifiers = list(kwargs.get("modifiers", ()))
 
     class _K:
         def __init__(self) -> None:
             self.kind = kind
             self.character = character
+            self.modifiers = modifiers
 
         def matches(self, *bindings: str) -> bool:
             return any(binding in matches for binding in bindings)

--- a/tests/beta/test_field_component_matrix.py
+++ b/tests/beta/test_field_component_matrix.py
@@ -112,6 +112,7 @@ _FIELD_PROFILES: tuple[tuple[str, dict[str, Any]], ...] = (
             "autofocus": True,
             "scroll": True,
             "wireframe": True,
+            "z": 1,
         },
     ),
 )
@@ -175,6 +176,9 @@ def test_every_field_parameter_is_explicitly_covered() -> None:
         # Deprecated alias for ``foreground`` (covered via the ``style``
         # profile); kept in the signature for backward compatibility.
         "color",
+        # Out-of-flow overlay: exercised on its own in test_grids, not through
+        # the in-flow render matrix (it would remove the field from layout).
+        "overlay",
         *{name for _, profile in _FIELD_PROFILES for name in profile},
     }
     parameters = set(inspect.signature(Field).parameters)

--- a/xnano/beta/components/dropdown.py
+++ b/xnano/beta/components/dropdown.py
@@ -51,6 +51,12 @@ class Dropdown(Options):
             accepts the current selection first).
     """
 
+    searchable: bool = True
+    """Whether typing while open edits ``query``.
+
+    A dropdown is a search box when expanded, so unlike a plain ``Options``
+    list it defaults to ``True``; set ``False`` for a pick-only dropdown.
+    """
     open: bool = False
     """Whether the options list is expanded."""
     placeholder: str | Any | None = None

--- a/xnano/beta/components/options.py
+++ b/xnano/beta/components/options.py
@@ -180,12 +180,10 @@ def _item_disabled(item: OptionItem) -> bool:
 @color_alias_dataclass
 @dataclasses.dataclass
 class Options(Component):
-    """Always-visible, filterable choice list.
+    """Always-visible, selectable choice list.
 
-    Typing while focused edits ``query`` (when ``searchable``); the
-    visible list narrows to fuzzy matches with matched characters
-    emphasized in ``match_color``. Up/down move the selection (skipping
-    disabled entries) and ``value`` reads the selected item:
+    Up/down move the selection (skipping disabled entries) and ``value``
+    reads the selected item:
 
         class Picker(BaseGrid):
             themes: Options = Field(
@@ -196,8 +194,13 @@ class Options(Component):
             def _choose(self, ctx: Context) -> None:
                 apply_theme(self.themes.value)
 
-    Set ``searchable=False`` to drive ``query`` reactively from another
-    field instead of direct typing.
+    A plain list is *not* a search box: typing-to-filter is opt-in. Set
+    ``searchable=True`` to turn the list into a fuzzy filter where printable
+    keys edit ``query`` and matched characters are emphasized in
+    ``match_color`` — a focused searchable list intentionally consumes those
+    keys, so leave it off for a list that only browses, or the keys never
+    reach your command hooks. Either way you can drive ``query`` reactively
+    from another field.
 
     Example:
         ``Options(items=("small", "medium", "large"), selected=1)``
@@ -206,7 +209,8 @@ class Options(Component):
         items: Entries to pick from (strings, ``Text``, or ``Option``).
         query: Filter text edited by typing when ``searchable``.
         filter: Whether ``query`` fuzzy-filters the visible items.
-        searchable: Whether typing while focused edits ``query``.
+        searchable: Whether typing while focused edits ``query`` (opt-in;
+            defaults to ``False`` so a plain list does not swallow keys).
         selected: Selection index within the *filtered* view.
         direction: Visual order of option rows.
         foreground: Default foreground color for unselected rows
@@ -215,6 +219,8 @@ class Options(Component):
         highlight_color: Foreground of the selected row.
         highlight_background: Background of the selected row.
         highlight_symbol: Symbol prepended to the selected row.
+        hovered: Row under the pointer (filtered-view index), or ``None``.
+        hover_symbol: Dim symbol prepended to the hovered row.
         match_color: Emphasis color for characters matched by ``query``.
         repeat_highlight_symbol: When ``True``, every row shows the
             highlight symbol (selected row still uses highlight style).
@@ -237,8 +243,13 @@ class Options(Component):
     """
     accept: AcceptPolicy = "replace"
     """How ``resolve_submission`` reconciles typed text with the selection."""
-    searchable: bool = True
-    """Whether typing while focused edits ``query`` directly."""
+    searchable: bool = False
+    """Whether typing while focused edits ``query`` directly.
+
+    Off by default: a plain ``Options`` browses with the arrow keys and lets
+    every other key reach app hooks. Turn it on to make the list a fuzzy
+    search box that consumes printable keys while focused.
+    """
     selected: int = 0
     """Selection index within the *filtered* view."""
     direction: OptionsDirection = "top_to_bottom"
@@ -254,6 +265,14 @@ class Options(Component):
     """Background of the selected row."""
     highlight_symbol: str = "> "
     """Symbol prepended to the selected row."""
+    hovered: int | None = None
+    """Row under the pointer (filtered-view index), or ``None``.
+
+    Set by :meth:`handle_hover` when mouse events are enabled; drawn as a
+    dim ``hover_symbol`` so it reads as distinct from the selection.
+    """
+    hover_symbol: str = "· "
+    """Symbol prepended to the hovered row (dim), distinct from selection."""
     match_color: ColorLike | None = "cyan"
     """Emphasis color for characters matched by ``query``."""
     repeat_highlight_symbol: bool = False
@@ -267,6 +286,10 @@ class Options(Component):
     # cursor stays hidden while focused.
     owns_cursor: bool = dataclasses.field(default=True, init=False)
     """Whether selection replaces the hardware caret."""
+    _content_area: Any = dataclasses.field(
+        default=None, init=False, repr=False, compare=False
+    )
+    """Last painted area, recorded so hover can map a pointer to a row."""
 
     def _filter_mode(self) -> "str | Callable[[str, str], bool]":
         """Normalize ``filter`` into a mode name or callable."""
@@ -538,11 +561,15 @@ class Options(Component):
             self._ensure_enabled_selection()
             return True
         character = keyboard.character
+        modifiers = keyboard.modifiers
         if (
             character is not None
             and len(character) == 1
             and character.isprintable()
             and character not in ("\n", "\r", "\t")
+            # ctrl/alt chords are app shortcuts, not search text.
+            and "ctrl" not in modifiers
+            and "alt" not in modifiers
         ):
             self.query = self.query + character
             self.selected = 0
@@ -554,9 +581,19 @@ class Options(Component):
         self,
         text: str,
         matched: tuple[int, ...],
+        hovered: bool = False,
     ) -> Any:
         """Build a ``TextBlock`` row, emphasizing fuzzy-matched chars."""
         from xnano.beta.core.content import Run, TextBlock
+
+        # A hovered row reads as a dim marker + indented label — visually
+        # apart from the selected row's bright highlight arrow.
+        if hovered:
+            return TextBlock(
+                lines=(
+                    (Run(text=self.hover_symbol + text, modifiers=("dim",)),),
+                ),
+            )
 
         # When repeating the symbol, bake it into every row and clear
         # Items' own highlight_symbol so columns stay aligned.
@@ -613,8 +650,10 @@ class Options(Component):
             self._entry_block(
                 _item_text(self.items[index]),
                 matched,
+                # Hover is its own indicator; never on the selected row.
+                hovered=position == self.hovered and position != selected,
             )
-            for index, matched in pairs
+            for position, (index, matched) in enumerate(pairs)
         )
         # When repeating the symbol, Items should not also prepend one
         # on the selected row (already baked into each entry).
@@ -674,6 +713,33 @@ class Options(Component):
             z=self.z,
             visible=self.visible,
         )
+
+    def after_render(self, ctx: "ComponentRenderContext", area: Any) -> None:
+        """Record the painted area so hover can map a pointer to a row."""
+        self._content_area = area
+
+    def handle_hover(self, x: int, y: int) -> bool:
+        """Mark the row under the pointer as hovered (mouse hover).
+
+        Hover is a *distinct* indicator from the selection: the hovered row
+        is set here and drawn with a dim ``hover_symbol``. Moving off the
+        rows clears it. Returns whether the hovered row changed.
+        """
+        del x  # rows span the full width; only the row (y) matters
+        area = self._content_area
+        if area is None:
+            return False
+        pairs = self._filtered()
+        # The query row (searchable) sits above the items; skip it.
+        top = area.y + (1 if self.searchable else 0)
+        row = y - top
+        if self.direction == "bottom_to_top" and pairs:
+            row = (len(pairs) - 1) - row
+        hovered = row if (pairs and 0 <= row < len(pairs)) else None
+        if hovered != self.hovered:
+            self.hovered = hovered
+            return True
+        return False
 
 
 # Migration alias — ``Select`` remains importable during the beta cutover.

--- a/xnano/beta/components/text.py
+++ b/xnano/beta/components/text.py
@@ -18,6 +18,7 @@ from xnano.beta.utils.deprecation import color_alias_dataclass
 if TYPE_CHECKING:
     from xnano.beta.colors import ColorLike
     from xnano.beta.events import KeyboardEventData
+    from xnano.beta.types import Area
 
 
 @color_alias_dataclass
@@ -105,6 +106,9 @@ class Text(Component):
     _editor: Any = dataclasses.field(
         default=None, init=False, repr=False, compare=False
     )
+    _cursor_position: tuple[int, int] | None = dataclasses.field(
+        default=None, init=False, repr=False, compare=False
+    )
     _markup_cache_key: tuple[str, bool, bool, str | None] | None = (
         dataclasses.field(default=None, init=False, repr=False, compare=False)
     )
@@ -180,6 +184,32 @@ class Text(Component):
     def owns_cursor(self) -> bool:
         """Whether this Text paints its own caret (multi-line editor)."""
         return self._editor is not None
+
+    @property
+    def cursor_position(self) -> tuple[int, int] | None:
+        """Absolute caret cell for the terminal cursor, set during paint.
+
+        Reported only for a focused multi-line editor (a single-line input
+        paints its own ``▌`` caret inline). ``None`` otherwise, which hides
+        the hardware cursor.
+        """
+        return self._cursor_position
+
+    def after_render(
+        self,
+        ctx: "ComponentRenderContext[Any]",
+        area: "Area",
+    ) -> None:
+        """Record the multi-line editor caret so the terminal cursor tracks it."""
+        if not (self._input_focused and self._editor is not None):
+            self._cursor_position = None
+            return
+        row, column = self._editor.cursor()
+        # ponytail: no soft-wrap/scroll accounting; clamps to the slot, which
+        # is exact for a note-sized editor. Add offsets if the body scrolls.
+        x = area.x + max(0, min(column, max(0, area.width - 1)))
+        y = area.y + max(0, min(row, max(0, area.height - 1)))
+        self._cursor_position = (x, y)
 
     @property
     def value(self) -> str:
@@ -637,11 +667,16 @@ class Text(Component):
             return False
 
         character = keyboard.character
+        modifiers = keyboard.modifiers
         if (
             character is not None
             and len(character) == 1
             and character.isprintable()
             and character not in ("\n", "\r", "\t")
+            # A ctrl/alt chord (ctrl+s, alt+x) is an app shortcut, not text:
+            # let it fall through to hooks instead of typing its letter.
+            and "ctrl" not in modifiers
+            and "alt" not in modifiers
         ):
             if self.read_only:
                 return True

--- a/xnano/beta/core/controller.py
+++ b/xnano/beta/core/controller.py
@@ -14,7 +14,7 @@ from typing import Any
 import xnano_core.rust.native as native
 from xnano_core import core
 
-from xnano.beta.core.content import Panel, TextBlock
+from xnano.beta.core.content import Clear, Panel, TextBlock
 from xnano.beta.core.layout import LayoutConstraint
 from xnano.beta.core.rendering import lower_content
 from xnano.beta.types import Area, Frame, Padding
@@ -145,6 +145,14 @@ class TerminalController:
         )
 
     paint_chrome = paint_frame
+
+    def paint_clear(self, area: Area, *, z: int = 0) -> None:
+        """Blank ``area`` at ``z`` so an overlay occludes the content below it.
+
+        ratatui styles a bordered block's interior but leaves the glyphs
+        under it intact; a popup must clear first to read as opaque.
+        """
+        self._paint(Clear(), area, z=z)
 
     def split_layout(
         self,
@@ -277,12 +285,15 @@ class TerminalController:
                     effect_key=effect_key,
                 )
             # Chrome owns the border: when the Field already frames this slot
-            # with a border, the nested grid must not draw a second one.
+            # with a border, the nested grid must not draw a second one. The
+            # field's z becomes the child grid's base so its whole subtree
+            # stacks on the right global layer.
             value._grid_build_frame(
                 area,
                 self,
                 suppress_frame_border=getattr(field, "border", None)
                 is not None,
+                base_z=parent_z,
             )
             return
         compose = getattr(value, "compose", None)
@@ -297,10 +308,13 @@ class TerminalController:
             )
             if not getattr(value, "visible", True):
                 return
+            # A component carries its own local ``z``; fold it onto the
+            # field's layer so a lifted slot lifts the component too.
+            component_z = parent_z + getattr(value, "z", 0)
             area = value.before_render(context, area)
             frame = value.get_frame()
             if frame is not None:
-                area = self.paint_frame(area, frame, z=value.z)
+                area = self.paint_frame(area, frame, z=component_z)
             variant = resolve_responsive_variant(
                 getattr(type(value), "_component_responsive_composes", None),
                 self.runtime.size[0],
@@ -312,7 +326,7 @@ class TerminalController:
                 self._paint(
                     content,
                     area,
-                    z=getattr(value, "z", parent_z),
+                    z=component_z,
                     effect_key=effect_key,
                 )
             value.after_render(context, area)

--- a/xnano/beta/core/runtime.py
+++ b/xnano/beta/core/runtime.py
@@ -155,9 +155,12 @@ class Runtime(Generic[StateT]):
         state: StateT | None = None,
         title: str | None = None,
         tick_interval: int = 16,
+        mouse_events: bool = False,
     ) -> "Runtime[StateT]":
         """Create a runtime backed by the active terminal."""
         session = CoreSession.init(tick_rate_ms=None)
+        if mouse_events:
+            session.enable_mouse_capture()
         return cls(
             session,
             live=True,
@@ -397,6 +400,9 @@ class Runtime(Generic[StateT]):
             )
             controller.paint_stage()
             controller.commit()
+            from xnano.beta.utils.focus import place_cursor_for_focus
+
+            place_cursor_for_focus(self)
             return
         styled_items = tuple(
             TextBlock(
@@ -571,11 +577,11 @@ class Runtime(Generic[StateT]):
         from xnano.beta.utils.focus import (
             is_focusable_component,
             set_field_focus,
-            spatial_focus_enabled,
         )
 
-        if not spatial_focus_enabled(self):
-            return
+        # A click is an explicit focus request, so — unlike arrow-key
+        # navigation — it is always on and does not require the ``autofocus``
+        # spatial opt-in; the focusability check below still gates it.
         value = getattr(hit.grid, hit.field_name, None)
         if not (
             is_focusable_component(value) or getattr(field, "autofocus", None)
@@ -613,6 +619,10 @@ class Runtime(Generic[StateT]):
                         field = hit.grid._grid_field_info(hit.field_name)
                         self._auto_scroll_wheel(hit, field, mouse.kind)
                         self._click_to_focus(hit, field, mouse.kind)
+                        component = getattr(hit.grid, hit.field_name, None)
+                        hover = getattr(component, "handle_hover", None)
+                        if callable(hover):
+                            hover(mouse.x, mouse.y)
                         event = Event.from_data(
                             MouseEventData(
                                 kind=mouse.kind,

--- a/xnano/beta/events.py
+++ b/xnano/beta/events.py
@@ -54,6 +54,14 @@ _MODIFIER_KEYS: frozenset[str] = frozenset({"ctrl", "alt", "shift"})
 """Modifier names accepted as standalone (bare) keyboard bindings."""
 
 
+_MODIFIER_KEY_NAMES: dict[str, tuple[str, ...]] = {
+    "ctrl": ("ctrl", "control"),
+    "alt": ("alt", "option"),
+    "shift": ("shift",),
+}
+"""Physical key names a terminal may report for each bare modifier press."""
+
+
 def normalize_keyboard_binding(
     binding: str,
 ) -> tuple[frozenset[str], str]:
@@ -219,12 +227,18 @@ class KeyboardEventData(AbstractEventData):
         """Return whether this event is a bare ``modifier`` key press.
 
         Covers terminals that deliver a modifier press as a key whose name is
-        (or starts with) the modifier — e.g. ``"shift"``, ``"shiftleft"``.
+        (or starts with) the modifier under any of the names terminals use —
+        ``"shift"``/``"shiftleft"``, ``"ctrl"``/``"control"``,
+        ``"alt"``/``"option"``.
         """
         key = self.key
         if not isinstance(key, str):
             return False
-        return key == modifier or key.startswith(modifier)
+        key = key.lower()
+        for name in _MODIFIER_KEY_NAMES.get(modifier, (modifier,)):
+            if key == name or key.startswith(name):
+                return True
+        return False
 
     def matches(self, *bindings: KeyboardBinding) -> bool:
         """Return whether this event matches any binding.

--- a/xnano/beta/fields.py
+++ b/xnano/beta/fields.py
@@ -247,6 +247,25 @@ class GridFieldInfo:
     ``class_name``; the terminal insets the field's slot by this
     amount before painting.
     """
+    z: int | None = None
+    """Layering order for this field's slot, relative to its grid.
+
+    ``None`` inherits the grid's own ``z``; an explicit value stacks the
+    field's whole subtree — plain text, a component, or a nested grid —
+    above (or below) its siblings. It is additive with the grid's ``z`` and
+    any nested field ``z``, so an overlay field lifts everything it contains
+    together. Live-toggle via ``grid_set_field``/``grid_update_field``.
+    """
+    overlay: bool = False
+    """Float this field over the grid instead of giving it a layout slot.
+
+    A normal field claims a share of the layout; an overlay field is taken
+    out of the flow and painted on top of the grid's content area, sized by
+    its ``width``/``height`` (percent, cells, or ratio; unset fills the
+    area) and centered. Pair it with a higher ``z`` for a popup or modal that
+    covers the panels behind it rather than pushing them aside. Hidden
+    overlays (``visible=False``) cost nothing until shown.
+    """
 
     def get_style(self) -> Style:
         """Return the unified ``Style`` for this field's chrome and text.
@@ -376,6 +395,8 @@ def Field(
     title_position: FrameTitlePosition | None = None,
     padding: types.PaddingLike | None = None,
     margin: types.PaddingLike | None = None,
+    z: int | None = None,
+    overlay: bool = False,
     slide: Sequence[types.Axis] | None = None,
     group: str | None = None,
     autofocus: bool | None = None,
@@ -411,6 +432,8 @@ def Field(
     title_position: FrameTitlePosition | None = None,
     padding: types.PaddingLike | None = None,
     margin: types.PaddingLike | None = None,
+    z: int | None = None,
+    overlay: bool = False,
     slide: Sequence[types.Axis] | None = None,
     group: str | None = None,
     autofocus: bool | None = None,
@@ -445,6 +468,8 @@ def Field(
     title_position: FrameTitlePosition | None = None,
     padding: types.PaddingLike | None = None,
     margin: types.PaddingLike | None = None,
+    z: int | None = None,
+    overlay: bool = False,
     slide: Sequence[types.Axis] | None = None,
     group: str | None = None,
     autofocus: bool | None = None,
@@ -480,6 +505,8 @@ def Field(
     title_position: FrameTitlePosition | None = None,
     padding: types.PaddingLike | None = None,
     margin: types.PaddingLike | None = None,
+    z: int | None = None,
+    overlay: bool = False,
     slide: Sequence[types.Axis] | None = None,
     group: str | None = None,
     autofocus: bool | None = None,
@@ -514,6 +541,8 @@ def Field(
     title_position: FrameTitlePosition | None = None,
     padding: types.PaddingLike | None = None,
     margin: types.PaddingLike | None = None,
+    z: int | None = None,
+    overlay: bool = False,
     slide: Sequence[types.Axis] | None = None,
     group: str | None = None,
     autofocus: bool | None = None,
@@ -562,6 +591,13 @@ def Field(
             field's area.
         padding: The padding to be applied around the content area of this field.
         margin: The margin to be applied around the outer area of this field.
+        z: Layering order for this field's slot relative to its grid. ``None``
+            inherits the grid's own ``z``; an explicit value stacks the field's
+            whole subtree (text, component, or nested grid) above or below its
+            siblings and is additive with the grid's ``z``.
+        overlay: Float this field over the grid's content area (centered, sized
+            by ``width``/``height``) instead of giving it a layout slot. Pair
+            with a higher ``z`` for a popup or modal over the panels behind it.
         slide: The axes along which this field may slide within its parent grid.
         class_name: Tailwind CSS classes styling this field — a space-separated
             string or a sequence of class tokens. Classes are lowered into the
@@ -637,6 +673,8 @@ def Field(
         title_position=title_position,
         padding=padding,
         margin=margin,
+        z=z,
+        overlay=overlay,
         slide=_normalize_slide_axes(slide),
         group=group,
         autofocus=autofocus,

--- a/xnano/beta/grids.py
+++ b/xnano/beta/grids.py
@@ -108,6 +108,7 @@ _GRID_FIELD_CONFIG_KEYS: frozenset[str] = frozenset(
         "strict",
         "slide",
         "visible",
+        "z",
         "wireframe",
         "color",
         "background",
@@ -534,6 +535,27 @@ def _resolve_slot_area(
         y=slot_area.y,
         width=slot_area.width,
         height=length,
+    )
+
+
+def _grid_overlay_area(inner: Area, field: GridFieldInfo) -> Area:
+    """Center an out-of-flow overlay field within the grid's content area.
+
+    ``width``/``height`` size the floating box (percent, cells, or ratio);
+    an unset or filling axis spans the whole area. The box is clamped to
+    ``inner`` and centered on both axes.
+    """
+    width = inner.width
+    height = inner.height
+    if field.width is not None and not field.width.is_fill:
+        width = max(1, min(field.width.resolve(inner.width), inner.width))
+    if field.height is not None and not field.height.is_fill:
+        height = max(1, min(field.height.resolve(inner.height), inner.height))
+    return Area(
+        x=inner.x + (inner.width - width) // 2,
+        y=inner.y + (inner.height - height) // 2,
+        width=width,
+        height=height,
     )
 
 
@@ -1552,6 +1574,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         title_position: FrameTitlePosition | None = UNSET,
         padding: PaddingLike | None = UNSET,
         margin: PaddingLike | None = UNSET,
+        z: int | None = UNSET,
         modifiers: Sequence[CharacterModifier] | None = UNSET,
         class_name: ClassNameLike | None = UNSET,
         bold: bool = UNSET,
@@ -1593,6 +1616,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                 "title_position": title_position,
                 "padding": padding,
                 "margin": margin,
+                "z": z,
                 "modifiers": modifiers,
                 "class_name": class_name,
                 "bold": bold,
@@ -1653,6 +1677,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         title_position: FrameTitlePosition | None = UNSET,
         padding: PaddingLike | None = UNSET,
         margin: PaddingLike | None = UNSET,
+        z: int | None = UNSET,
         modifiers: Sequence[CharacterModifier] | None = UNSET,
         class_name: ClassNameLike | None = UNSET,
         bold: bool = UNSET,
@@ -1695,6 +1720,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                 "title_position": title_position,
                 "padding": padding,
                 "margin": margin,
+                "z": z,
                 "modifiers": modifiers,
                 "class_name": class_name,
                 "bold": bold,
@@ -1837,6 +1863,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         session: Any,
         *,
         suppress_frame_border: bool = False,
+        base_z: int = 0,
     ) -> None:
         self.columns = area.width
         self.rows = area.height
@@ -1845,7 +1872,10 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         if responsive:
             self._grid_render_responsive(responsive, area)
         self._grid_assemble(
-            area, session, suppress_frame_border=suppress_frame_border
+            area,
+            session,
+            suppress_frame_border=suppress_frame_border,
+            base_z=base_z,
         )
 
     def _grid_render_responsive(
@@ -1893,6 +1923,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         session: Any,
         *,
         suppress_frame_border: bool = False,
+        base_z: int = 0,
     ) -> None:
         if not self.visible:
             return
@@ -1901,13 +1932,18 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         self._grid_last_slot_areas = {}
         self._grid_field_hits = []
 
+        # z is a single global painter's layer for the whole frame, so a
+        # nested grid stacks on top of its parent's base rather than resetting
+        # to zero: fold the incoming base into this grid's own ``z``.
+        grid_z = base_z + self.z
+
         grid_frame = self._grid_frame_for_paint(suppress_frame_border)
 
         fields = self._grid_fields
 
         if not fields:
             if grid_frame is not None:
-                session.paint_frame(area, grid_frame, z=self.z)
+                session.paint_frame(area, grid_frame, z=grid_z)
             return
 
         active_names: list[str] = []
@@ -1964,19 +2000,63 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
 
         if not active_names:
             if grid_frame is not None:
-                session.paint_frame(area, grid_frame, z=self.z)
+                session.paint_frame(area, grid_frame, z=grid_z)
             return
 
         inner = area
         if grid_frame is not None:
-            inner = session.paint_frame(area, grid_frame, z=self.z)
+            inner = session.paint_frame(area, grid_frame, z=grid_z)
 
-        slot_areas = session.split_layout(
-            inner,
-            self._grid_direction,
-            self._grid_gap,
-            active_constraints,
-        )
+        if any(field.overlay for field in active_fields):
+            # Overlay fields leave the flow: the split sizes only the in-flow
+            # fields, and each overlay is centered over ``inner`` and painted
+            # last (highest paint order, on top of the panels).
+            flow_names: list[str] = []
+            flow_fields: list[GridFieldInfo] = []
+            flow_values: list[Any] = []
+            flow_constraints: list[_GridLayoutConstraint] = []
+            overlay_names: list[str] = []
+            overlay_fields: list[GridFieldInfo] = []
+            overlay_values: list[Any] = []
+            for name, field, value, constraint in zip(
+                active_names,
+                active_fields,
+                active_values,
+                active_constraints,
+            ):
+                if field.overlay:
+                    overlay_names.append(name)
+                    overlay_fields.append(field)
+                    overlay_values.append(value)
+                else:
+                    flow_names.append(name)
+                    flow_fields.append(field)
+                    flow_values.append(value)
+                    flow_constraints.append(constraint)
+            flow_slots = (
+                session.split_layout(
+                    inner,
+                    self._grid_direction,
+                    self._grid_gap,
+                    flow_constraints,
+                )
+                if flow_constraints
+                else []
+            )
+            overlay_slots = [
+                _grid_overlay_area(inner, field) for field in overlay_fields
+            ]
+            active_names = flow_names + overlay_names
+            active_fields = flow_fields + overlay_fields
+            active_values = flow_values + overlay_values
+            slot_areas = flow_slots + overlay_slots
+        else:
+            slot_areas = session.split_layout(
+                inner,
+                self._grid_direction,
+                self._grid_gap,
+                active_constraints,
+            )
 
         collect_mouse_geometry = self._grid_needs_mouse_geometry()
 
@@ -1984,9 +2064,11 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             field_name = active_names[index]
             field = active_fields[index]
             value = active_values[index]
-            slot_area = _resolve_slot_area(
-                session, slot_area, field, value, self._grid_direction
-            )
+            if not field.overlay:
+                # An overlay already carries its final centered geometry.
+                slot_area = _resolve_slot_area(
+                    session, slot_area, field, value, self._grid_direction
+                )
             self._grid_last_slot_areas[field_name] = slot_area
             # Always-on LayoutMap (Stage): record geometry; never tied to
             # wireframe — overlay only reads this map.
@@ -2017,16 +2099,25 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                     parent_area=area,
                     slide_axes=slide_axes,
                 )
+            # A field may lift its whole slot onto its own layer; ``None``
+            # inherits this grid's folded z.
+            field_z = grid_z if field.z is None else grid_z + field.z
+            # An overlay occludes what it floats over: clear its area first so
+            # glyphs beneath the popup do not bleed through.
+            if field.overlay:
+                paint_clear = getattr(session, "paint_clear", None)
+                if paint_clear is not None:
+                    paint_clear(paint_area, z=field_z)
             field_frame = self._grid_field_frame(field_name, field)
             if field_frame is not None:
                 paint_chrome = getattr(session, "paint_chrome", None)
                 if paint_chrome is not None and hasattr(field, "get_style"):
                     paint_area = paint_chrome(
-                        paint_area, field.get_style(), z=self.z
+                        paint_area, field.get_style(), z=field_z
                     )
                 else:
                     paint_area = session.paint_frame(
-                        paint_area, field_frame, z=self.z
+                        paint_area, field_frame, z=field_z
                     )
             # The wireframe is a debug skeleton for the field's allocated
             # cells; paint it *before* the value so live content renders
@@ -2036,7 +2127,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                     session, "paint_field_wireframe", None
                 )
                 if paint_wireframe is not None:
-                    paint_wireframe(paint_area, z=self.z)
+                    paint_wireframe(paint_area, z=field_z)
             if value is None:
                 continue
             scroll_offset = 0
@@ -2049,7 +2140,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                 value,
                 paint_area,
                 field,
-                parent_z=self.z,
+                parent_z=field_z,
                 effect_key=field_name,
                 owner=self,
                 owner_field_name=field_name,

--- a/xnano/beta/terminal.py
+++ b/xnano/beta/terminal.py
@@ -32,6 +32,10 @@ class Terminal(Generic[StateT]):
     ``Terminal`` selects a live session when one is available and otherwise
     uses an offscreen buffer. Use :meth:`offscreen` explicitly in tests.
 
+    Pass ``mouse_events=True`` to receive clicks, drags, hovers, and wheel
+    events — required for click-to-focus and ``@on_click``/``@on_mouse``
+    hooks; it is off by default so a keyboard-only app pays nothing.
+
     Attributes:
         runtime: Runtime owned by the terminal.
         state: Application state shared with event hooks.
@@ -57,10 +61,12 @@ class Terminal(Generic[StateT]):
         state: StateT | None = None,
         title: str | None = None,
         tick_interval: int = 16,
+        mouse_events: bool = False,
     ) -> None:
         self._state = state
         self._title = title
         self._tick_interval = tick_interval
+        self._mouse_events = mouse_events
         self._runtime: Runtime[StateT] | None = None
         self.surface = "terminal"
 
@@ -102,6 +108,7 @@ class Terminal(Generic[StateT]):
                 state=self._state,
                 title=self._title,
                 tick_interval=self._tick_interval,
+                mouse_events=self._mouse_events,
             ).enter()
         else:
             self._runtime = Runtime.offscreen(

--- a/xnano/beta/utils/focus.py
+++ b/xnano/beta/utils/focus.py
@@ -267,11 +267,19 @@ def apply_text_keyboard(text: Any, keyboard: Any) -> bool:
 
 
 def place_cursor_for_focus(terminal: Any) -> None:
-    """Place the cursor using the focused component's cursor hint."""
+    """Show and place the terminal caret at the focused input, else hide it.
+
+    A focused text input reports an absolute ``cursor_position`` during
+    paint; the caret follows it and is shown. With nothing editable focused
+    the caret is hidden so a browsing UI shows no stray cursor.
+    """
     component = focused_component(terminal)
     position = getattr(component, "cursor_position", None)
-    if component is not None and position is not None:
+    if position is not None:
         terminal.cursor.position = position
+        terminal.cursor.visible = True
+    else:
+        terminal.cursor.visible = False
 
 
 def scroll_handle_for_group(


### PR DESCRIPTION
Framework fixes surfaced while building the getting-started notes app:

- Field(z=): threads a field's z through its whole subtree (string, component, nested grid); additive, global painter order.
- Field(overlay=): out-of-flow, centered popup that clears its area so it paints opaque over the panels behind it.
- Terminal(mouse_events=): enable mouse capture; click-to-focus no longer gated behind the arrow-nav opt-in.
- Options: default searchable=False (a list no longer swallows keys; Dropdown overrides back to True); distinct dim hover indicator separate from selection.
- Text/Options inputs no longer consume ctrl/alt chords as typed text, so app shortcuts (ctrl+s) reach hooks.
- Bare ctrl/shift/alt usable as event keys, normalized across terminal key names.
- Multiline editor caret surfaced via the terminal cursor (place_cursor_for_focus is now actually called each frame).