### PR TITLE
chore(deps): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    ignore:
+      # xnano-core is released manually in lockstep with the Rust
+      # crate (see scripts/resolve_release_plan.py) — never let
+      # Dependabot bump this pin on its own.
+      - dependency-name: "xnano-core"
+
+  - package-ecosystem: "cargo"
+    directory: "/xnano-core"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering the three ecosystems in this repo: the root `uv` workspace, the `xnano-core` Cargo crate, and GitHub Actions.
- Groups each ecosystem's bumps into a single weekly PR instead of one-per-dependency.
- Ignores `xnano-core` in the `uv` ecosystem since it's pinned and released manually in lockstep with the Rust crate (see `scripts/resolve_release_plan.py`).

## Test plan
- [ ] Merge and confirm Dependabot opens grouped PRs on its next weekly run