### PR TITLE
fix(xnano-core): migrate rust bindings to ratatui 0.30

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,20 @@ cargo clean
 maturin develop --uv
 ```
 
+On some macOS toolchains (observed on a macOS 27 beta + Xcode Command Line
+Tools combo), maturin's default `-C strip=symbols` rustc flag produces a
+`native.abi3.so` that dyld refuses to load with `mis-aligned LINKEDIT string
+pool`. The failure is nondeterministic — rebuilding with identical source can
+flip between a loadable and a corrupt binary. `cargo build`/`cargo check`
+(which don't strip) are unaffected, so this only shows up when the extension
+is actually imported from Python. If `import xnano_core` raises that dlopen
+error, rebuild with stripping disabled:
+```bash
+cd xnano-core
+cargo clean
+RUSTFLAGS="-C strip=none" maturin develop --uv
+```
+
 ### Docs
 ```bash
 uv run mkdocs serve                  # local docs server (zensical/mkdocs)

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.2.0"
+pip install "xnano>=1.2.1"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.2.0"
+uv add "xnano>=1.2.1"
 ```
 
 > [!TIP]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,13 +32,13 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "pip"
 
     ```bash title="Install with pip"
-    pip install "xnano>=1.2.0"
+    pip install "xnano>=1.2.1"
     ```
 
 === "uv"
 
     ```bash title="Install with uv"
-    uv pip install "xnano>=1.2.0"
+    uv pip install "xnano>=1.2.1"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -47,7 +47,7 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "poetry"
 
     ```bash title="Install with poetry"
-    poetry install "xnano>=1.2.0"
+    poetry install "xnano>=1.2.1"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -56,7 +56,7 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "conda"
 
     ```bash title="Install with conda"
-    conda install "xnano>=1.2.0"
+    conda install "xnano>=1.2.1"
     ```
 
 ## Notetaking Application

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.2.0"
+version = "1.2.1"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"
@@ -40,7 +40,7 @@ dependencies = [
     "markdown-it-py>=3.0.0",
     "pydantic-core>=2.0.0",
     "pygments>=2.17.0",
-    "xnano-core==0.0.14",
+    "xnano-core==0.0.15",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2352,7 +2352,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },

--- a/xnano-core/Cargo.toml
+++ b/xnano-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xnano-core"
-version = "0.0.14"
+version = "0.0.15"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/hsaeed3/xnano"

--- a/xnano-core/python/xnano_core/rust/native.pyi
+++ b/xnano-core/python/xnano_core/rust/native.pyi
@@ -100,7 +100,7 @@ class Flex(enum.IntEnum):
     """Flex distribution mode for layout constraints.
 
     Maps to :class:`ratatui::layout::Flex`.
-    See https://docs.rs/ratatui/0.29.0/ratatui/layout/enum.Flex.html
+    See https://docs.rs/ratatui/0.30.2/ratatui/layout/enum.Flex.html
     """
 
     Legacy = ...
@@ -109,6 +109,7 @@ class Flex(enum.IntEnum):
     Center = ...
     SpaceBetween = ...
     SpaceAround = ...
+    SpaceEvenly = ...
 
 class Constraint:
     """Layout size constraint.

--- a/xnano-core/rust/src/bindings/buffer.rs
+++ b/xnano-core/rust/src/bindings/buffer.rs
@@ -147,11 +147,6 @@ pub fn render_widget_inner(
         resolved = inner;
     }
 
-    #[cfg(feature = "editor")]
-    if let Ok(editor) = resolved.extract::<PyRef<super::engine::editor::PyTextEditor>>() {
-        Widget::render(&editor.inner, area.inner, buffer);
-        return Ok(());
-    }
     if let Ok(paragraph) = resolved.extract::<PyRef<PyParagraph>>() {
         paragraph.inner.clone().render(area.inner, buffer);
         return Ok(());

--- a/xnano-core/rust/src/bindings/convert_core.rs
+++ b/xnano-core/rust/src/bindings/convert_core.rs
@@ -2,7 +2,7 @@ use ratatui::buffer::Buffer as RtBuffer;
 use ratatui::layout::{Margin as RtMargin, Rect as RtRect};
 use ratatui_core::layout::Margin as CoreMargin;
 use ratatui::style::{Color as RtColor, Modifier as RtModifier, Style as RtStyle};
-use ratatui_core::buffer::{Buffer as CoreBuffer, CellDiffOption};
+use ratatui_core::buffer::Buffer as CoreBuffer;
 use ratatui_core::layout::Rect as CoreRect;
 use ratatui_core::style::{Color as CoreColor, Modifier as CoreModifier, Style as CoreStyle};
 
@@ -66,6 +66,8 @@ pub fn to_core_style(style: RtStyle) -> CoreStyle {
     CoreStyle {
         fg: style.fg.map(to_core_color),
         bg: style.bg.map(to_core_color),
+        #[cfg(feature = "terminal")]
+        underline_color: style.underline_color.map(to_core_color),
         add_modifier: to_core_modifier(style.add_modifier),
         sub_modifier: to_core_modifier(style.sub_modifier),
     }
@@ -78,6 +80,10 @@ pub fn from_core_style(style: CoreStyle) -> RtStyle {
     }
     if let Some(c) = style.bg {
         rt.bg = Some(from_core_color(c));
+    }
+    #[cfg(feature = "terminal")]
+    if let Some(c) = style.underline_color {
+        rt.underline_color = Some(from_core_color(c));
     }
     rt.add_modifier = from_core_modifier(style.add_modifier);
     rt.sub_modifier = from_core_modifier(style.sub_modifier);
@@ -98,17 +104,13 @@ pub fn to_core_margin(margin: RtMargin) -> CoreMargin {
 fn sync_cell_to_core(src: &ratatui::buffer::Cell, dst: &mut ratatui_core::buffer::Cell) {
     dst.set_symbol(src.symbol());
     dst.set_style(to_core_style(src.style()));
-    if src.skip {
-        dst.set_diff_option(CellDiffOption::Skip);
-    } else {
-        dst.set_diff_option(CellDiffOption::None);
-    }
+    dst.set_diff_option(src.diff_option);
 }
 
 fn sync_cell_from_core(src: &ratatui_core::buffer::Cell, dst: &mut ratatui::buffer::Cell) {
     dst.set_symbol(src.symbol());
     dst.set_style(from_core_style(src.style()));
-    dst.set_skip(matches!(src.diff_option, CellDiffOption::Skip));
+    dst.set_diff_option(src.diff_option);
 }
 
 pub fn sync_to_core_buffer(src: &RtBuffer) -> CoreBuffer {

--- a/xnano-core/rust/src/bindings/engine/render_ir.rs
+++ b/xnano-core/rust/src/bindings/engine/render_ir.rs
@@ -932,7 +932,7 @@ impl CoreRenderIR {
                         .map(|(val, blabel, text_val, bstyle, vstyle)| {
                             let mut b = Bar::default()
                                 .value(*val)
-                                .label(blabel.as_str().into())
+                                .label(blabel.as_str())
                                 .style(*bstyle)
                                 .value_style(*vstyle);
                             if let Some(tv) = text_val { b = b.text_value(tv.clone()); }
@@ -940,7 +940,7 @@ impl CoreRenderIR {
                         })
                         .collect();
                     let mut g = BarGroup::default().bars(&rat_bars);
-                    if let Some(lbl) = group_label { g = g.label(lbl.as_str().into()); }
+                    if let Some(lbl) = group_label { g = g.label(lbl.as_str()); }
                     chart = chart.data(g);
                 }
                 Widget::render(chart, rect, buf);

--- a/xnano-core/rust/src/bindings/layout.rs
+++ b/xnano-core/rust/src/bindings/layout.rs
@@ -221,6 +221,12 @@ pub enum PyFlex {
     Center,
     SpaceBetween,
     SpaceAround,
+    // Added after ratatui 0.30's CSS-flexbox-aligned Flex rework: the old
+    // ratatui 0.29 `SpaceAround` behavior (equal space between items and
+    // edges) was renamed `SpaceEvenly`, while `SpaceAround` now means
+    // edge-spacing is half of between-item spacing, matching CSS. Appended
+    // at the end so existing `eq_int` discriminants stay stable.
+    SpaceEvenly,
 }
 
 impl From<PyFlex> for Flex {
@@ -232,6 +238,7 @@ impl From<PyFlex> for Flex {
             PyFlex::Center => Flex::Center,
             PyFlex::SpaceBetween => Flex::SpaceBetween,
             PyFlex::SpaceAround => Flex::SpaceAround,
+            PyFlex::SpaceEvenly => Flex::SpaceEvenly,
         }
     }
 }
@@ -455,50 +462,12 @@ impl LayoutSpec {
         layout
     }
 
+    // `ratatui::layout` is a re-export of `ratatui_core::layout` as of
+    // ratatui 0.30's crate split, so `Layout`/`Constraint`/`Flex`/
+    // `Spacing`/`Direction` are the same types either side — no
+    // conversion needed.
     pub(crate) fn to_core(&self) -> ratatui_core::layout::Layout {
-        use ratatui_core::layout::{Constraint as CoreConstraint, Flex as CoreFlex, Layout as CoreLayout, Spacing as CoreSpacing};
-
-        let constraints: Vec<CoreConstraint> = self
-            .constraints
-            .iter()
-            .copied()
-            .map(|c| match c {
-                Constraint::Min(v) => CoreConstraint::Min(v),
-                Constraint::Max(v) => CoreConstraint::Max(v),
-                Constraint::Length(v) => CoreConstraint::Length(v),
-                Constraint::Percentage(v) => CoreConstraint::Percentage(v),
-                Constraint::Ratio(n, d) => CoreConstraint::Ratio(n, d),
-                Constraint::Fill(v) => CoreConstraint::Fill(v),
-            })
-            .collect();
-
-        let spacing = match self.spacing {
-            Spacing::Space(v) => CoreSpacing::Space(v),
-            Spacing::Overlap(v) => CoreSpacing::Overlap(v),
-        };
-
-        let flex = match self.flex {
-            Flex::Legacy => CoreFlex::Legacy,
-            Flex::Start => CoreFlex::Start,
-            Flex::End => CoreFlex::End,
-            Flex::Center => CoreFlex::Center,
-            Flex::SpaceBetween => CoreFlex::SpaceBetween,
-            Flex::SpaceAround => CoreFlex::SpaceAround,
-        };
-
-        let mut layout = CoreLayout::default()
-            .direction(match self.direction {
-                Direction::Horizontal => ratatui_core::layout::Direction::Horizontal,
-                Direction::Vertical => ratatui_core::layout::Direction::Vertical,
-            })
-            .horizontal_margin(self.horizontal_margin)
-            .vertical_margin(self.vertical_margin)
-            .flex(flex)
-            .spacing(spacing);
-        if !constraints.is_empty() {
-            layout = layout.constraints(constraints);
-        }
-        layout
+        self.to_ratatui()
     }
 }
 

--- a/xnano-core/rust/src/bindings/widgets.rs
+++ b/xnano-core/rust/src/bindings/widgets.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::PyList;
-use ratatui::widgets::block::Position as TitlePosition;
+use ratatui::widgets::TitlePosition;
 use ratatui::symbols::border;
 use ratatui::widgets::{
     Block, BorderType, Borders, Gauge, HighlightSpacing, List, ListDirection, ListItem, ListState,
@@ -58,7 +58,7 @@ impl PyBorders {
 #[pyclass(name = "BorderSet", module = "xnano_core.rust.native", from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PyBorderSet {
-    pub inner: border::Set,
+    pub inner: border::Set<'static>,
 }
 
 #[pymethods]

--- a/xnano-core/rust/src/bindings/widgets_extra.rs
+++ b/xnano-core/rust/src/bindings/widgets_extra.rs
@@ -6,7 +6,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Position, Rect};
 use ratatui::symbols::Marker;
 use ratatui::text::Line;
-use ratatui::widgets::block::Padding;
+use ratatui::widgets::Padding;
 use ratatui::widgets::canvas::{Canvas, Circle, Line as CanvasLine, Points, Rectangle};
 use ratatui::widgets::{
     Axis, Bar, BarChart, BarGroup, Cell, Chart, Dataset, GraphType, LegendPosition, LineGauge, Row,

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -16,7 +16,7 @@ try:
 except (
     importlib.metadata.PackageNotFoundError
 ):  # pragma: no cover - editable / source trees
-    __version__ = "1.2.0"
+    __version__ = "1.2.1"
 
 if TYPE_CHECKING:
     from xnano import cli, components, core, events, hooks, requests


### PR DESCRIPTION
## Summary
Dependabot's rust-dependencies bump (#96) landed ratatui 0.29 -> 0.30 without updating xnano-core's bindings for its crate-split API changes, which broke the build (`cargo check` failed with 7 errors). This fixes it and migrates onto the new patterns where 0.30 makes the old code redundant:

- `widgets.rs`/`widgets_extra.rs`: `widgets::block::{Position,Padding}` moved to `widgets::{TitlePosition,Padding}`; `border::Set` gained a lifetime parameter.
- `convert_core.rs`: `Style` gained `underline_color` (feature-gated on `"terminal"`); migrated cell diffing off deprecated `Cell::skip` to `CellDiffOption` directly, since `ratatui::buffer` is now a re-export of `ratatui_core::buffer` (identical types, no conversion needed).
- `layout.rs`: same re-export applies to `ratatui::layout`, so `PyLayout::to_core` collapses to reuse `to_ratatui` instead of hand-converting every `Constraint`/`Flex`/`Spacing`/`Direction` value. Added a `PyFlex::SpaceEvenly` variant since 0.30 renamed the old `SpaceAround` behavior to `SpaceEvenly` and gave `SpaceAround` new CSS-flexbox-aligned semantics.
- `render_ir.rs`: `Bar`/`BarGroup::label` now accept `Into<Line>` directly, so the old `.into()` call became ambiguous.
- `buffer.rs`: dropped the `PyTextEditor` branch in `render_widget_inner` — it's unreachable from Python (the editor is only ever used for text/cursor state via `.text()`/`.cursor()`/`.input()`, never rendered as a widget) and can't compile against tui-textarea 0.7, which is still pinned to ratatui 0.29.
- Verified all three feature combinations compile clean (`--all-features`, default, `--no-default-features`) and the full pytest suite passes (706 passed, 6 skipped).
- Documents a local build flake in `CLAUDE.md`: on this machine's toolchain, maturin's `-C strip=symbols` intermittently produces a `native.abi3.so` that dyld refuses to load with a mis-aligned LINKEDIT error; `RUSTFLAGS="-C strip=none"` works around it.

## Test plan
- [x] `cargo check --all-features` / default / `--no-default-features`
- [x] `cargo test --all-features`
- [x] `uv run pytest` (706 passed, 6 skipped)