### PR TITLE
fix(chart): consolidate Series onto schema.Series

### DIFF
--- a/tests/components/test_chart.py
+++ b/tests/components/test_chart.py
@@ -53,6 +53,21 @@ def test_explicit_bounds_override() -> None:
     assert node.y_axis.bounds == (-5.0, 5.0)
 
 
+def test_explicit_bounds_normalize_flat_and_reversed_ranges() -> None:
+    node = _node(
+        Chart(
+            series={"a": [1]},
+            x_bounds=(5, 5),
+            y_bounds=(10, -10),
+        )
+    )
+    assert node.x_axis.bounds == (5.0, 6.0)
+    assert node.y_axis.bounds == (-10.0, 10.0)
+
+    negative = _node(Chart(series={"a": [-2]}, x_bounds=(-3, -3)))
+    assert negative.x_axis.bounds == (-4.0, -3.0)
+
+
 def test_flat_series_expands_bounds() -> None:
     node = _node(Chart(series={"flat": [5, 5, 5]}))
     low, high = node.y_axis.bounds

--- a/xnano/components/chart.py
+++ b/xnano/components/chart.py
@@ -18,7 +18,7 @@ from typing import (
 )
 
 from xnano.components.component import Component
-from xnano.components.schema import ComponentDescriptor
+from xnano.components.schema import ComponentDescriptor, Series
 from xnano.core.content import (
     Plot,
     PlotAxis,
@@ -55,39 +55,6 @@ ResolvedDataset: TypeAlias = tuple[
     "CanvasMarkerLike | None",
 ]
 """Resolved ``(label, points, color, kind, marker)`` dataset tuple."""
-
-
-@dataclasses.dataclass
-class Series(ComponentDescriptor):
-    """Declares one series of a ``Chart``.
-
-    Attributes:
-        label: Legend label; ``None`` derives it from the attribute name.
-        color: Series color.
-        kind: Per-series plot kind, overriding the chart default.
-        marker: Glyph set used to paint the series.
-    """
-
-    label: str | None = None
-    """Legend label."""
-    color: "ColorLike | None" = None
-    """Series color."""
-    kind: GraphTypeLike | None = None
-    """Per-series graph representation."""
-    marker: CanvasMarkerLike | None = None
-    """Marker used to paint samples."""
-
-    if TYPE_CHECKING:
-
-        def __new__(cls, *args: Any, **kwargs: Any) -> Any: ...
-
-    def resolve_label(self) -> str:
-        """Return the legend label, deriving one from ``name`` when unset.
-
-        Returns:
-            The legend label for this series.
-        """
-        return self.label if self.label is not None else self.name
 
 
 @dataclasses.dataclass

--- a/xnano/components/schema.py
+++ b/xnano/components/schema.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, TypeAlias
 
 if TYPE_CHECKING:
     from xnano.colors import ColorLike
-    from xnano.types import Alignment, GraphTypeLike
+    from xnano.types import Alignment, CanvasMarkerLike, GraphTypeLike
 
 ColorResolver: TypeAlias = Any
 FormatResolver: TypeAlias = str | Callable[[Any], str] | None
@@ -103,9 +103,10 @@ class Series(ComponentDescriptor):
     """Describe one chart series.
 
     Attributes:
-        label: Legend label.
+        label: Legend label; ``None`` derives it from the attribute name.
         color: Series color.
         kind: Plot representation.
+        marker: Glyph set used to paint the series.
     """
 
     label: str | None = None
@@ -114,6 +115,8 @@ class Series(ComponentDescriptor):
     """Series color."""
     kind: "GraphTypeLike | None" = None
     """Graph representation."""
+    marker: "CanvasMarkerLike | None" = None
+    """Marker used to paint samples."""
 
     if TYPE_CHECKING:
 
@@ -121,7 +124,7 @@ class Series(ComponentDescriptor):
 
     def resolve_label(self) -> str:
         """Return the displayed legend label."""
-        return self.label or self.name
+        return self.label if self.label is not None else self.name
 
 
 __all__ = (


### PR DESCRIPTION
Removes the duplicate `Series` dataclass from `components/chart.py` and imports the canonical one from `components/schema.py`, which gains the `marker` field and a `None`-aware `resolve_label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)