### PR TITLE
fix(cli): handle HelpException in command dispatch

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import pytest
 
 from xnano.cli import Argument, CliError, Command, Option
@@ -92,3 +94,36 @@ def test_option_and_argument_metadata_types() -> None:
     assert argument.metavar == "TARGET"
     error = CliError("boom", exit_code=2)
     assert error.exit_code == 2
+
+
+def test_annotated_command_combines_arguments_options_and_repeats() -> None:
+    app = Command(name="deploy", strict=True)
+    calls: list[tuple[str, list[str], bool]] = []
+
+    @app
+    def deploy(
+        environment: Annotated[
+            str,
+            Argument(
+                help="Deployment environment",
+                metavar="ENV",
+                choices=("staging", "production"),
+            ),
+        ],
+        tag: Annotated[
+            list[str],
+            Option("-t", "--tag", help="Image tag"),
+        ],
+        force: Annotated[
+            bool,
+            Option("-f", "--force", help="Skip confirmation"),
+        ] = False,
+    ) -> None:
+        calls.append((environment, tag, force))
+
+    app.run(["production", "--tag", "api", "-t", "worker", "--force"])
+
+    assert calls == [("production", ["api", "worker"], True)]
+    help_text = app.get_help()
+    assert "ENV" in help_text
+    assert "--tag" in help_text

--- a/xnano/cli/command.py
+++ b/xnano/cli/command.py
@@ -568,6 +568,9 @@ class Command:
         except HelpRequested as help_requested:
             print(render_help(help_requested.command), end="")
             sys.exit(0)
+        except HelpException as help_exception:
+            print(render_help(help_exception.command), end="")
+            sys.exit(0)
         except CliError as error:
             print_error(error.message, error.command or self)
             sys.exit(error.exit_code)


### PR DESCRIPTION
`Command` now catches `HelpException` and renders help + exits cleanly, matching the existing `HelpRequested` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)