### PR TITLE
fix(render): preserve styling and pass live area to compose

### DIFF
--- a/tests/core/test_core_render_content.py
+++ b/tests/core/test_core_render_content.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import pytest
 from xnano_core.rust.engine import (
     CoreRenderContent,
+    CoreRenderIR,
     CoreRenderNode,
     CoreSession,
+    IrLine,
 )
 from xnano_core.rust.native import (
+    Buffer,
     BufferMutView,
     Constraint,
     ListItem,
@@ -127,6 +130,70 @@ def test_stateful_scrollbar_renders(offscreen_session: CoreSession) -> None:
     state.set_position(10)
     offscreen_session.render(
         CoreRenderNode.leaf(CoreRenderContent.stateful(scrollbar, state))
+    )
+    assert any(
+        line.strip()
+        for line in offscreen_session.buffer_snapshot().to_string_lines()
+    )
+
+
+def test_widget_ir_stateful_and_drawable_render_in_one_layout(
+    offscreen_session: CoreSession,
+) -> None:
+    table = RatTable.new(
+        [Row.new(["Ada", "active"])],
+        [Constraint.percentage(50), Constraint.percentage(50)],
+    )
+
+    def draw_status(buffer: Buffer, rect: Rect) -> None:
+        buffer.set_string(rect.x, rect.y, "READY", Style.default())
+
+    tree = CoreRenderNode.column(
+        constraints=[
+            Constraint.length(2),
+            Constraint.length(3),
+            Constraint.min(1),
+        ],
+        children=[
+            CoreRenderNode.leaf(
+                CoreRenderContent.widget(Paragraph.new("Deployments"))
+            ),
+            CoreRenderNode.row(
+                constraints=[
+                    Constraint.percentage(50),
+                    Constraint.percentage(50),
+                ],
+                children=[
+                    CoreRenderNode.leaf(
+                        CoreRenderContent.ir(
+                            CoreRenderIR.list(
+                                [
+                                    IrLine.raw("api"),
+                                    IrLine.raw("worker"),
+                                ],
+                                None,
+                                None,
+                                None,
+                                None,
+                                None,
+                                "• ",
+                            )
+                        )
+                    ),
+                    CoreRenderNode.leaf(
+                        CoreRenderContent.stateful(table, TableState())
+                    ),
+                ],
+            ),
+            CoreRenderNode.leaf(CoreRenderContent.drawable(draw_status)),
+        ],
+    )
+
+    offscreen_session.render(tree)
+    text = "\n".join(offscreen_session.buffer_snapshot().to_string_lines())
+    assert all(
+        value in text
+        for value in ("Deployments", "api", "worker", "Ada", "active", "READY")
     )
 
 

--- a/tests/core/test_core_render_ir.py
+++ b/tests/core/test_core_render_ir.py
@@ -274,23 +274,23 @@ class TestCoreRenderIRRenders:
 
     def test_progress_bar_renders(self) -> None:
         ir = CoreRenderIR.progress_bar(0.5, "50%", None, None)
-        _render(ir)  # must not raise
+        assert "50%" in _text(_render(ir))
 
     def test_sparkline_renders(self) -> None:
         ir = CoreRenderIR.sparkline(
             [1, 2, 3, 4, 5], None, None, None, None, None
         )
-        _render(ir)  # must not raise
+        assert "█" in _text(_render(ir))
 
     def test_line_gauge_renders(self) -> None:
         ir = CoreRenderIR.line_gauge(0.75, None, None, None, None, None)
-        _render(ir)
+        assert "75%" in _text(_render(ir))
 
     def test_scrollbar_renders(self) -> None:
         ir = CoreRenderIR.scrollbar(
             0, 100, 10, None, None, None, None, None, None
         )
-        _render(ir)
+        assert "█" in _text(_render(ir))
 
     def test_tabs_renders_titles(self) -> None:
         titles = [IrLine.raw("Tab-A"), IrLine.raw("Tab-B")]
@@ -322,14 +322,16 @@ class TestCoreRenderIRRenders:
         ir = CoreRenderIR.canvas([], (0.0, 40.0), (0.0, 12.0), None, None)
         _render(ir)
 
-    def test_bar_chart_renders_without_error(self) -> None:
+    def test_bar_chart_renders_value_and_label(self) -> None:
         # bar tuple: (value, label, text_value, bar_fg, bar_bg, value_fg, value_bg)
         bar = (5, "bar", None, None, None, None, None)
         group = (None, [bar])
         ir = CoreRenderIR.bar_chart(
             [group], 1, 0, 0, None, False, None, None, None
         )
-        _render(ir)
+        text = _text(_render(ir))
+        assert "5" in text
+        assert "b" in text
 
     def test_ir_content_via_leaf_node(self) -> None:
         ir = CoreRenderIR.span("via-leaf", None, None, [])

--- a/xnano/core/rendering.py
+++ b/xnano/core/rendering.py
@@ -359,8 +359,10 @@ def lower_content(content: Any) -> core.CoreRenderNode:
     compose = getattr(content, "compose", None)
     if callable(compose):
         from xnano.components.component import ComponentRenderContext
+        from xnano.core.runtime import get_active_runtime
         from xnano.types import Area
 
+        runtime = get_active_runtime()
         # A component with responsive compose variants swaps in the one
         # matching the live window width; the plain `compose` handles
         # every tier a component leaves unoverridden. Skipped entirely for
@@ -368,22 +370,18 @@ def lower_content(content: Any) -> core.CoreRenderNode:
         responsive = getattr(
             type(content), "_component_responsive_composes", None
         )
-        if responsive:
-            from xnano.core.runtime import get_active_runtime
+        if responsive and runtime is not None:
             from xnano.utils.responsive import (
                 resolve_responsive_variant,
             )
 
-            runtime = get_active_runtime()
-            if runtime is not None:
-                variant = resolve_responsive_variant(
-                    responsive, runtime.size[0]
-                )
-                if variant is not None:
-                    compose = getattr(content, variant)
+            variant = resolve_responsive_variant(responsive, runtime.size[0])
+            if variant is not None:
+                compose = getattr(content, variant)
+        width, height = runtime.size if runtime is not None else (0, 0)
         content = compose(
             ComponentRenderContext(
-                area=Area(x=0, y=0, width=0, height=0),
+                area=Area(x=0, y=0, width=width, height=height),
             )
         )
     if content is None:

--- a/xnano/rendering.py
+++ b/xnano/rendering.py
@@ -242,20 +242,25 @@ def render(
     finally:
         terminal.close()
 
-    body = _frame_text(
-        frame,
-        styled=any(
-            value is not None
-            for value in (
-                color,
-                background,
-                modifiers,
-                border,
-                border_sides,
-                border_color,
-            )
-        ),
+    # Emit ANSI when styling is present, matching print-like semantics: a
+    # bare scalar with no style kwargs stays plain text, but any component,
+    # grid, or content primitive carries its own color/modifiers and must
+    # keep them — driving ``styled`` off the top-level kwargs alone dropped
+    # the color from ``render(Text(...))``, ``render(chart)``, etc.
+    styled = any(
+        value is not None
+        for value in (
+            color,
+            background,
+            modifiers,
+            border,
+            border_sides,
+            border_color,
+        )
+    ) or any(
+        not isinstance(value, (str, int, float, bool)) for value in values
     )
+    body = _frame_text(frame, styled=styled)
     chunk = body + ("\n" if end is None else end)
     stream_id = _normalize_stream_id(stream)
     if stream_id is None:


### PR DESCRIPTION
`render()` now emits ANSI when values carry their own style (components, grids, content), not only when top-level style kwargs are set. `lower_content` passes the live runtime size as the compose area instead of a zero area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)