### PR TITLE
test: expand coverage across components and framework

### DIFF
--- a/tests/components/test_bar.py
+++ b/tests/components/test_bar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -50,9 +50,26 @@ def test_resolve_rejects_wide_glyph() -> None:
         resolve_bar_glyphs((" ", "😀"))
 
 
+def test_combining_grapheme_is_one_terminal_cell() -> None:
+    assert resolve_bar_glyphs((" ", "e\u0301")) == (" ", "e\u0301")
+
+
+@pytest.mark.parametrize("invalid", ("", "ab", "a😀"))
+def test_invalid_graphemes_are_rejected(invalid: str) -> None:
+    with pytest.raises(ValueError, match="single terminal cell"):
+        resolve_bar_glyphs((" ", invalid))
+
+
 def test_component_post_init_resolves_glyphs() -> None:
     bar = Bar(data=[1, 2, 3], glyphs="ascii")
     assert bar.resolved_glyphs == resolve_bar_glyphs("ascii")
+
+
+def test_invalid_direction_and_absent_glyph_are_rejected() -> None:
+    with pytest.raises(ValueError, match="Unsupported bar direction"):
+        Bar(data=[1], direction=cast(Any, "sideways"))
+    with pytest.raises(ValueError, match="absent_glyph"):
+        Bar(data=[0], absent_glyph="😀")
 
 
 def test_colors_length_must_match_data() -> None:
@@ -100,6 +117,33 @@ def test_direction_down_inverts_samples() -> None:
         for span in down.compose(_ctx()).rows[0]  # type: ignore[union-attr]
     )
     assert up_text != down_text
+
+
+def test_custom_distribution_handles_absent_colors_and_empty_data() -> None:
+    bar = Bar(
+        data=[0, 5],
+        glyphs=(" ", "."),
+        colors=("red", "green"),
+        absent_color="gray",
+        absent_glyph="-",
+        max_value=5,
+    )
+    content = bar.compose(_ctx())
+    assert isinstance(content, CellCanvas)
+    assert [span.text for span in content.rows[0]] == ["-", "."]
+    assert [span.color for span in content.rows[0]] == ["gray", "green"]
+
+    empty = Bar(data=[], glyphs=(" ", ".")).compose(_ctx(width=7))
+    assert isinstance(empty, CellCanvas)
+    assert empty.width == 7
+    assert empty.rows[0][0].text == " "
+
+
+def test_downward_nonpositive_scale_stays_absent() -> None:
+    bar = Bar(data=(-3, 0), direction="down", glyphs=(" ", "#"))
+    content = bar.compose(_ctx())
+    assert isinstance(content, CellCanvas)
+    assert [span.text for span in content.rows[0]] == [" ", " "]
 
 
 def test_fit_content_defaults_false() -> None:

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 from typing import Any
 
+from xnano.actions import Action
 from xnano.components.button import Button
 from xnano.components.component import ComponentRenderContext
+from xnano.components.dropdown import Dropdown
+from xnano.components.input import Input
 from xnano.core.content import Panel, TextBlock
+from xnano.core.runtime import Runtime
+from xnano.fields import Field
+from xnano.grids import BaseGrid
+from xnano.hooks import on_click
 from xnano.types import Area, is_focusable_component
 
 
@@ -132,31 +139,61 @@ def test_get_label_text_from_text_like() -> None:
 
     assert Button(label=_TextLike()).get_label_text() == "FromValue"
 
+    class _ContentLike:
+        content = "FromContent"
 
-def test_button_offscreen_smoke_render() -> None:
-    from xnano.core.runtime import Runtime
+    class _StringLike:
+        def __str__(self) -> str:
+            return "FromString"
 
-    button = Button(label="Submit", foreground="cyan")
-    runtime = Runtime.offscreen(width=40, height=6)
+    assert Button(label=_ContentLike()).get_label_text() == "FromContent"
+    assert Button(label=_StringLike()).get_label_text() == "FromString"
+
+
+def test_button_submits_composed_form_state() -> None:
+    class Form(BaseGrid, direction="vertical"):
+        name: Input = Field(
+            default_factory=lambda: Input(placeholder="name"),
+            group="name",
+            height=1,
+        )
+        environment: Dropdown = Field(
+            default_factory=lambda: Dropdown(
+                items=("staging", "production"),
+                searchable=False,
+            ),
+            group="environment",
+            height=2,
+        )
+        submit: Button = Field(
+            default_factory=lambda: Button(label="Deploy"),
+            group="submit",
+            height=1,
+        )
+        status: str = Field(default="Not deployed", height=1)
+
+        @on_click("submit")
+        def submit_form(self) -> None:
+            self.status = f"{self.name.value} → {self.environment.value}"
+
+    runtime = Runtime.offscreen(width=40, height=8)
     try:
-        frame = runtime.render(button)
-        assert frame is not None
-        output = runtime.get_output()
-        assert "Submit" in output
-    finally:
-        runtime.close()
+        form = Form()
+        runtime.set_root(form)
+        assert "Deploy" in runtime.render().text
 
+        assert runtime.focus("name")
+        for character in "api":
+            runtime.perform(Action.keyboard(character))
 
-def test_button_focused_offscreen_smoke_render() -> None:
-    from xnano.core.runtime import Runtime
+        assert runtime.focus("environment")
+        runtime.perform(Action.keyboard("down"))
+        runtime.perform(Action.keyboard("down"))
+        runtime.perform(Action.keyboard("enter"))
 
-    button = Button(label="Save")
-    button._input_focused = True
-    runtime = Runtime.offscreen(width=40, height=6)
-    try:
-        frame = runtime.render(button)
-        assert frame is not None
-        output = runtime.get_output()
-        assert "Save" in output
+        runtime.perform(Action.click("submit"))
+        assert form.name.value == "api"
+        assert form.environment.value == "production"
+        assert "api → production" in runtime.render().text
     finally:
         runtime.close()

--- a/tests/components/test_image.py
+++ b/tests/components/test_image.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import io
+import struct
+import zlib
 from typing import Any, cast
 
 import pytest
 
+import xnano.components.image as image_module
 from xnano.components.component import ComponentRenderContext
 from xnano.components.image import Image, ImageData, ImageFit, ImageFrame
 from xnano.core import Runtime
@@ -46,6 +49,106 @@ def _get_png_bytes() -> bytes:
     stream = io.BytesIO()
     image.save(stream, format="PNG")
     return stream.getvalue()
+
+
+def _get_xni_bytes() -> bytes:
+    palette = bytes((255, 0, 0, 0, 255, 0))
+    indexes = zlib.compress(bytes((0, 1)))
+    return (
+        b"XNI1"
+        + struct.pack(">HHH", 2, 1, 1)
+        + struct.pack(">HHI", 25, 2, len(indexes))
+        + palette
+        + indexes
+    )
+
+
+def test_compact_image_decodes_and_resizes_for_terminal_cells() -> None:
+    data = ImageData.from_bytes(_get_xni_bytes())
+    assert (data.width, data.height) == (2, 1)
+    assert data.frames[0].duration_ms == 25
+
+    image = Image(source=data, fit="contain", background=(0, 0, 255))
+    canvas = image.compose(_ctx(4, 2))
+    assert isinstance(canvas, CellCanvas)
+    assert len(canvas.rows) == 2
+    assert len(canvas.rows[0]) == 4
+    assert {cell.color for row in canvas.rows for cell in row} >= {
+        "#ff0000",
+        "#00ff00",
+    }
+
+
+def test_compact_image_rejects_invalid_boundaries() -> None:
+    with pytest.raises(ValueError, match="positive dimensions"):
+        ImageData(width=0, height=1, frames=())
+    with pytest.raises(ValueError, match="does not match"):
+        ImageData(
+            width=2,
+            height=1,
+            frames=(ImageFrame(bytes((0, 0, 0)), 10),),
+        )
+    with pytest.raises(ValueError, match="XNI1 header"):
+        ImageData.from_bytes(b"PNG")
+    with pytest.raises(ValueError, match="trailing bytes"):
+        ImageData.from_bytes(_get_xni_bytes() + b"x")
+
+    compressed = zlib.compress(bytes((0,)))
+    wrong_pixel_count = (
+        b"XNI1"
+        + struct.pack(">HHH", 2, 1, 1)
+        + struct.pack(">HHI", 25, 1, len(compressed))
+        + bytes((255, 0, 0))
+        + compressed
+    )
+    with pytest.raises(ValueError, match="invalid pixel count"):
+        ImageData.from_bytes(wrong_pixel_count)
+
+    corrupt = (
+        b"XNI1"
+        + struct.pack(">HHH", 1, 1, 1)
+        + struct.pack(">HHI", 25, 1, 3)
+        + bytes((255, 0, 0))
+        + b"bad"
+    )
+    with pytest.raises(ValueError, match="truncated or corrupt"):
+        ImageData.from_bytes(corrupt)
+
+
+def test_dependency_free_resize_preserves_nearest_colors(monkeypatch) -> None:
+    frame = image_module._RasterFrame(
+        pixels=bytes((255, 0, 0, 0, 255, 0)),
+        width=2,
+        height=1,
+        duration_ms=40,
+    )
+
+    def unavailable():
+        raise ImportError
+
+    monkeypatch.setattr(image_module, "_get_pillow_image_module", unavailable)
+    resized = image_module._resize_frame(frame, 4, 2)
+    assert (resized.width, resized.height) == (4, 2)
+    assert resized.pixels[:6] == bytes((255, 0, 0, 255, 0, 0))
+    assert resized.pixels[6:12] == bytes((0, 255, 0, 0, 255, 0))
+    assert image_module._resize_frame(frame, 2, 1) is frame
+
+
+@pytest.mark.parametrize("fit", ("crop", "cover", "stretch", "smart"))
+def test_fit_modes_fill_requested_terminal_area(fit: ImageFit) -> None:
+    pixels = bytes((255, 0, 0) * 2 + (0, 255, 0) * 2)
+    image = Image(
+        source=ImageData(
+            width=2,
+            height=2,
+            frames=(ImageFrame(pixels, 40),),
+        ),
+        fit=fit,
+    )
+    canvas = image.compose(_ctx(3, 2))
+    assert isinstance(canvas, CellCanvas)
+    assert canvas.width == 3
+    assert canvas.height == 2
 
 
 def test_image_data_without_pillow_file_io() -> None:
@@ -130,6 +233,21 @@ def test_invalid_speed_rejected() -> None:
         )
 
 
+def test_terminal_geometry_configuration_is_validated() -> None:
+    data = ImageData(
+        width=1,
+        height=2,
+        frames=(ImageFrame(bytes((0, 0, 0) * 2), 100),),
+    )
+    with pytest.raises(ValueError, match="Horizontal pixels"):
+        Image(
+            source=data,
+            horizontal_pixels_per_cell=cast(Any, 3),
+        )
+    with pytest.raises(ValueError, match="three RGB"):
+        Image(source=data, background=(0, 0, 999))
+
+
 def test_get_size_native_cells() -> None:
     # 4x2 pixels → 4 cells wide, 1 cell tall with half-blocks.
     pixels = bytes([0, 255, 0] * 8)
@@ -156,6 +274,70 @@ def test_position_ms_override() -> None:
     )
     canvas = image.compose(_ctx(1, 1))
     assert canvas.rows[0][0].color == "#0000ff"
+
+
+def test_source_change_resets_playback_and_canvas_cache() -> None:
+    red = ImageData(
+        width=1,
+        height=2,
+        frames=(ImageFrame(bytes((255, 0, 0) * 2), 40),),
+    )
+    green = ImageData(
+        width=1,
+        height=2,
+        frames=(ImageFrame(bytes((0, 255, 0) * 2), 40),),
+    )
+    image = Image(source=red)
+    first = image.compose(_ctx(1, 1))
+    assert image.compose(_ctx(1, 1)) is first
+    image.seek(20)
+    image.source = green
+    second = image.compose(_ctx(1, 1))
+    assert second is not first
+    assert second.rows[0][0].color == "#00ff00"
+    assert image._paused_elapsed_ms == 0.0
+
+
+def test_playback_idempotence_and_nonlooping_clamp() -> None:
+    frames = (
+        ImageFrame(bytes((255, 0, 0) * 2), 40),
+        ImageFrame(bytes((0, 0, 255) * 2), 90),
+    )
+    image = Image(
+        source=ImageData(width=1, height=2, frames=frames),
+        loop=False,
+    )
+    image.play()
+    assert image.playing is True
+    image.pause()
+    frozen = image._paused_elapsed_ms
+    image.pause()
+    assert image._paused_elapsed_ms == frozen
+    image.seek(10_000)
+    assert image._started_at_ns is None
+    assert image.get_frame_index(10_000) == 1
+    image.play()
+    started = image._started_at_ns
+    image.play()
+    assert image._started_at_ns == started
+
+    looping = Image(source=image.source, loop=True)
+    assert looping.finished is False
+
+
+def test_terminal_aspect_mode_uses_source_width() -> None:
+    image = Image(
+        source=ImageData(
+            width=4,
+            height=2,
+            frames=(ImageFrame(bytes((0, 255, 0) * 8), 40),),
+        ),
+        horizontal_pixels_per_cell=2,
+        correct_terminal_aspect=True,
+    )
+    assert image.get_size(_ctx()).width == 4
+    canvas = image.compose(_ctx(4, 1))
+    assert canvas.width == 4
 
 
 def test_runtime_offscreen_render_smoke() -> None:
@@ -194,3 +376,15 @@ def test_runtime_png_with_pillow() -> None:
         assert len(frame.text) > 0
     finally:
         runtime.close()
+
+
+def test_transparent_stream_composites_over_configured_background() -> None:
+    pillow_image = _require_pillow()
+    source = pillow_image.new("RGBA", (1, 2), (0, 255, 0, 0))
+    stream = io.BytesIO()
+    source.save(stream, format="PNG")
+    stream.seek(0)
+
+    image = Image(source=stream, background=(255, 0, 0))
+    canvas = image.compose(_ctx(1, 1))
+    assert canvas.rows[0][0].color == "#ff0000"

--- a/tests/components/test_input.py
+++ b/tests/components/test_input.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import pytest
+
 from xnano.components.component import ComponentRenderContext
 from xnano.components.input import Input
 from xnano.components.text import Text
@@ -58,6 +60,48 @@ def test_submit_keys_not_consumed() -> None:
 
     assert field.handle_keyboard(cast(Any, _K())) is False
     assert field.value == "x"
+
+
+@pytest.mark.parametrize(
+    ("content", "width", "minimum", "maximum", "expected"),
+    (
+        ("", 10, 2, None, 2),
+        ("abcdefghij", 4, 1, None, 3),
+        ("a\nb\nc", 20, 1, 2, 2),
+        ("abc", 0, 1, None, 1),
+    ),
+)
+def test_auto_height_tracks_wrapping_with_bounds(
+    content: str,
+    width: int,
+    minimum: int,
+    maximum: int | None,
+    expected: int,
+) -> None:
+    field = Input(
+        content,
+        auto_height=True,
+        min_rows=minimum,
+        max_rows=maximum,
+    )
+    size = field.get_size(
+        ComponentRenderContext(area=Area(x=0, y=0, width=width, height=10))
+    )
+    assert size.height == expected
+
+
+def test_fixed_input_size_uses_rows_and_natural_width() -> None:
+    explicit = Input("one\ntwo", multiline=True, rows=5)
+    size = explicit.get_size(
+        ComponentRenderContext(area=Area(x=0, y=0, width=0, height=8))
+    )
+    assert size == type(size)(width=3, height=5)
+
+    unwrapped = Input("one two", auto_height=True, wrap=False, min_rows=1)
+    size = unwrapped.get_size(
+        ComponentRenderContext(area=Area(x=0, y=0, width=2, height=8))
+    )
+    assert size.height == 1
 
 
 def test_offscreen_render_smoke() -> None:

--- a/tests/components/test_link.py
+++ b/tests/components/test_link.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from xnano.actions import Action
 from xnano.components.component import ComponentRenderContext
 from xnano.components.link import Link
 from xnano.components.text import Text
 from xnano.core import Runtime
 from xnano.core.content import TextBlock
+from xnano.fields import Field
+from xnano.grids import BaseGrid
+from xnano.hooks import on_keyboard
 from xnano.types import Area
 
 
@@ -35,6 +39,14 @@ def test_link_value_is_label_or_url() -> None:
     assert empty.value == "https://example.com"
 
 
+def test_link_label_assignment_obeys_text_limits() -> None:
+    link = Link("documentation", url="/docs", max_length=4, cursor=99)
+    link.value = "reference"
+    assert link.value == "refe"
+    assert link.content == "refe"
+    assert link.cursor == 4
+
+
 def test_link_compose_underline_and_color() -> None:
     link = Link("docs", url="https://example.com")
     content = link.compose(_ctx())
@@ -56,8 +68,19 @@ def test_link_focused_color() -> None:
     assert content.color == "cyan"
 
 
+def test_visited_link_uses_default_visited_cue() -> None:
+    link = Link("docs", url="/docs", visited=True)
+    content = link.compose(_ctx())
+    assert isinstance(content, TextBlock)
+    assert content.color == "magenta"
+
+
 def test_link_activation_keys_not_consumed() -> None:
-    link = Link("go", url="https://example.com")
+    link = Link(
+        "go",
+        url="https://example.com",
+        passthrough=("ctrl+p",),
+    )
 
     class _K:
         kind = "press"
@@ -68,29 +91,43 @@ def test_link_activation_keys_not_consumed() -> None:
 
     assert link.handle_keyboard(cast(Any, _K())) is False
 
-
-def test_link_does_not_open_browser() -> None:
-    """handle_keyboard must not launch external processes."""
-    link = Link("go", url="https://example.com")
-
-    class _K:
-        kind = "press"
-        character = None
-
+    class _Passthrough:
         def matches(self, *bindings: str) -> bool:
-            return "enter" in bindings
+            return "ctrl+p" in bindings
 
-    # Smoke: calling handle_keyboard is side-effect free.
-    assert link.handle_keyboard(cast(Any, _K())) is False
-    assert link.url == "https://example.com"
+    assert link.handle_keyboard(cast(Any, _Passthrough())) is False
 
 
-def test_offscreen_render_smoke() -> None:
-    runtime = Runtime.offscreen(40, 10)
-    try:
-        frame = runtime.render(
-            Link("docs", url="https://example.com", color="cyan")
+def test_link_activation_updates_composed_navigation() -> None:
+    class Navigation(BaseGrid, direction="vertical"):
+        docs: Link = Field(
+            default_factory=lambda: Link(
+                [Text("API ", modifiers=("bold",)), Text("docs")],
+                url="https://example.com/docs",
+                focused_color="cyan",
+            ),
+            group="docs",
+            height=1,
         )
-        assert "docs" in frame.text
+        status: str = Field(default="Not visited", height=1)
+
+        @on_keyboard("enter")
+        def visit_docs(self) -> None:
+            self.docs.visited = True
+            self.status = self.docs.url
+
+    runtime = Runtime.offscreen(40, 4)
+    try:
+        navigation = Navigation()
+        runtime.set_root(navigation)
+        assert runtime.focus("docs")
+        assert "API docs" in runtime.render().text
+
+        runtime.perform(Action.keyboard("enter"))
+        frame = runtime.render()
+        assert navigation.docs.visited is True
+        assert "https://example.com/docs" in frame.text
+        assert navigation.docs.color == "blue"
+        assert navigation.docs.modifiers == ()
     finally:
         runtime.close()

--- a/tests/components/test_loader.py
+++ b/tests/components/test_loader.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import time
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from xnano.components.component import ComponentRenderContext
 from xnano.components.loader import (
     Loader,
+    LoaderStyle,
     resolve_loader_symbols,
 )
+from xnano.components.text import Text
 from xnano.core import Runtime
 from xnano.core.content import Gauge, LineGauge, TextBlock
 from xnano.types import Area
@@ -33,6 +35,15 @@ def test_resolve_custom_frames() -> None:
 def test_resolve_unknown_preset() -> None:
     with pytest.raises(ValueError, match="Unknown loader"):
         resolve_loader_symbols("nope")  # type: ignore[arg-type]
+
+
+def test_loader_rejects_empty_symbols_style_and_interval() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        resolve_loader_symbols(())
+    with pytest.raises(ValueError, match="Unsupported loader style"):
+        Loader(style=cast(Any, "circle"))
+    with pytest.raises(ValueError, match="greater than zero"):
+        Loader(interval=0)
 
 
 def test_ratio_from_direct_value() -> None:
@@ -77,6 +88,33 @@ def test_spinner_label_appended() -> None:
     assert "loading" in content.text
 
 
+def test_inline_spinner_uses_component_label_protocols() -> None:
+    class PlainLabel:
+        def plain(self) -> str:
+            return "plain label"
+
+    class StringLabel:
+        def __str__(self) -> str:
+            return "string label"
+
+    plain = Loader(
+        symbols=("*",),
+        label=cast(Any, PlainLabel()),
+        running=False,
+    )
+    assert plain.resolved_symbols == ("*",)
+    assert plain.current_frame() == "*"
+    assert plain.inline_text() == "* plain label"
+
+    fallback = Loader(
+        symbols=("*",),
+        label=cast(Any, StringLabel()),
+        running=False,
+    )
+    assert fallback.inline_text() == "* string label"
+    assert Loader(symbols=("*",), running=False).inline_text() == "*"
+
+
 def test_bar_style_gauge_content() -> None:
     loader = Loader(value=0.7, style="bar")
     content = loader.compose(_ctx())
@@ -105,6 +143,27 @@ def test_label_false_hides_label() -> None:
     content = loader.compose(_ctx())
     assert isinstance(content, Gauge)
     assert content.label is None
+
+
+@pytest.mark.parametrize(
+    ("style", "content_type"),
+    (("bar", Gauge), ("line", LineGauge)),
+)
+def test_indeterminate_progress_uses_composed_text_label(
+    style: LoaderStyle,
+    content_type: type[Gauge] | type[LineGauge],
+) -> None:
+    loader = Loader(
+        value=None,
+        style=style,
+        label=Text("Syncing", foreground="cyan"),
+        symbols=("*",),
+        running=False,
+    )
+    content = loader.compose(_ctx())
+    assert isinstance(content, content_type)
+    assert content.progress == 0.0
+    assert content.label == "* Syncing"
 
 
 def test_restart_resets_epoch() -> None:

--- a/tests/components/test_table.py
+++ b/tests/components/test_table.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, cast
 
+import pytest
+
 from xnano.components.component import ComponentRenderContext
 from xnano.components.table import Column, Table
 from xnano.core import Runtime
@@ -79,6 +81,45 @@ def test_columns_dict_with_column_spec() -> None:
     )
     assert _cell_text(node.rows[0].cells[0]).strip() == "12ms"
 
+    function_format = _node(
+        Table(
+            data=_ROWS,
+            columns={
+                "latency": Column(format=lambda value: f"{value / 10:.1f}")
+            },
+        )
+    )
+    assert _cell_text(function_format.rows[0].cells[0]) == "1.2"
+
+
+def test_callable_column_and_object_rows_form_a_projection() -> None:
+    class Service:
+        def __init__(self, name: str, latency: int) -> None:
+            self.name = name
+            self.latency = latency
+
+    table = Table(
+        data=[Service("api", 12), Service("db", 4)],
+        columns=cast(
+            Any,
+            {
+                "summary": lambda row: f"{row.name}:{row.latency}",
+                "missing": None,
+            },
+        ),
+    )
+    node = _node(table)
+    assert [_cell_text(row.cells[0]) for row in node.rows] == [
+        "api:12",
+        "db:4",
+    ]
+
+    inferred = _node(Table(data=[Service("worker", 7)]))
+    assert [_cell_text(cell) for cell in inferred.header.cells] == [
+        "Name",
+        "Latency",
+    ]
+
 
 class Services(Table):
     service: str = Column()
@@ -145,6 +186,41 @@ def test_selected_row_respects_sort_display_index() -> None:
     assert table.selected_row["service"] == "db"
 
 
+def test_missing_sort_column_falls_back_to_row_key() -> None:
+    table = Table(
+        data=_ROWS,
+        columns=["service"],
+        sort="latency",
+        selected=0,
+    )
+    selected_row = table.selected_row
+    assert selected_row is not None
+    assert selected_row["service"] == "db"
+
+
+def test_invalid_and_empty_selections_have_no_value() -> None:
+    assert Table(data=_ROWS, selected=None).value is None
+    assert Table(data=_ROWS, selected=-1).value is None
+    assert Table(data=_ROWS, selected=99).value is None
+    empty = Table(data=[], selected=2, focusable=True)
+    assert empty.move(1) is None
+    assert empty.selected is None
+
+
+@pytest.mark.parametrize(
+    ("align", "expected"),
+    (("left", "x   "), ("center", " x  ")),
+)
+def test_fixed_width_alignment(align: str, expected: str) -> None:
+    node = _node(
+        Table(
+            data=[{"value": "x"}],
+            columns={"value": Column(width=4, align=align)},  # type: ignore[arg-type]
+        )
+    )
+    assert _cell_text(node.rows[0].cells[0]) == expected
+
+
 def test_handle_keyboard_when_focusable() -> None:
     table = Table(data=_ROWS, selected=0, focusable=True)
 
@@ -163,6 +239,41 @@ def test_handle_keyboard_when_focusable() -> None:
     assert table.selected == 2
 
 
+@pytest.mark.parametrize(
+    ("binding", "selected", "expected"),
+    (
+        ("j", 4, 5),
+        ("k", 4, 3),
+        ("pagedown", 4, 14),
+        ("pageup", 14, 4),
+        ("home", 14, 0),
+        ("end", 4, 24),
+    ),
+)
+def test_log_table_navigation_shortcuts(
+    binding: str,
+    selected: int,
+    expected: int,
+) -> None:
+    table = Table(
+        data=[
+            {"line": index, "message": f"event {index}"} for index in range(25)
+        ],
+        selected=selected,
+        focusable=True,
+    )
+
+    class _Key:
+        def matches(self, *bindings: str) -> bool:
+            return binding in bindings
+
+    assert table.handle_keyboard(cast(Any, _Key())) is True
+    assert table.selected == expected
+    value = table.value
+    assert value is not None
+    assert value["message"] == f"event {expected}"
+
+
 def test_handle_keyboard_ignored_when_not_focusable() -> None:
     table = Table(data=_ROWS, selected=0, focusable=False)
 
@@ -174,6 +285,26 @@ def test_handle_keyboard_ignored_when_not_focusable() -> None:
     assert table.selected == 0
 
 
+def test_table_passthrough_and_unknown_keys_bubble() -> None:
+    table = Table(
+        data=_ROWS,
+        selected=0,
+        focusable=True,
+        passthrough=("down",),
+    )
+
+    class _Key:
+        def __init__(self, binding: str) -> None:
+            self.binding = binding
+
+        def matches(self, *bindings: str) -> bool:
+            return self.binding in bindings
+
+    assert table.handle_keyboard(cast(Any, _Key("down"))) is False
+    assert table.selected == 0
+    assert table.handle_keyboard(cast(Any, _Key("enter"))) is False
+
+
 def test_hide_header() -> None:
     node = _node(Table(data=_ROWS, show_header=False))
     assert node.header is None
@@ -183,6 +314,10 @@ def test_empty_data_is_safe() -> None:
     node = _node(Table(data=[]))
     assert node.rows == ()
     assert node.header is None
+
+    scalar = _node(Table(data=[1, 2, 3]))
+    assert scalar.header is None
+    assert len(scalar.rows) == 3
 
 
 def test_empty_data_with_declared_columns_keeps_header() -> None:

--- a/tests/components/test_text.py
+++ b/tests/components/test_text.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
+from xnano.actions import Action
 from xnano.components.component import ComponentRenderContext
 from xnano.components.text import Text
 from xnano.core import Runtime
-from xnano.core.content import TextBlock
+from xnano.core.content import Panel, TextBlock
+from xnano.fields import Field
+from xnano.grids import BaseGrid
+from xnano.hooks import on_keyboard
 from xnano.types import Area
 
 
@@ -94,10 +100,39 @@ def test_content_assignment_syncs_editor() -> None:
     assert text._editor.text() == "replaced"
 
 
+def test_editor_mode_transition_preserves_native_text() -> None:
+    text = Text("draft", input=True, multiline=True)
+    assert text._editor is not None
+    text._editor.set_text("native edit")
+    object.__setattr__(text, "content", "")
+    text._sync_editor_state()
+    assert text.content == "native edit"
+
+    text.multiline = False
+    text._sync_editor_state()
+    assert text.content == "native edit"
+    assert text._editor is None
+
+    replaced = Text("old", input=True, multiline=True)
+    object.__setattr__(replaced, "content", "new")
+    replaced._sync_editor_state()
+    assert replaced._editor is not None
+    assert replaced._editor.text() == "new"
+
+
 def test_value_clamps_max_length() -> None:
     text = Text("", input=True, max_length=3)
     text.value = "abcdef"
     assert text.value == "abc"
+    assert Text([Text("nested")]).value == ""
+
+
+def test_multiline_value_assignment_updates_editor_and_clamps_cursor() -> None:
+    text = Text("old", input=True, multiline=True, cursor=99)
+    text.value = "new"
+    assert text._editor is not None
+    assert text._editor.text() == "new"
+    assert text.cursor == 3
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +176,13 @@ def test_read_only_paste_consumed() -> None:
     assert text.value == "ab"
 
 
+def test_paste_contract_without_editor_and_at_capacity() -> None:
+    assert Text("", input=True).handle_paste("ignored") is False
+    full = Text("abc", input=True, multiline=True, max_length=3)
+    assert full.handle_paste("ignored") is True
+    assert full.value == "abc"
+
+
 # ---------------------------------------------------------------------------
 # Keyboard / placeholder
 # ---------------------------------------------------------------------------
@@ -168,6 +210,19 @@ def test_placeholder_when_empty_unfocused() -> None:
     assert content.color == "gray"
 
 
+def test_styled_placeholder_keeps_component_color() -> None:
+    text = Text(
+        "",
+        input=True,
+        placeholder=Text("search logs", foreground="yellow"),
+    )
+    content = text.compose(_ctx())
+    assert isinstance(content, TextBlock)
+    assert content.text == "search logs"
+    assert content.color == "yellow"
+    assert "dim" in content.modifiers
+
+
 def test_multiline_creates_editor() -> None:
     text = Text("hello\nworld", input=True, multiline=True)
     assert text._editor is not None
@@ -191,6 +246,25 @@ def test_markup_cache_reuses_lines() -> None:
     assert first is not None
 
 
+@pytest.mark.parametrize(
+    ("text", "mode"),
+    (
+        ("\x1b[31mred\x1b[0m", "ansi"),
+        ("value = 1", "language"),
+    ),
+)
+def test_markup_modes_render_styled_lines(text: str, mode: str) -> None:
+    component = (
+        Text(text, ansi=True)
+        if mode == "ansi"
+        else Text(text, language="python")
+    )
+    content = component.compose(_ctx())
+    assert isinstance(content, TextBlock)
+    assert content.lines
+    assert "".join(run.text for line in content.lines for run in line)
+
+
 def test_compose_plain() -> None:
     text = Text("hello", foreground="cyan")
     content = text.compose(_ctx())
@@ -199,10 +273,156 @@ def test_compose_plain() -> None:
     assert content.color == "cyan"
 
 
-def test_offscreen_render_smoke() -> None:
-    runtime = Runtime.offscreen(40, 10)
+def test_nested_text_shapes_preserve_rows_and_styles() -> None:
+    single = Text(Text("nested", foreground="green")).compose(_ctx())
+    assert isinstance(single, TextBlock)
+    assert single.text == "nested"
+
+    lines = Text(
+        [
+            Text("first\nsecond", foreground="cyan"),
+            "third",
+        ]
+    ).compose(_ctx())
+    assert isinstance(lines, TextBlock)
+    assert ["".join(run.text for run in line) for line in lines.lines] == [
+        "first",
+        "second",
+        "third",
+    ]
+    assert lines.lines[0][0].color == "cyan"
+
+    leaf = Text("leaf", foreground="green")
+    assert leaf._as_children() == [leaf]
+    assert leaf._to_span_node().text == "leaf"
+    nested = Text(leaf)
+    assert nested._as_children() == [leaf]
+    assert nested._to_span_node().text == "leaf"
+    assert isinstance(Text(["a", "b"])._to_line_node(_ctx()), TextBlock)
+    assert Text([leaf])._to_span_node().text == ""
+    assert Text("line")._to_line_node(_ctx()).text == "line"
+
+    nested_lines = Text([Text([Text("ignored")]), Text("shown\nnext")])
+    content = nested_lines.compose(_ctx())
+    assert isinstance(content, TextBlock)
+    assert ["".join(run.text for run in line) for line in content.lines] == [
+        "shown",
+        "next",
+    ]
+    assert (
+        nested_lines._build_line_nodes_from_leaf_children(
+            [Text([Text("ignored")])]
+        )
+        == []
+    )
+
+
+def test_placeholder_normalization_rejects_nested_content() -> None:
+    assert Text("", placeholder="search")._placeholder_string() == "search"
+    assert (
+        Text("", placeholder=Text([Text("nested")]))._placeholder_string()
+        is None
+    )
+    non_string = Text([Text("value")], input=True)
+    assert non_string._input_display_content() == ("", None, False)
+
+
+def test_fill_wraps_text_without_losing_content() -> None:
+    content = Text("alert", background="red", fill=True).compose(_ctx())
+    assert isinstance(content, Panel)
+    assert content.background == "red"
+    assert isinstance(content.child, TextBlock)
+    assert content.child.text == "alert"
+
+
+@pytest.mark.parametrize(
+    ("binding", "start", "cursor", "expected", "expected_cursor"),
+    (
+        ("backspace", "abcd", 2, "acd", 1),
+        ("delete", "abcd", 2, "abd", 2),
+        ("left", "abcd", 2, "abcd", 1),
+        ("right", "abcd", 2, "abcd", 3),
+        ("home", "abcd", 2, "abcd", 0),
+        ("end", "abcd", 2, "abcd", 4),
+    ),
+)
+def test_single_line_editor_commands(
+    binding: str,
+    start: str,
+    cursor: int,
+    expected: str,
+    expected_cursor: int,
+) -> None:
+    text = Text(start, input=True, cursor=cursor)
+    assert text.handle_keyboard(_kbd(matches={binding})) is True
+    assert text.value == expected
+    assert text.cursor == expected_cursor
+
+
+def test_non_input_and_navigation_keys_bubble() -> None:
+    assert Text("label").handle_keyboard(_kbd(character="x")) is False
+    text = Text("value", input=True)
+    assert text.handle_keyboard(_kbd(matches={"enter"})) is False
+    assert text.handle_keyboard(_kbd(character="x", kind="release")) is False
+    assert (
+        text.handle_keyboard(_kbd(character="x", modifiers=("ctrl",))) is False
+    )
+    assert text.value == "value"
+
+    non_string = Text([Text("value")], input=True)
+    assert non_string.handle_keyboard(_kbd(character="x")) is False
+
+    read_only = Text("value", input=True, read_only=True)
+    assert read_only.handle_keyboard(_kbd(matches={"backspace"})) is True
+    assert read_only.handle_keyboard(_kbd(matches={"delete"})) is True
+    assert read_only.value == "value"
+
+    start = Text("value", input=True, cursor=0)
+    assert start.handle_keyboard(_kbd(matches={"backspace"})) is True
+    assert start.value == "value"
+    end = Text("value", input=True, cursor=5)
+    assert end.handle_keyboard(_kbd(matches={"delete"})) is True
+    assert end.value == "value"
+
+
+def test_terminal_node_matches_component_composition() -> None:
+    text = Text("terminal", foreground="cyan")
+    assert text.get_terminal_node(_ctx()) == text.compose(_ctx())
+
+
+def test_multiline_editor_drives_composed_preview() -> None:
+    class Editor(BaseGrid, direction="vertical"):
+        notes: Text = Field(
+            default_factory=lambda: Text(
+                "",
+                input=True,
+                multiline=True,
+                placeholder=Text("release notes", foreground="yellow"),
+                max_length=12,
+                tab_size=2,
+            ),
+            group="notes",
+            height=3,
+        )
+        preview: str = Field(default="Nothing saved", height=2)
+
+        @on_keyboard("ctrl+s")
+        def save_notes(self) -> None:
+            self.preview = self.notes.value
+
+    runtime = Runtime.offscreen(40, 6)
     try:
-        frame = runtime.render(Text("hello", foreground="cyan"))
-        assert "hello" in frame.text
+        editor = Editor()
+        runtime.set_root(editor)
+        assert runtime.focus("notes")
+        runtime.render()
+
+        assert editor.notes.handle_paste("one\ttwo\nthree") is True
+        runtime.perform(Action.keyboard("ctrl+s"))
+        frame = runtime.render()
+
+        assert editor.notes.value == "one two\nthre"
+        assert "one two" in frame.text
+        assert editor.notes.cursor_position is not None
     finally:
         runtime.close()

--- a/tests/test_color_alias_and_text_default.py
+++ b/tests/test_color_alias_and_text_default.py
@@ -13,6 +13,12 @@ import warnings
 
 import pytest
 
+from xnano.colors import (
+    Color,
+    get_native_color,
+    pydantic_color,
+    tailwind_color,
+)
 from xnano.components.text import Text
 from xnano.fields import Field
 from xnano.grids import BaseGrid
@@ -73,3 +79,63 @@ def test_str_default_on_text_field_renders() -> None:
     terminal.close()
 
     assert "hello world" in frame.text
+
+
+def test_color_forms_flow_through_field_component_and_terminal() -> None:
+    class App(BaseGrid):
+        label: Text = Field(
+            default_factory=lambda: Text(
+                "status",
+                foreground="#22c55e",
+            ),
+            background="slate-900",
+            border="rounded",
+        )
+
+    terminal = Terminal.offscreen(cols=24, rows=4)
+    try:
+        terminal.attach_grid(App())
+        frame = terminal.render()
+        ansi = terminal.get_output_as_ansi()
+
+        assert frame.contains("status")
+        assert "38;2;34;197;94" in ansi
+        assert "48;2;15;23;42" in ansi
+    finally:
+        terminal.close()
+
+
+def test_color_inputs_share_one_conversion_contract() -> None:
+    assert Color.parse("red").as_rgb_tuple() == (255, 0, 0)
+    assert Color.parse("#0f08").as_hex(include_alpha=True) == "#00ff0088"
+    assert (
+        Color.parse((34, 197, 94, 128)).as_hex(include_alpha=True)
+        == "#22c55e80"
+    )
+
+    accent = tailwind_color("violet", 600)
+    assert Color.parse("violet-600") is accent
+    assert Color.parse(accent) is accent
+    assert accent.as_rgb_tuple(include_alpha=True) == (
+        accent.r,
+        accent.g,
+        accent.b,
+        accent.a,
+    )
+    assert pydantic_color("red") == Color(255, 0, 0)
+    assert get_native_color(None) is None
+    assert get_native_color("#22c55e") is get_native_color("#22c55e")
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "#12",
+        "not-a-color",
+        (1, 2),
+        42,
+    ),
+)
+def test_invalid_user_colors_fail_at_the_boundary(value: object) -> None:
+    with pytest.raises(ValueError):
+        Color.parse(value)  # ty: ignore[invalid-argument-type]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -7,6 +7,9 @@ from typing import cast
 from xnano.context import Context
 from xnano.core.runtime import Runtime
 from xnano.events import AbstractEventData, Event, KeyboardEventData
+from xnano.fields import Field
+from xnano.grids import BaseGrid
+from xnano.hooks import on_keyboard
 
 
 class _Facade:
@@ -82,5 +85,29 @@ def test_ctx_cursor_and_device_are_runtime_objects() -> None:
         runtime.cursor.move(3, 3)
         assert runtime.cursor.position == (3, 3)
         assert ctx.cursor.get_position() == (3, 3)
+    finally:
+        runtime.close()
+
+
+def test_real_hook_context_combines_state_runtime_and_rendering() -> None:
+    class App(BaseGrid):
+        message: str = Field(default="waiting")
+
+        @on_keyboard("enter")
+        def submit(self, ctx: Context[dict[str, str]]) -> None:
+            state = ctx.get_state()
+            self.message = f"{state['name']}:{ctx.surface}:{ctx.render_size}"
+
+    runtime = Runtime.offscreen(45, 6, state={"name": "Ada"})
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+        runtime.dispatch(
+            Event.from_data(KeyboardEventData.from_binding("enter"))
+        )
+
+        frame = runtime.render()
+        assert frame.contains("Ada:offscreen:small")
     finally:
         runtime.close()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from xnano.events import (
+    ClipboardEventData,
     Event,
+    FocusEventData,
     KeyboardEventData,
     MouseEventData,
     ResizeEventData,
-    event_from_core,
+    TickEventData,
     normalize_keyboard_binding,
 )
 
@@ -35,7 +37,34 @@ def test_normalize_binding_aliases() -> None:
     assert normalize_keyboard_binding("return") == (frozenset(), "enter")
 
 
-def test_event_from_core_smoke() -> None:
-    # Offscreen sessions can synthesize core events; just ensure the
-    # helper is importable and rejects nothing obvious when unused.
-    assert callable(event_from_core)
+def test_uniform_event_accessors_across_user_input_types() -> None:
+    keyboard = Event.from_data(
+        KeyboardEventData.from_binding(
+            "ctrl+s",
+            kind="repeat",
+            character="s",
+        )
+    )
+    mouse = Event.from_data(
+        MouseEventData(kind="drag", x=4, y=5, button="left")
+    )
+    clipboard = Event.from_data(ClipboardEventData("pasted"))
+    focus = Event.from_data(FocusEventData(kind="field_gained", field="name"))
+    tick = Event.from_data(TickEventData(elapsed_ms=16))
+
+    assert keyboard.keyboard_event is not None
+    assert keyboard.keyboard_event_kind == "repeat"
+    assert keyboard.keyboard_modifiers == ["ctrl"]
+    assert keyboard.keyboard_event.character == "s"
+    assert mouse.mouse_event_kind == "drag"
+    assert mouse.mouse_button == "left"
+    assert clipboard.is_clipboard_event()
+    assert clipboard.clipboard_text == "pasted"
+    assert focus.is_focus_event()
+    assert focus.focus_event is not None
+    assert focus.focus_event.field == "name"
+    assert tick.is_tick_event()
+    assert tick.tick_event is not None
+    assert tick.tick_event.elapsed_ms == 16
+    assert tick.keyboard_event is None
+    assert tick.keyboard_modifiers == []

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import inspect
 
+import pytest
+
 from xnano import hooks
 from xnano.components.text import Text
 from xnano.core.runtime import Runtime
@@ -107,5 +109,98 @@ def test_on_field_expression_fires_via_safe_evaluator() -> None:
         app.count = 3
         runtime.render()
         assert app.label == "count=3"
+    finally:
+        runtime.close()
+
+
+def test_grid_combines_component_fields_state_and_hooks() -> None:
+    class Dashboard(BaseGrid):
+        title: Text = Field(default_factory=lambda: Text("Build queue"))
+        status: Text = Field(default_factory=lambda: Text("idle"))
+        jobs: int = Field(default=0, state=True)
+
+        @hooks.on_field("jobs > 0")
+        def _show_jobs(self) -> None:
+            self.status = Text(f"{self.jobs} jobs running")
+
+    runtime = Runtime.offscreen(30, 6)
+    try:
+        dashboard = Dashboard()
+        runtime.set_root(dashboard)
+        assert "idle" in runtime.render().text
+
+        dashboard.jobs = 3
+        frame = runtime.render()
+
+        assert frame.contains("Build queue")
+        assert frame.contains("3 jobs running")
+        assert isinstance(dashboard.status, Text)
+    finally:
+        runtime.close()
+
+
+def test_grid_non_init_fields_follow_constructor_contract() -> None:
+    class App(BaseGrid):
+        title: str = Field(default="hello")
+        generated: str = Field(default_factory=lambda: "system", init=False)
+        empty: str = Field(init=False)
+
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        App(generated="override")  # ty: ignore[unknown-argument]
+
+    app = App()
+    assert app.title == "hello"
+    assert app.generated == "system"
+    assert app.empty is None
+
+
+def test_grid_settings_merge_across_inheritance_and_body_override() -> None:
+    class Parent(BaseGrid, direction="horizontal", border="plain"):
+        label: str = Field(default="parent")
+
+    class Child(Parent, gap=2):
+        grid_settings = {"direction": "vertical", "padding": 1}
+
+    child = Child()
+    assert child.grid_settings["border"] == "plain"
+    assert child.grid_settings["gap"] == 2
+    assert child.grid_settings["direction"] == "vertical"
+    assert child.grid_settings["padding"] == 1
+
+
+def test_runtime_field_patch_combines_style_sizing_and_slide() -> None:
+    class App(BaseGrid):
+        body: str = Field(default="ready", slide=("x", "y"))
+        count: int = Field(default=1, state=True)
+
+    runtime = Runtime.offscreen(30, 8)
+    try:
+        app = App()
+        runtime.set_root(app)
+        runtime.render()
+
+        app.grid_set_field(
+            "body",
+            "updated",
+            position=(999, 999),
+            class_name="text-red-500 bg-slate-900 p-1 rounded",
+            width=16,
+            height=6,
+            bold=True,
+        )
+        frame = runtime.render()
+        info = app._grid_field_info("body")
+
+        assert frame.contains("updated")
+        assert info.width is not None and info.width.value == 16
+        assert info.height is not None and info.height.value == 6
+        assert info.modifiers == ("bold",)
+        assert info.border == "rounded"
+        assert app.grid_field_position("body") != (999, 999)
+
+        with pytest.raises(TypeError, match="state field"):
+            app.grid_set_field("count", 2)
+        with pytest.raises(AttributeError, match="no layout field"):
+            app.grid_set_field("missing", "value")
     finally:
         runtime.close()

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -182,6 +182,28 @@ def test_pager_status_line_shows_percentage() -> None:
         terminal.close()
 
 
+def test_mixed_document_scrolls_across_user_content() -> None:
+    source = (
+        "# Release notes\n\n"
+        "> [!WARNING]\n> Back up first.\n\n"
+        "```python\nfrom xnano import render\nrender('ready')\n```\n\n"
+        + _tall_document(20)
+    )
+    document, terminal = _viewer(source, cols=55, rows=12)
+    try:
+        first = terminal.render(document)
+        assert first.contains("Release notes")
+        assert first.contains("Warning")
+
+        _press(terminal, "end")
+        last = terminal.render(document)
+
+        assert last.contains("Heading 19")
+        assert document.body.scroll_percentage() == 100
+    finally:
+        terminal.close()
+
+
 def test_code_block_has_gutter_and_keeps_inner_indent() -> None:
     text = "intro\n\n```python\ndef f():\n    return 1\n```\n\nafter"
     document, terminal = _viewer(text, cols=40, rows=12)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -86,9 +86,33 @@ def test_dispatch_request_with_runtime_context() -> None:
     assert grid.count == 1
 
 
-def test_request_decorator_factory() -> None:
-    decorator = request("PATCH", "/thing")
-    assert callable(decorator)
+def test_generic_request_decorator_updates_renderable_grid() -> None:
+    class App(BaseGrid):
+        message: str = Field(default="waiting")
+
+        @request("PATCH", "/thing")
+        def update(self, ctx) -> Response:
+            payload = ctx.request.json()
+            self.message = f"updated {payload['name']}"
+            return Response.json({"message": self.message})
+
+    app = App()
+    response = dispatch_request(
+        app,
+        "PATCH",
+        "/thing",
+        request_obj=Request.from_parts(
+            "PATCH",
+            "/thing",
+            headers={"content-type": "application/json"},
+            body=b'{"name": "dashboard"}',
+        ),
+        runtime=app,
+    )
+
+    assert isinstance(response, Response)
+    assert response.as_bytes() == b'{"message": "updated dashboard"}'
+    assert app.message == "updated dashboard"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Broadens test coverage for components (bar, button, image, input, link, loader, table, text) and framework areas (colors/text defaults, context, events, grids, markdown, requests). Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)