### PR TITLE
chore(release): bump xnano to 1.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.2.1"
+version = "1.2.2"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2377,7 +2377,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -16,7 +16,7 @@ try:
 except (
     importlib.metadata.PackageNotFoundError
 ):  # pragma: no cover - editable / source trees
-    __version__ = "1.2.1"
+    __version__ = "1.2.2"
 
 if TYPE_CHECKING:
     from xnano import cli, components, core, events, hooks, requests


### PR DESCRIPTION
Bumps the xnano Python package version 1.2.1 → 1.2.2 (`__init__.py`, `pyproject.toml`, `uv.lock`). `uv lock --check` passes.

Deferred to the in-progress core release (not included here to avoid an inconsistent lock): the xnano-core 0.0.16 Cargo.toml/Cargo.lock bump, the `xnano-core==0.0.16` pin, and the `set_version.py` docs/sandbox additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)