### PR TITLE
chore(release): bump xnano-core to 0.0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "markdown-it-py>=3.0.0",
     "pydantic-core>=2.0.0",
     "pygments>=2.17.0",
-    "xnano-core==0.0.15",
+    "xnano-core==0.0.16",
 ]
 
 [project.optional-dependencies]

--- a/xnano-core/Cargo.lock
+++ b/xnano-core/Cargo.lock
@@ -1890,7 +1890,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "xnano-core"
-version = "0.0.14"
+version = "0.0.16"
 dependencies = [
  "crossterm",
  "palette",

--- a/xnano-core/Cargo.toml
+++ b/xnano-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xnano-core"
-version = "0.0.15"
+version = "0.0.16"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/hsaeed3/xnano"


### PR DESCRIPTION
Bumps the xnano-core Rust extension 0.0.15 → 0.0.16.

- `xnano-core/Cargo.toml`: version → 0.0.16
- `xnano-core/Cargo.lock`: regenerated (also corrects the stale 0.0.14 entry that was on main)
- `pyproject.toml`: pin → `xnano-core==0.0.16`

`uv lock --check` passes (editable member carries no lock version pin, so uv.lock is unchanged).

Deferred: the `scripts/set_version.py` docs/sandbox additions still ride with the separate docs/sandbox branch, since they reference `docs/sandbox.md` which is not yet on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)