### PR TITLE
test(perf): benchmarks + stress suites

### DIFF
--- a/tests/benchmarks/test_core_performance.py
+++ b/tests/benchmarks/test_core_performance.py
@@ -1,0 +1,148 @@
+"""tests.benchmarks.test_core_performance
+
+---
+
+Track the core lowering, native rendering, and frame snapshot paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+from xnano_core.core import (
+    CoreRenderContent,
+    CoreRenderIR,
+    CoreRenderNode,
+    CoreSession,
+)
+from xnano_core.rust.native import Constraint
+
+from xnano.core.content import (
+    Bar,
+    BarGroup,
+    Bars,
+    CellCanvas,
+    CellSpan,
+    Gauge,
+    Items,
+    Panel,
+    Sparkline,
+    Stack,
+    TableGrid,
+    TableRow,
+    TextBlock,
+)
+from xnano.core.rendering import lower_content
+from xnano.core.runtime import Runtime
+
+
+def _dashboard_content(rows: int) -> Stack:
+    services = tuple(
+        TableRow(cells=(f"service-{index}", "ready", str(index)))
+        for index in range(rows)
+    )
+    return Stack(
+        children=(
+            Panel(
+                child=TextBlock(text="All systems operational"),
+                title="Status",
+                border="rounded",
+            ),
+            Gauge(progress=0.72, label="CPU 72%"),
+            Sparkline(data=tuple(range(32))),
+            Bars(
+                groups=(
+                    BarGroup(
+                        label="requests",
+                        bars=tuple(
+                            Bar(value=index + 1, label=str(index))
+                            for index in range(8)
+                        ),
+                    ),
+                ),
+                max_value=8,
+            ),
+            Items(items=tuple(f"worker-{index}" for index in range(rows))),
+            TableGrid(
+                header=TableRow(cells=("Service", "State", "Queue")),
+                rows=services,
+                column_widths=(18, 8, 8),
+            ),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "rows",
+    (10, 100),
+    ids=("small-dashboard", "large-dashboard"),
+)
+def test_bench_core_content_lowering(benchmark, rows: int) -> None:
+    """Measure Python content lowering without terminal setup."""
+    content = _dashboard_content(rows)
+    node = benchmark(lower_content, content)
+    assert isinstance(node, CoreRenderNode)
+
+
+def test_bench_core_cell_canvas_cache_hit(benchmark) -> None:
+    """Measure the hot identity-cache path used by images and animation."""
+    canvas = CellCanvas.from_rows(
+        tuple(
+            (
+                CellSpan(
+                    " " * 80,
+                    background=f"#{row:02x}4080",
+                ),
+            )
+            for row in range(24)
+        )
+    )
+    lower_content(canvas)
+    node = benchmark(lower_content, canvas)
+    assert isinstance(node, CoreRenderNode)
+
+
+def test_bench_core_native_render_tree(benchmark) -> None:
+    """Measure native layout and paint for a representative scene graph."""
+    session = CoreSession.offscreen(120, 40)
+    children = [
+        CoreRenderNode.leaf(
+            CoreRenderContent.ir(
+                CoreRenderIR.paragraph_raw(
+                    f"row {index} " * 8,
+                    None,
+                    None,
+                    [],
+                    None,
+                    True,
+                )
+            )
+        )
+        for index in range(20)
+    ]
+    tree = CoreRenderNode.column(
+        children,
+        constraints=[Constraint.fill(1) for _ in children],
+    )
+    benchmark(session.render, tree)
+    assert session.buffer_snapshot().to_string_lines()
+
+
+@pytest.mark.parametrize(
+    ("width", "height"),
+    ((80, 24), (200, 50)),
+    ids=("terminal", "dashboard"),
+)
+def test_bench_runtime_render_and_snapshot(
+    benchmark,
+    width: int,
+    height: int,
+) -> None:
+    """Measure the public core paint path including frame serialization."""
+    runtime = Runtime.offscreen(width, height)
+    runtime.set_root(_dashboard_content(20))
+    try:
+        frame = benchmark(runtime.render)
+        assert frame.width == width
+        assert frame.height == height
+    finally:
+        runtime.close()

--- a/tests/benchmarks/test_options_performance.py
+++ b/tests/benchmarks/test_options_performance.py
@@ -1,0 +1,76 @@
+"""tests.benchmarks.test_options_performance
+
+---
+
+Track large dynamic option-list filtering and rendering.
+"""
+
+from typing import Any
+
+from xnano.components.component import ComponentRenderContext
+from xnano.components.options import Option, Options
+from xnano.core.content import Items, Stack
+from xnano.core.runtime import Runtime
+from xnano.types import Area
+
+
+_ITEMS = tuple(
+    Option(label=f"model-{index:04d}", value=index) for index in range(3_000)
+)
+_CONTEXT = ComponentRenderContext[Any](
+    area=Area(x=0, y=0, width=80, height=24)
+)
+
+
+def test_bench_options_compose_visible_window(benchmark) -> None:
+    """Measure composing a terminal-sized window from 3,000 options."""
+    options = Options(items=_ITEMS, selected=1_500)
+    content = benchmark(options.compose, _CONTEXT)
+    assert isinstance(content, Items)
+    assert len(content.items) == 24
+
+
+def test_bench_options_fuzzy_filter(benchmark) -> None:
+    """Measure fuzzy searching the complete 3,000-option data set."""
+    options = Options(items=_ITEMS, query="m299")
+    visible = benchmark(lambda: options.visible_items)
+    assert visible
+
+
+def test_bench_options_runtime_render(benchmark) -> None:
+    """Measure public rendering and frame serialization at SSH dimensions."""
+    options = Options(items=_ITEMS, searchable=True, selected=1_500)
+    runtime = Runtime.offscreen(width=80, height=24)
+    runtime.set_root(options)
+    try:
+        frame = benchmark(runtime.render)
+        assert frame.width == 80
+        assert frame.height == 24
+    finally:
+        runtime.close()
+
+
+def test_bench_options_dynamic_replacement(benchmark) -> None:
+    """Measure a gateway update followed by a complete terminal render."""
+    options = Options(items=_ITEMS, selected=1_500)
+    updated = tuple(
+        Option(label=f"gateway-{index:04d}", value=index)
+        for index in range(3_000)
+    )
+    runtime = Runtime.offscreen(width=80, height=24)
+    runtime.set_root(options)
+    source = _ITEMS
+
+    def replace_and_render() -> None:
+        nonlocal source
+        source = updated if source is _ITEMS else _ITEMS
+        selected = options.selected_value
+        options.items = source
+        options.select_value(selected)
+        runtime.render()
+
+    try:
+        benchmark(replace_and_render)
+        assert options.selected_value == 1_500
+    finally:
+        runtime.close()

--- a/tests/stress/test_options_scale.py
+++ b/tests/stress/test_options_scale.py
@@ -1,0 +1,87 @@
+"""tests.stress.test_options_scale
+
+---
+
+Exercise large option lists and competing Python work.
+"""
+
+import threading
+
+from typing import Any
+
+from xnano.components.component import ComponentRenderContext
+from xnano.components.options import Option, Options
+from xnano.core.content import Items, Stack
+from xnano.core.runtime import Runtime
+from xnano.types import Area
+
+
+def _large_items(prefix: str = "model") -> tuple[Option, ...]:
+    return tuple(
+        Option(label=f"{prefix}-{index:04d}", value=index)
+        for index in range(3_000)
+    )
+
+
+def test_large_options_compose_only_the_terminal_window() -> None:
+    options = Options(
+        items=_large_items(),
+        searchable=True,
+        selected=2_999,
+    )
+    context = ComponentRenderContext[Any](
+        area=Area(x=0, y=0, width=80, height=24)
+    )
+
+    content = options.compose(context)
+
+    assert isinstance(content, Stack)
+    visible = content.children[1]
+    assert isinstance(visible, Items)
+    assert len(visible.items) == 23
+    assert visible.selected == 22
+    assert options.selected_value == 2_999
+
+
+def test_large_options_preserve_selection_across_gateway_update() -> None:
+    options = Options(items=_large_items(), selected=1_937)
+    runtime = Runtime.offscreen(width=80, height=24)
+    runtime.set_root(options)
+    try:
+        runtime.render()
+        selected = options.selected_value
+        options.items = _large_items("gateway")
+        assert options.select_value(selected)
+        frame = runtime.render()
+        assert frame.height == 24
+        assert options.selected_value == 1_937
+    finally:
+        runtime.close()
+
+
+def test_large_options_render_while_python_service_is_busy() -> None:
+    options = Options(items=_large_items(), selected=1_500)
+    runtime = Runtime.offscreen(width=80, height=24)
+    runtime.set_root(options)
+    started = threading.Event()
+    stopped = threading.Event()
+
+    def run_service() -> None:
+        value = 1
+        started.set()
+        while not stopped.is_set():
+            value = (value * 1_103_515_245 + 12_345) & 0x7FFFFFFF
+
+    worker = threading.Thread(target=run_service)
+    worker.start()
+    started.wait()
+    try:
+        for selected in (0, 750, 1_500, 2_250, 2_999):
+            options.select(selected)
+            frame = runtime.render()
+            assert frame.height == 24
+            assert options.selected_value == selected
+    finally:
+        stopped.set()
+        worker.join()
+        runtime.close()

--- a/tests/stress/test_runtime_scale.py
+++ b/tests/stress/test_runtime_scale.py
@@ -1,0 +1,104 @@
+"""tests.stress.test_runtime_scale
+
+---
+
+Exercise mixed components, large data, and live service updates.
+"""
+
+import queue
+import threading
+
+from xnano.components.chart import Chart
+from xnano.components.options import Options
+from xnano.components.table import Table
+from xnano.core.runtime import Runtime
+from xnano.fields import Field
+from xnano.grids import BaseGrid
+
+
+def test_large_mixed_dashboard_updates_as_one_render_tree() -> None:
+    models = tuple(f"model-{index:04d}" for index in range(3_000))
+    rows = [
+        {"model": model, "latency": index % 100}
+        for index, model in enumerate(models)
+    ]
+
+    class Dashboard(BaseGrid, direction="vertical"):
+        models: Options = Field(
+            default_factory=lambda: Options(
+                items=models,
+                selected=1_500,
+            ),
+            height=12,
+        )
+        requests: Chart = Field(
+            default_factory=lambda: Chart(
+                series={"latency": tuple(range(3_000))},
+                legend=False,
+            ),
+            height=10,
+        )
+        results: Table = Field(
+            default_factory=lambda: Table(data=rows, selected=1_500),
+            height=16,
+        )
+
+    dashboard = Dashboard()
+    runtime = Runtime.offscreen(width=100, height=40)
+    runtime.set_root(dashboard)
+    try:
+        first = runtime.render()
+        dashboard.models.select(2_999)
+        dashboard.requests.series = {
+            "latency": tuple(reversed(range(3_000)))
+        }
+        dashboard.results.data = list(reversed(rows))
+        second = runtime.render()
+
+        assert (first.width, first.height) == (second.width, second.height)
+        assert dashboard.models.selected_value == "model-2999"
+        assert dashboard.results.selected_row is not None
+    finally:
+        runtime.close()
+
+
+def test_large_options_render_at_common_terminal_sizes() -> None:
+    items = tuple(f"endpoint-{index:04d}" for index in range(3_000))
+    for width, height in ((40, 10), (80, 24), (160, 50)):
+        options = Options(items=items, selected=2_999, searchable=True)
+        runtime = Runtime.offscreen(width=width, height=height)
+        try:
+            frame = runtime.render(options)
+            assert frame.width == width
+            assert frame.height == height
+            assert options.selected_value == "endpoint-2999"
+        finally:
+            runtime.close()
+
+
+def test_service_snapshots_can_feed_repeated_renders() -> None:
+    snapshots: queue.Queue[tuple[str, ...]] = queue.Queue(maxsize=1)
+    options = Options(items=(), selected=1_500)
+    runtime = Runtime.offscreen(width=80, height=24)
+    runtime.set_root(options)
+
+    def run_service() -> None:
+        for revision in range(5):
+            snapshots.put(
+                tuple(
+                    f"revision-{revision}-model-{index:04d}"
+                    for index in range(3_000)
+                )
+            )
+
+    worker = threading.Thread(target=run_service)
+    worker.start()
+    try:
+        for revision in range(5):
+            options.items = snapshots.get()
+            frame = runtime.render()
+            assert f"revision-{revision}" in options.selected_label
+            assert frame.height == 24
+    finally:
+        worker.join()
+        runtime.close()


### PR DESCRIPTION
Adds CodSpeed benchmark suites (`tests/benchmarks/`) and scale/stress tests (`tests/stress/`) for the core runtime and options component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)