### PR TITLE
test: core public API + framework coverage

### DIFF
--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -1,0 +1,60 @@
+"""tests.components.test_component"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import xnano.components as components
+from xnano.components.component import Component, ComponentRenderContext
+from xnano.components.schema import Column
+from xnano.types import Area, Size
+
+
+def test_public_component_exports_are_resolvable() -> None:
+    for name in components.__all__:
+        assert getattr(components, name) is not None
+    assert set(dir(components)) >= set(components.__all__)
+
+
+def test_unknown_component_export_has_normal_attribute_error() -> None:
+    try:
+        getattr(components, "MissingHero")
+    except AttributeError as error:
+        assert "MissingHero" in str(error)
+    else:
+        raise AssertionError("missing export unexpectedly resolved")
+
+
+def test_component_default_extension_contracts_are_noops() -> None:
+    component = Component()
+    ctx = ComponentRenderContext[Any](
+        area=Area(x=1, y=2, width=10, height=4),
+        state={"ready": True},
+    )
+    area = ctx.area
+
+    assert component.focused is False
+    assert component.get_frame() is None
+    assert component.get_size(ctx) == Size(width=0, height=0)
+    assert component.before_render(ctx, area) == area
+    assert component.after_render(ctx, area) is None
+    assert component.compose(ctx) is None
+    assert component.compose_extra_small(ctx) is None
+    assert component.compose_small(ctx) is None
+    assert component.compose_medium(ctx) is None
+    assert component.compose_large(ctx) is None
+    assert component.compose_extra_large(ctx) is None
+    assert component.handle_keyboard(cast(Any, object())) is False
+    assert component.handle_paste("text") is False
+
+
+def test_component_descriptors_are_inherited_without_shared_mutation() -> None:
+    class Base(Component):
+        value: int = Column(header="Base")
+
+    class Child(Base):
+        pass
+
+    assert Base._declared["value"].name == "value"
+    assert Child._declared["value"].name == "value"
+    assert Child._declared["value"] is Base._declared["value"]

--- a/tests/core/test_core_demo_lifecycle.py
+++ b/tests/core/test_core_demo_lifecycle.py
@@ -1,0 +1,91 @@
+"""Tests for showcase entry and runtime lifecycle workflows."""
+
+from __future__ import annotations
+
+import pathlib
+
+import xnano.core.demo as demo
+import xnano.markdown
+import xnano.terminal
+from xnano.actions import Action
+from xnano.core.demo import Demo, IntroSplash, Showcase
+from xnano.core.runtime import Runtime
+
+
+def test_demo_advances_from_intro_to_interactive_showcase() -> None:
+    runtime = Runtime.offscreen(80, 24)
+    try:
+        app = Demo()
+        runtime.set_root(app)
+        intro = runtime.render()
+        assert isinstance(app.view, IntroSplash)
+        assert intro.width == 80
+        assert intro.height == 24
+
+        runtime.perform(Action.tick(1000))
+        runtime.perform(Action.tick(1000))
+        runtime.perform(Action.tick(1100))
+        showcase = runtime.render()
+        assert isinstance(app.view, Showcase)
+        assert showcase.contains("xnano")
+        assert showcase.revision > intro.revision
+    finally:
+        runtime.close()
+
+
+def test_runtime_schedules_showcase_updates_before_next_pump() -> None:
+    runtime = Runtime.offscreen(80, 24)
+    try:
+        app = Showcase()
+        runtime.set_root(app)
+        runtime.render()
+        runtime.call_soon(setattr, app, "header", app.header)
+        assert runtime.pump()
+        frame = runtime.render()
+        assert frame.contains("showcase")
+        runtime.request_exit()
+        assert not runtime.pump()
+    finally:
+        runtime.close()
+
+
+def test_demo_entry_routes_documents_and_showcase(
+    monkeypatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    opened: list[pathlib.Path] = []
+    launched: list[bool] = []
+    monkeypatch.setattr(xnano.markdown, "run_markdown", opened.append)
+    monkeypatch.setattr(demo, "run_showcase", lambda: launched.append(True))
+
+    document = tmp_path / "guide.md"
+    demo.run_demo([str(document)])
+    demo.run_demo()
+
+    assert opened == [document]
+    assert launched == [True]
+
+
+def test_showcase_entry_uses_viewport_size_for_paint_cadence(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeTerminal:
+        def __init__(self, **settings: object) -> None:
+            captured.update(settings)
+
+        def run(self, root: object) -> None:
+            captured["root"] = root
+
+    monkeypatch.setattr(xnano.terminal, "Terminal", FakeTerminal)
+    monkeypatch.setattr(
+        demo.shutil if hasattr(demo, "shutil") else __import__("shutil"),
+        "get_terminal_size",
+        lambda fallback: (400, 100),
+    )
+    demo.run_showcase()
+
+    assert captured["title"] == "xnano · showcase"
+    assert captured["tick_interval"] == 100
+    assert isinstance(captured["root"], Demo)

--- a/tests/core/test_core_public_compositions.py
+++ b/tests/core/test_core_public_compositions.py
@@ -1,0 +1,257 @@
+"""Tests for composed public content through the core runtime."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from xnano_core.core import (
+    CoreRenderContent,
+    CoreRenderIR,
+    CoreRenderNode,
+    CoreSession,
+)
+
+from xnano.core.content import (
+    Bar,
+    BarGroup,
+    Bars,
+    Canvas,
+    CanvasCircle,
+    CanvasLine,
+    CanvasPoints,
+    CanvasPrint,
+    CanvasRectangle,
+    CellCanvas,
+    Clear,
+    Gauge,
+    Items,
+    LineGauge,
+    Native,
+    Panel,
+    Plot,
+    PlotAxis,
+    PlotDataset,
+    Run,
+    Scrollbar,
+    Sparkline,
+    Stack,
+    TableGrid,
+    TableRow,
+    TextBlock,
+)
+from xnano.core.rendering import lower_content
+from xnano.core.runtime import Runtime
+from xnano.fields import Field
+from xnano.grids import BaseGrid
+from xnano.types import Sizing
+
+
+def test_operations_dashboard_switches_between_composed_views() -> None:
+    runtime = Runtime.offscreen(48, 12)
+    try:
+        overview = Stack(
+            children=(
+                Panel(
+                    child=TextBlock(text="All systems operational"),
+                    title="Status",
+                    border="rounded",
+                ),
+                Gauge(progress=0.72, label="CPU 72%"),
+                LineGauge(progress=0.4, label="Queue 40%"),
+            )
+        )
+        frame = runtime.render(overview)
+        assert frame.contains("Status")
+        assert frame.contains("All systems operational")
+        assert frame.contains("CPU 72%")
+        assert frame.contains("Queue 40%")
+
+        detail = Stack(
+            direction="horizontal",
+            children=(
+                Items(
+                    items=("api", "worker", "scheduler"),
+                    selected=1,
+                    highlight_symbol="› ",
+                ),
+                TableGrid(
+                    header=TableRow(cells=("Service", "State")),
+                    rows=(
+                        TableRow(cells=("api", "ready")),
+                        TableRow(cells=("worker", "busy")),
+                    ),
+                    column_widths=(10, 8),
+                    selected_row=1,
+                ),
+            ),
+        )
+        frame = runtime.render(detail)
+        assert all(
+            frame.contains(value)
+            for value in ("scheduler", "Service", "api", "ready", "busy")
+        )
+        assert frame.revision > 0
+    finally:
+        runtime.close()
+
+
+def test_metrics_view_combines_chart_canvas_and_scroll_position() -> None:
+    runtime = Runtime.offscreen(48, 12)
+    try:
+        metrics = Stack(
+            children=(
+                Bars(
+                    groups=(
+                        BarGroup(
+                            label="requests",
+                            bars=(
+                                Bar(value=8, label="GET"),
+                                Bar(value=3, label="POST"),
+                            ),
+                        ),
+                    ),
+                    max_value=10,
+                ),
+                Sparkline(data=(1, 4, 2, 8, 5)),
+                CellCanvas.from_rows((("cache: warm",), ("region: west",))),
+                Scrollbar(
+                    content_length=100,
+                    viewport_length=20,
+                    position=40,
+                    orientation="horizontal_bottom",
+                ),
+            )
+        )
+
+        frame = runtime.render(metrics)
+        assert frame.width == 48
+        assert frame.height == 12
+        assert frame.contains("cache: warm")
+        assert frame.contains("region: west")
+        assert frame.text.strip()
+        assert frame.ansi
+        assert len(frame.rows) == 12
+    finally:
+        runtime.close()
+
+
+def test_canvas_overview_combines_geometry_and_styled_annotations() -> None:
+    runtime = Runtime.offscreen(48, 12)
+    try:
+        canvas = Canvas(
+            x_bounds=(0.0, 10.0),
+            y_bounds=(0.0, 10.0),
+            marker="braille",
+            shapes=(
+                CanvasRectangle(x=1, y=1, width=8, height=6, color="blue"),
+                CanvasLine(x1=1, y1=1, x2=9, y2=7, color="cyan"),
+                CanvasCircle(x=5, y=5, radius=2, color="green"),
+                CanvasPoints(coords=((2, 8), (5, 9), (8, 8)), color="yellow"),
+                CanvasPrint(
+                    x=3,
+                    y=5,
+                    content=Run(
+                        text="LIVE",
+                        color="white",
+                        modifiers=("bold",),
+                    ),
+                ),
+            ),
+        )
+
+        frame = runtime.render(canvas)
+        assert frame.contains("LIVE")
+        assert frame.text.strip()
+    finally:
+        runtime.close()
+
+
+def test_native_escape_hatches_and_fallback_content_render_together() -> None:
+    runtime = Runtime.offscreen(40, 8)
+    try:
+        node = CoreRenderNode.leaf(
+            CoreRenderContent.ir(CoreRenderIR.span("native-node", None, None, []))
+        )
+        content = Stack(
+            children=(
+                Native(interface_kind="terminal", payload=node),
+                Native(
+                    interface_kind="terminal",
+                    payload=CoreRenderIR.span("native-ir", None, None, []),
+                ),
+                Native(interface_kind="terminal", payload={"state": "ready"}),
+            )
+        )
+        frame = runtime.render(content)
+        assert frame.contains("native-node")
+        assert frame.contains("native-ir")
+        assert frame.contains("'state': 'ready'")
+
+        class ServiceState:
+            def __str__(self) -> str:
+                return "fallback-service"
+
+        assert runtime.render(ServiceState()).contains("fallback-service")
+        assert not runtime.render(Clear()).text.strip()
+    finally:
+        runtime.close()
+
+
+def test_configured_plot_and_partial_panel_render_as_one_status_view() -> None:
+    runtime = Runtime.offscreen(48, 12)
+    try:
+        view = Stack(
+            children=(
+                Plot(
+                    datasets=(
+                        PlotDataset(
+                            data=((0, 2), (1, 5), (2, 3)),
+                            name="latency",
+                            graph_type="line",
+                            marker="dot",
+                            color="cyan",
+                        ),
+                    ),
+                    x_axis=PlotAxis(
+                        title="minute",
+                        bounds=(0, 2),
+                        labels=("now", "later"),
+                        color="white",
+                    ),
+                    y_axis=PlotAxis(title="ms", bounds=(0, 5)),
+                    color="blue",
+                    legend_position="bottom_left",
+                ),
+                Panel(
+                    child=TextBlock(text="healthy"),
+                    title="Service",
+                    title_position="bottom",
+                    border_sides=("left", "right"),
+                    border_color="green",
+                    background="black",
+                ),
+            )
+        )
+        frame = runtime.render(view)
+        assert frame.contains("ms")
+        assert frame.contains("healthy")
+        assert frame.contains("Service")
+    finally:
+        runtime.close()
+
+
+def test_grid_mixes_fixed_percent_ratio_fit_and_flexible_fields() -> None:
+    class Dashboard(BaseGrid, gap=1):
+        title: Any = Field(default="Overview", height=1)
+        alerts: Any = Field(default="No alerts", height="20%")
+        jobs: Any = Field(default="Jobs", height="1/4")
+        detail: Any = Field(default="Detail", height=Sizing.fit(minimum=1))
+        footer: Any = Field(default="Ready", height="1fr")
+
+    session = CoreSession.offscreen(40, 16)
+    session.render(lower_content(Dashboard()))
+    text = "\n".join(session.buffer_snapshot().to_string_lines())
+    assert all(
+        value in text
+        for value in ("Overview", "No alerts", "Jobs", "Detail", "Ready")
+    )

--- a/tests/core/test_core_public_effects.py
+++ b/tests/core/test_core_public_effects.py
@@ -1,0 +1,126 @@
+"""Tests for public effect descriptions lowered through the core engine."""
+
+from __future__ import annotations
+
+import pytest
+
+from xnano.core.effects import build_native_effect, resolve_native_effect
+from xnano.effects import (
+    AbstractEffect,
+    CoalesceEffect,
+    DelayEffect,
+    DissolveEffect,
+    EffectCellFilter,
+    FadeEffect,
+    FadeFromBothEffect,
+    FadeFromEffect,
+    FadeToEffect,
+    PaintBackgroundEffect,
+    PaintEffect,
+    PaintForegroundEffect,
+    ParallelEffect,
+    RepeatEffect,
+    SequenceEffect,
+    SleepEffect,
+    SlideInEffect,
+    SlideOutEffect,
+    SweepInEffect,
+    SweepOutEffect,
+)
+
+
+@pytest.mark.parametrize(
+    "effect",
+    (
+        FadeEffect(color="cyan", interpolation="linear"),
+        FadeFromEffect(color="blue", interpolation="smooth_step"),
+        FadeToEffect(color="white", background="black"),
+        FadeFromBothEffect(color="white", background="black"),
+        DissolveEffect(),
+        CoalesceEffect(),
+        SweepInEffect(direction="up_to_down", color="green"),
+        SweepOutEffect(direction="down_to_up", color="green"),
+        SlideInEffect(direction="left_to_right", color="yellow"),
+        SlideOutEffect(direction="right_to_left", color="yellow"),
+        PaintEffect(color="white", background="blue"),
+        PaintForegroundEffect(color="cyan"),
+        PaintBackgroundEffect(background="black"),
+        SleepEffect(duration_ms=10),
+    ),
+)
+def test_transition_catalog_lowers_for_runtime_playback(
+    effect: AbstractEffect,
+) -> None:
+    assert build_native_effect(effect) is not None
+
+
+def test_nested_loading_transition_lowers_with_filters_and_repetition() -> None:
+    transition = SequenceEffect(
+        effects=(
+            ParallelEffect(
+                effects=(
+                    FadeEffect(color="cyan", cell_filter="text"),
+                    PaintBackgroundEffect(
+                        background="black",
+                        cell_filter="background_only",
+                    ),
+                )
+            ),
+            DelayEffect(
+                duration_ms=20,
+                child=RepeatEffect(
+                    child=CoalesceEffect(cell_filter="non_empty"),
+                    times=2,
+                ),
+            ),
+        )
+    )
+
+    assert resolve_native_effect(transition) is not None
+    assert resolve_native_effect(
+        "repeat",
+        child=SleepEffect(duration_ms=1),
+        duration_ms=20,
+    ) is not None
+    assert build_native_effect(
+        RepeatEffect(child=SleepEffect(duration_ms=1))
+    ) is not None
+
+
+@pytest.mark.parametrize(
+    "cell_filter",
+    ("all", "text", "non_empty", "background", "background_only"),
+)
+def test_transition_can_target_each_runtime_cell_group(
+    cell_filter: EffectCellFilter,
+) -> None:
+    assert (
+        resolve_native_effect(FadeEffect(color="cyan", cell_filter=cell_filter))
+        is not None
+    )
+
+
+@pytest.mark.parametrize(
+    ("effect", "message"),
+    (
+        (SequenceEffect(), "at least one child"),
+        (ParallelEffect(), "at least one child"),
+        (RepeatEffect(), "require a child"),
+        (DelayEffect(), "require a child"),
+        (FadeEffect(color="not-a-real-color"), "must resolve to a color"),
+    ),
+)
+def test_invalid_transition_descriptions_explain_the_problem(
+    effect: AbstractEffect,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        build_native_effect(effect)
+
+
+def test_custom_unsupported_effect_fails_at_the_lowering_boundary() -> None:
+    class CustomEffect(AbstractEffect):
+        pass
+
+    with pytest.raises(ValueError, match="unsupported effect type"):
+        build_native_effect(CustomEffect())

--- a/tests/core/test_core_public_errors.py
+++ b/tests/core/test_core_public_errors.py
@@ -1,0 +1,34 @@
+"""Tests for actionable errors raised across public core workflows."""
+
+from __future__ import annotations
+
+import pytest
+
+from xnano.core.exceptions import (
+    ExtraNotInstalledError,
+    FieldValidationError,
+    HookError,
+    TerminalNotActiveError,
+)
+
+
+def test_runtime_errors_preserve_actionable_context() -> None:
+    cause = LookupError("missing service")
+    hook_error = HookError("refresh", cause)
+    assert hook_error.hook_name == "refresh"
+    assert hook_error.cause is cause
+    assert hook_error.__cause__ is cause
+    assert "refresh" in str(hook_error)
+
+    class ValidationFailure:
+        def errors(self) -> list[dict[str, str]]:
+            return [{"message": "must be positive"}]
+
+    assert "must be positive" in str(
+        FieldValidationError("retries", ValidationFailure())  # type: ignore
+    )
+    assert "active live runtime" in str(TerminalNotActiveError())
+    assert "Pillow" in str(ExtraNotInstalledError("images"))
+    assert "standard library" in str(ExtraNotInstalledError("requests"))
+    with pytest.raises(ValueError, match="Unknown extra"):
+        ExtraNotInstalledError("audio")

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,77 @@
+"""tests.test_entrypoint
+
+---
+
+Exercise the installed command and complete lazy public interface.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+import xnano
+import xnano.__main__ as entrypoint
+
+
+def test_public_interface_lazily_resolves_every_documented_export() -> None:
+    """Every name advertised by ``from xnano import *`` resolves."""
+    exported = {name: getattr(xnano, name) for name in xnano.__all__}
+    assert set(dir(xnano)) == set(xnano.__all__)
+    assert all(value is not None for value in exported.values())
+    with pytest.raises(AttributeError, match="no attribute"):
+        xnano.__getattr__("DetroitSmash")
+
+
+def test_command_without_arguments_launches_showcase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The installed command defaults to the interactive showcase."""
+    calls: list[str] = []
+    monkeypatch.setattr(sys, "argv", ["xnano"])
+    monkeypatch.setattr(
+        "xnano.core.demo.run_demo",
+        lambda: calls.append("showcase"),
+    )
+    entrypoint.run_demo()
+    assert calls == ["showcase"]
+
+
+@pytest.mark.parametrize("argument", ("-h", "--help", "help"))
+def test_command_help_aliases_print_usage(
+    argument: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["xnano", argument])
+    entrypoint.run_demo()
+    assert "Usage: xnano [PATH.md]" in capsys.readouterr().out
+
+
+def test_command_opens_markdown_document(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    document = tmp_path / "guide.md"
+    document.write_text("# Guide", encoding="utf-8")
+    opened: list[str] = []
+    monkeypatch.setattr(sys, "argv", ["xnano", str(document)])
+    monkeypatch.setattr(
+        "xnano.markdown.run_markdown",
+        lambda path: opened.append(path),
+    )
+    entrypoint.run_demo()
+    assert opened == [str(document)]
+
+
+def test_command_rejects_unknown_input(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["xnano", "missing.txt"])
+    with pytest.raises(SystemExit) as exit_error:
+        entrypoint.run_demo()
+    assert exit_error.value.code == 2
+    assert "unknown input" in capsys.readouterr().err

--- a/tests/test_user_compositions.py
+++ b/tests/test_user_compositions.py
@@ -1,0 +1,638 @@
+"""tests.test_user_compositions
+
+---
+
+Exercise realistic applications built by composing xnano objects instead of
+testing each object in isolation.
+"""
+
+from __future__ import annotations
+
+import http.client
+import io
+import json
+import threading
+import types
+from typing import Annotated
+
+import pytest
+
+from xnano.actions import Action
+from xnano.cli.command import Command
+from xnano.cli.help import format_plain_help, print_error, render_help
+from xnano.cli.parameters import Argument, Option
+from xnano.components.bar import Bar
+from xnano.components.button import Button
+from xnano.components.chart import Chart
+from xnano.components.dropdown import Dropdown
+from xnano.components.input import Input
+from xnano.components.link import Link
+from xnano.components.loader import Loader
+from xnano.components.options import Options
+from xnano.components.table import Table
+from xnano.components.text import Text
+from xnano.core.effects import resolve_native_effect
+from xnano.core.frame import Frame, frame_from_terminal
+from xnano.core.runtime import Runtime
+from xnano.effects import AbstractEffect, Effect
+from xnano.fields import Field
+from xnano.grids import BaseGrid
+from xnano.hooks import on_click, on_keyboard
+from xnano.requests import Response, on_get_request, on_post_request
+from xnano.server.native import NativeWebServer
+from xnano.terminal import Terminal
+from xnano.web import Web, grid_factory
+
+
+def test_operator_dashboard_composes_data_display_and_controls() -> None:
+    """A dashboard can mix status, trends, records, controls, and hooks."""
+
+    class Dashboard(BaseGrid, direction="vertical", gap=1):
+        heading: Text = Field(
+            default_factory=lambda: Text(
+                [
+                    Text("API ", modifiers=("bold",)),
+                    Text("healthy", foreground="green-400"),
+                ]
+            ),
+            height=1,
+        )
+        trend: Chart = Field(
+            default_factory=lambda: Chart(
+                series={"requests": [2, 5, 4, 8]},
+                kind="line",
+            ),
+            height=4,
+        )
+        capacity: Bar = Field(
+            default_factory=lambda: Bar(
+                data=[2, 5, 3, 7],
+                max_value=10,
+                foreground="cyan-400",
+            ),
+            height=2,
+        )
+        progress: Loader = Field(
+            default_factory=lambda: Loader(
+                value=0.75,
+                style="bar",
+                label="deploy",
+            ),
+            height=1,
+        )
+        services: Table = Field(
+            default_factory=lambda: Table(
+                data=[
+                    {"name": "api", "status": "ok"},
+                    {"name": "worker", "status": "busy"},
+                ],
+                focusable=True,
+            ),
+            group="services",
+            height=5,
+        )
+        filter: Input = Field(
+            default_factory=lambda: Input(placeholder="filter services"),
+            group="filter",
+            height=1,
+        )
+        refresh: Button = Field(
+            default_factory=lambda: Button(label="Refresh"),
+            group="refresh",
+            height=1,
+        )
+        docs: Link = Field(
+            default_factory=lambda: Link(
+                "Runbook",
+                url="https://example.com/runbook",
+            ),
+            group="docs",
+            height=1,
+        )
+        message: str = Field(default="idle", height=1)
+
+        @on_click("refresh")
+        def refresh_data(self) -> None:
+            self.message = "refreshed"
+
+    runtime = Runtime.offscreen(60, 20)
+    try:
+        dashboard = Dashboard()
+        runtime.set_root(dashboard)
+        frame = runtime.render()
+        for expected in ("healthy", "api", "deploy", "Runbook"):
+            assert expected in frame.text
+
+        assert runtime.focus("services")
+        runtime.perform(Action.keyboard("down"))
+        assert dashboard.services.value is not None
+        assert dashboard.services.value["name"] == "worker"
+
+        assert runtime.focus("filter")
+        runtime.perform(Action.keyboard("a"))
+        runtime.perform(Action.keyboard("p"))
+        runtime.perform(Action.keyboard("i"))
+        assert dashboard.filter.value == "api"
+
+        runtime.perform(Action.click("refresh"))
+        assert "refreshed" in runtime.render().text
+    finally:
+        runtime.close()
+
+
+def test_settings_form_composes_dropdown_options_and_editable_text() -> None:
+    """A settings form can move focus while preserving each editor's state."""
+
+    class Settings(BaseGrid, direction="vertical"):
+        environment: Dropdown = Field(
+            default_factory=lambda: Dropdown(
+                items=("development", "production"),
+                placeholder="environment",
+            ),
+            group="environment",
+            height=2,
+        )
+        features: Options = Field(
+            default_factory=lambda: Options(
+                items=("logging", "metrics", "tracing"),
+                accept="extend",
+                searchable=True,
+            ),
+            group="features",
+            height=5,
+        )
+        notes: Input = Field(
+            default_factory=lambda: Input(placeholder="release notes"),
+            group="notes",
+            height=4,
+        )
+
+    runtime = Runtime.offscreen(50, 14)
+    try:
+        settings = Settings()
+        runtime.set_root(settings)
+        runtime.render()
+
+        assert runtime.focus("environment")
+        runtime.perform(Action.keyboard("down"))
+        runtime.perform(Action.keyboard("down"))
+        runtime.perform(Action.keyboard("enter"))
+        assert settings.environment.value == "production"
+
+        assert runtime.focus("features")
+        runtime.perform(Action.keyboard("m"))
+        runtime.perform(Action.keyboard("e"))
+        runtime.perform(Action.keyboard("enter"))
+        assert settings.features.value
+
+        assert runtime.focus("notes")
+        for binding in ("r", "e", "a", "d", "y", " ", "n", "o", "w"):
+            runtime.perform(Action.keyboard(binding))
+        assert "ready" in settings.notes.value
+        assert "now" in runtime.render().text
+    finally:
+        runtime.close()
+
+
+def test_animation_choreography_composes_every_effect_kind() -> None:
+    """An application can build and lower a complete transition palette."""
+    leaf = Effect(
+        "fade",
+        color="violet-400",
+        interpolation="sine_in_out",
+        key="status",
+    )
+    kinds = (
+        "fade",
+        "fade_from",
+        "fade_to",
+        "fade_from_both",
+        "dissolve",
+        "coalesce",
+        "sweep_in",
+        "sweep_out",
+        "slide_in",
+        "slide_out",
+        "paint",
+        "paint_fg",
+        "paint_bg",
+        "sleep",
+    )
+    palette: list[AbstractEffect] = [
+        Effect(
+            kind,
+            color="cyan-300",
+            background="slate-900",
+            direction="right_to_left",
+            gradient_length=8,
+            randomness=1,
+            interpolation="linear",
+            key=kind,
+        )
+        for kind in kinds
+    ]
+    palette.extend(
+        (
+            Effect("sequence", effects=palette[:2]),
+            Effect("parallel", effects=palette[2:4]),
+            Effect("repeat", child=leaf, times=2),
+            Effect("repeat", child=leaf, duration_ms=450),
+            Effect("repeat", child=leaf),
+            Effect("delay", child=leaf, duration_ms=50),
+        )
+    )
+
+    for effect in palette:
+        assert resolve_native_effect(effect) is not None
+    assert Effect(leaf) is leaf
+
+
+def test_cli_workflow_composes_typed_arguments_options_and_subcommands(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A deployment CLI supports typed repeats, flags, help, and errors."""
+    command = Command(
+        name="deploy",
+        description="Deploy an application.",
+        strict=True,
+    )
+    calls: list[tuple[str, int, list[str], bool]] = []
+
+    @command
+    @Command.option(
+        ["--verbose", "-v"],
+        default=False,
+        help="Verbose output",
+        is_flag=True,
+    )
+    def deploy(
+        target: Annotated[str, Argument(help="Deployment target")],
+        count: Annotated[
+            int,
+            Option("--count", "-c", help="Replica count", metavar="N"),
+        ] = 1,
+        tag: Annotated[
+            list[str],
+            Option("--tag", help="Image tag"),
+        ] = [],
+        verbose: Annotated[
+            bool,
+            Option("--verbose", "-v", help="Verbose output"),
+        ] = False,
+    ) -> None:
+        calls.append((target, count, tag, verbose))
+
+    @command.command(description="Show deployment status.")
+    def status(
+        environment: Annotated[
+            str,
+            Argument(
+                help="Environment",
+                metavar="ENV",
+                choices=("dev", "prod"),
+            ),
+        ],
+    ) -> str:
+        return environment
+
+    command.run(
+        [
+            "api",
+            "--count=3",
+            "--tag",
+            "stable",
+            "--tag",
+            "latest",
+            "--verbose",
+        ]
+    )
+    assert calls == [("api", 3, ["stable", "latest"], True)]
+    assert command.run(["status", "prod"]) == "prod"
+
+    parser = command._build_parser()
+    assert command._build_parser() is parser
+    help_text = format_plain_help(command)
+    assert all(
+        text in help_text
+        for text in ("Usage: deploy", "Deployment target", "Commands:", "status")
+    )
+    assert render_help(command, stream=io.StringIO()) == help_text
+
+    errors = io.StringIO()
+    print_error("bad deployment", command, file=errors)
+    assert "Error: bad deployment" in errors.getvalue()
+
+    with pytest.raises(SystemExit) as help_exit:
+        command.run(["--help"])
+    assert help_exit.value.code == 0
+    assert "Usage: deploy" in capsys.readouterr().out
+
+    with pytest.raises(SystemExit) as error_exit:
+        command.run(["--unknown"])
+    assert error_exit.value.code == 2
+    assert "Unknown option" in capsys.readouterr().err
+
+
+def test_nested_workspace_combines_layout_focus_overlay_and_effects() -> None:
+    """A workspace can combine nested grids, focus, overlays, and animation."""
+
+    class Navigation(BaseGrid, direction="vertical"):
+        pages: Options = Field(
+            default_factory=lambda: Options(
+                items=("Overview", "Logs", "Settings"),
+                searchable=False,
+            ),
+            group="navigation",
+        )
+
+    class Workspace(BaseGrid, direction="horizontal", gap=1):
+        navigation: Navigation = Field(
+            default_factory=Navigation,
+            width="1/3",
+            border="rounded",
+            title="Pages",
+        )
+        content: list[object] = Field(
+            default_factory=lambda: [
+                Text("Overview", modifiers=("bold",)),
+                Chart(series={"cpu": [1, 4, 2, 5]}),
+                Table(data=[{"service": "api", "latency": 12}]),
+            ],
+            direction="vertical",
+            width="2fr",
+            gap=1,
+            border="double",
+            title="Workspace",
+            group="content",
+        )
+        notice: Text = Field(
+            default_factory=lambda: Text("Saved"),
+            overlay=True,
+            align="center",
+            width=12,
+            height=3,
+            border="rounded",
+            z=5,
+        )
+
+        @on_keyboard("s")
+        def save(self) -> None:
+            self.notice = Text("Saved now")
+
+    runtime = Runtime.offscreen(80, 24)
+    try:
+        workspace = Workspace()
+        runtime.set_root(workspace)
+        frame = runtime.render()
+        assert all(
+            text in frame.text
+            for text in ("Pages", "Workspace", "Overview", "Saved")
+        )
+        assert runtime.focus("navigation")
+        runtime.perform(Action.keyboard("down"))
+        assert workspace.navigation.pages.value == "Logs"
+        runtime.perform(Action.keyboard("s"))
+        assert "Saved now" in runtime.render().text
+        assert workspace.grid_play_effect(
+            Effect("coalesce", duration_ms=20),
+            fields=["content"],
+        )
+    finally:
+        runtime.close()
+
+
+def test_frame_export_combines_render_cursor_device_and_commands() -> None:
+    """A rendered frame preserves the metadata needed by remote clients."""
+    cursor = types.SimpleNamespace(
+        get_position=lambda: (4, 2),
+        visible=False,
+        style=lambda: "steady_bar",
+    )
+    device = types.SimpleNamespace(title=lambda: "Operations")
+    terminal = types.SimpleNamespace(
+        size=types.SimpleNamespace(width=40, height=8),
+        get_output=lambda: "ready",
+        get_output_as_ansi=lambda: "\x1b[32mready\x1b[0m",
+        cursor=cursor,
+        device=device,
+        _frame_commands=({"kind": "clipboard", "value": "ready"},),
+    )
+
+    frame = frame_from_terminal(terminal, revision=7)
+    assert frame == Frame(
+        width=40,
+        height=8,
+        text="ready",
+        ansi="\x1b[32mready\x1b[0m",
+        cursor_position=(4, 2),
+        cursor_visible=False,
+        cursor_style="steady_bar",
+        title="Operations",
+        commands=({"kind": "clipboard", "value": "ready"},),
+        revision=7,
+    )
+    assert frame.contains("ready")
+    assert frame.rows[0] == "ready"
+    assert len(frame.rows) == 8
+
+    fallback = frame_from_terminal(
+        types.SimpleNamespace(size=lambda: (2, 2))
+    )
+    assert fallback.rows == ("", "")
+
+
+def test_browser_session_combines_shell_frames_events_and_request_hooks() -> (
+    None
+):
+    """One web session serves UI, input, and application HTTP routes."""
+
+    class App(BaseGrid):
+        message: str = Field(default="waiting")
+
+        @on_keyboard("enter")
+        def submit(self) -> None:
+            self.message = "submitted"
+
+        @on_get_request("/health")
+        def health(self) -> Response:
+            return Response.json({"status": "ok"})
+
+        @on_post_request("/jobs")
+        def create_job(self, ctx) -> Response:
+            return Response.json(
+                {"received": ctx.request.json()},
+                status=202,
+            )
+
+    server = NativeWebServer(
+        ("127.0.0.1", 0),
+        App,
+        title="<Operations>",
+        width=32,
+        height=6,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection(
+        "127.0.0.1",
+        server.server_address[1],
+        timeout=2,
+    )
+    try:
+        connection.request("GET", "/")
+        response = connection.getresponse()
+        shell = response.read().decode()
+        assert response.status == 200
+        assert "&lt;Operations&gt;" in shell
+
+        connection.request("GET", "/health")
+        response = connection.getresponse()
+        assert json.loads(response.read()) == {"status": "ok"}
+
+        connection.request(
+            "POST",
+            "/jobs?priority=high",
+            body=json.dumps({"name": "backup"}),
+            headers={"content-type": "application/json"},
+        )
+        response = connection.getresponse()
+        assert response.status == 202
+        assert json.loads(response.read()) == {
+            "received": {"name": "backup"}
+        }
+
+        connection.request(
+            "POST",
+            "/xnano/event",
+            body=json.dumps(
+                {
+                    "type": "keyboard",
+                    "binding": "enter",
+                    "kind": "press",
+                }
+            ),
+            headers={"content-type": "application/json"},
+        )
+        response = connection.getresponse()
+        response.read()
+        assert response.status == 204
+
+        connection.request("GET", "/xnano/frame")
+        response = connection.getresponse()
+        assert "submitted" in json.loads(response.read())["text"]
+
+        connection.request(
+            "POST",
+            "/xnano/event",
+            body=b"not-json",
+            headers={"content-type": "application/json"},
+        )
+        response = connection.getresponse()
+        response.read()
+        assert response.status == 400
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_web_host_accepts_component_factory_and_managed_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The web host normalizes roots and forwards its complete configuration."""
+    component = Text("ready")
+    factory, shared, grid_class = grid_factory(component)
+    assert shared is True
+    assert grid_class is None
+    assert factory() is component
+
+    callable_factory = lambda: Text("fresh")
+    factory, shared, grid_class = grid_factory(callable_factory)
+    assert factory is callable_factory
+    assert shared is False
+    assert grid_class is None
+    with pytest.raises(TypeError):
+        grid_factory(object())
+
+    calls: list[dict[str, object]] = []
+
+    def serve_application(factory, **options) -> None:
+        assert isinstance(factory(), Text)
+        calls.append(options)
+
+    monkeypatch.setattr(
+        "xnano.server.native.serve_native",
+        serve_application,
+    )
+    web = Web(
+        state={"tenant": "demo"},
+        title="Status",
+        width=100,
+        height=30,
+    )
+    web.run(callable_factory, host="0.0.0.0", port=9000)
+    assert calls == [
+        {
+            "state": {"tenant": "demo"},
+            "title": "Status",
+            "host": "0.0.0.0",
+            "port": 9000,
+            "width": 100,
+            "height": 30,
+        }
+    ]
+
+    managed = types.SimpleNamespace(
+        shutdown=lambda: calls.append({"shutdown": True}),
+        server_close=lambda: calls.append({"closed": True}),
+    )
+    web._server = managed
+    web.close()
+    assert web._server is None
+    assert calls[-2:] == [{"shutdown": True}, {"closed": True}]
+
+
+def test_terminal_facade_combines_lazy_runtime_state_focus_and_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The high-level terminal keeps one runtime across its public controls."""
+
+    class Form(BaseGrid, direction="vertical"):
+        name: Input = Field(default_factory=Input, group="name", height=1)
+        email: Input = Field(default_factory=Input, group="email", height=1)
+
+    monkeypatch.setattr(
+        Terminal,
+        "supports_live_terminal",
+        staticmethod(lambda: False),
+    )
+    terminal = Terminal(state={"step": 1}, title="Signup")
+    assert terminal.state == {"step": 1}
+    assert terminal.surface == "terminal"
+
+    form = Form()
+    terminal.attach_grid(form)
+    frame = terminal.render(form)
+    assert frame.width == terminal.size[0]
+    assert terminal.surface == "offscreen"
+    assert terminal.device is terminal.runtime.device
+    assert terminal.cursor is terminal.runtime.cursor
+    assert terminal.actions is terminal.runtime.actions
+    assert terminal.stage is terminal.runtime.stage
+
+    terminal.state = {"step": 2}
+    assert terminal.runtime.state == {"step": 2}
+    assert terminal.focus("name")
+    assert terminal.focus_next()
+    assert terminal.focused_group == "email"
+    assert terminal.focus_previous()
+    assert terminal.focused_group == "name"
+    terminal.blur()
+    assert terminal.focused_group is None
+    assert terminal.get_output() == terminal.runtime.get_output()
+    assert terminal.get_output_as_ansi() == terminal.runtime.get_output_as_ansi()
+
+    terminal.request_exit()
+    assert terminal.runtime._should_exit is True
+    terminal.close()


### PR DESCRIPTION
Adds coverage for the core public API (demo lifecycle, compositions, effects, errors), the component base, the entrypoint, and user compositions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)