### PR TITLE
fix(tests): skip ComponentRenderContext[Any] subscript on Python 3.10

### DIFF
--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import Any, cast
 
 import xnano.components as components
@@ -27,10 +28,18 @@ def test_unknown_component_export_has_normal_attribute_error() -> None:
 
 def test_component_default_extension_contracts_are_noops() -> None:
     component = Component()
-    ctx = ComponentRenderContext[Any](
-        area=Area(x=1, y=2, width=10, height=4),
-        state={"ready": True},
-    )
+    # Python 3.10's typing sets __orig_class__ on the instance after
+    # __init__, which frozen dataclasses reject; skip the subscript there.
+    if sys.version_info < (3, 11):
+        ctx = ComponentRenderContext(
+            area=Area(x=1, y=2, width=10, height=4),
+            state={"ready": True},
+        )
+    else:
+        ctx = ComponentRenderContext[Any](
+            area=Area(x=1, y=2, width=10, height=4),
+            state={"ready": True},
+        )
     area = ctx.area
 
     assert component.focused is False

--- a/tests/stress/test_options_scale.py
+++ b/tests/stress/test_options_scale.py
@@ -5,6 +5,7 @@
 Exercise large option lists and competing Python work.
 """
 
+import sys
 import threading
 
 from typing import Any
@@ -29,9 +30,16 @@ def test_large_options_compose_only_the_terminal_window() -> None:
         searchable=True,
         selected=2_999,
     )
-    context = ComponentRenderContext[Any](
-        area=Area(x=0, y=0, width=80, height=24)
-    )
+    # Python 3.10's typing sets __orig_class__ on the instance after
+    # __init__, which frozen dataclasses reject; skip the subscript there.
+    if sys.version_info < (3, 11):
+        context = ComponentRenderContext(
+            area=Area(x=0, y=0, width=80, height=24)
+        )
+    else:
+        context = ComponentRenderContext[Any](
+            area=Area(x=0, y=0, width=80, height=24)
+        )
 
     content = options.compose(context)
 


### PR DESCRIPTION
## Summary
- Guard two remaining `ComponentRenderContext[Any](...)` call sites so they omit the generic subscript on Python < 3.11.
- Matches the existing pattern in `tests/benchmarks/test_options_performance.py` for the frozen-dataclass / `__orig_class__` clash on 3.10.

## Test plan
- [x] `uv run --python 3.10 pytest` — 892 passed, 6 skipped
- [x] Confirm CI Python 3.10 job is green