### PR TITLE
feat(docs): enable web analytics for https://xnano.hammad.app/

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,6 +3,12 @@
 {% block extrahead %}
 {{ super() }}
 <script>
+    window.va = window.va || function () {
+        (window.vaq = window.vaq || []).push(arguments);
+    };
+</script>
+<script defer src="/_vercel/insights/script.js"></script>
+<script>
     (() => {
         const styles = ["mono", "serif", "modern"];
         const sizes = ["auto", "small", "medium", "large"];


### PR DESCRIPTION
Adds the Vercel Web Analytics tracking script to the docs site (xnano.hammad.app deploys via Vercel).

Since this is a Material/zensical site — not a Next.js app — the `npx`/`@vercel/analytics` component route doesn't apply. Instead the manual HTML snippet from Vercel's quickstart is injected into the theme's `extrahead` block in `docs/overrides/main.html`, so it lands in `<head>` on every page. Uses the canonical `/_vercel/insights/script.js` path served by Vercel once Web Analytics is enabled for the project in the dashboard.

The script tracks route changes via the History API, so it works with the theme's `navigation.instant` (SPA-style) navigation.

Note: Web Analytics must be enabled for the project in the Vercel dashboard for `/_vercel/insights/*` to be served.