### PR TITLE
Uncomment mkdocstrings plugin config in zensical.toml

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -267,32 +267,32 @@ custom_fences = [
     { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" },
 ]
 
-# [project.plugins.mkdocstrings.handlers.python]
-# inventories = ["https://docs.python.org/3/objects.inv"]
+[project.plugins.mkdocstrings.handlers.python]
+inventories = ["https://docs.python.org/3/objects.inv"]
 
-# [project.plugins.mkdocstrings.handlers.python.options]
-# docstring_style = "google"
-# inherited_members = true          # false
-# merge_init_into_class = true
-# parameter_headings = false
-# members_order = "source"
-# filters = ["!^_", "^__"]
-# heading_level = 2
-# separate_signature = true
-# docstring_section_style = "list"
-# backlinks = "tree"
-# show_root_heading = true
-# show_root_full_path = true
-# show_signature_annotations = true
-# show_source = true
-# show_symbol_type_heading = true
-# show_symbol_type_toc = true
-# show_root_toc_entry = false
-# signature_crossrefs = true
-# summary = true
-# unwrap_annotated = true
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+inherited_members = true          # false
+merge_init_into_class = true
+parameter_headings = false
+members_order = "source"
+filters = ["!^_", "^__"]
+heading_level = 2
+separate_signature = true
+docstring_section_style = "list"
+backlinks = "tree"
+show_root_heading = true
+show_root_full_path = true
+show_signature_annotations = true
+show_source = true
+show_symbol_type_heading = true
+show_symbol_type_toc = true
+show_root_toc_entry = false
+signature_crossrefs = true
+summary = true
+unwrap_annotated = true
 
-# extensions = ["griffe_typingdoc"]
+extensions = ["griffe_typingdoc"]
 
 [project.plugins]
 


### PR DESCRIPTION
## Summary
- Uncomments the `[project.plugins.mkdocstrings.handlers.python]` config block in `zensical.toml`, which was left commented out
- `mkdocstrings-python` and `griffe-typingdoc` are already declared as dependencies in `pyproject.toml`, so the handler config was just dead weight sitting disabled

## Test plan
- [x] Verified `zensical.toml` still parses correctly with `tomllib` and the `mkdocstrings` plugin table nests as expected
- [ ] `uv run mkdocs serve` to confirm API reference pages render with docstrings


---
_Generated by [Claude Code](https://claude.ai/code/session_017NB4Tunkh6AeGJKtvkse4q)_