### PR TITLE
release: xnano 1.2.3b1 prerelease fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.2.1"
+pip install "xnano>=1.2.3b1"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.2.1"
+uv add "xnano>=1.2.3b1"
 ```
 
 > [!TIP]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,13 +32,13 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "pip"
 
     ```bash title="Install with pip"
-    pip install "xnano>=1.2.2"
+    pip install "xnano>=1.2.3b1"
     ```
 
 === "uv"
 
     ```bash title="Install with uv"
-    uv pip install "xnano>=1.2.2"
+    uv pip install "xnano>=1.2.3b1"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -47,7 +47,7 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "poetry"
 
     ```bash title="Install with poetry"
-    poetry install "xnano>=1.2.2"
+    poetry install "xnano>=1.2.3b1"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -56,7 +56,7 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "conda"
 
     ```bash title="Install with conda"
-    conda install "xnano>=1.2.2"
+    conda install "xnano>=1.2.3b1"
     ```
 
 ## Notetaking Application

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -201,7 +201,7 @@ class Notes: # (1)!
     current: int | None = None
 ```
 
-1. A plain dataclass — no [xnano]{data-preview} base class required. Anything you pass to `Terminal(state=...)` becomes the shared state.
+1. A plain dataclass — no [xnano]{data-preview} base class required. Anything you pass to `run(state=...)` becomes the shared state.
 2. We track whether the editor is open (`editing`) and, when editing an existing note, its index (`current`). `None` means we're writing a brand-new note.
 
 Every event handler receives a `Context`, and `ctx.state` *is* this object — the same instance, everywhere.
@@ -349,7 +349,7 @@ Right now the `editor` is an ordinary field, so it claims its own slice of the l
 [xnano]{data-preview} apps are keyboard-first, but a click or a hover is often the most natural thing to reach for. Mouse input is **opt-in** — turn it on when you run:
 
 ```python title="Enabling the Mouse"
-Terminal(state=Notes(), mouse_events=True).run(NotesApp())
+Terminal(mouse_events=True).run(NotesApp(), state=Notes())
 ```
 
 With mouse events on, two behaviors come for free:
@@ -510,7 +510,7 @@ class NotesApp(BaseGrid, direction="vertical"):
         ctx.runtime.request_exit()
 
 if __name__ == "__main__":
-    Terminal(state=Notes(), mouse_events=True).run(NotesApp())
+    Terminal(mouse_events=True).run(NotesApp(), state=Notes())
 ```
 
 Run it with `python notes.py`, and you have a complete little application: browse your notes on the left, watch the count on the right, pop open the editor to write or edit, and every keybind in reach along the bottom.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -20,7 +20,7 @@ and so on — every family, every shade from `50` to `950`. The grid below rende
 all of them. Change a shade in `shades` or drop a family from `palettes` to see
 the effect.
 
-```pyodide install="xnano>=1.2.2" height="28"
+```pyodide install="xnano>=1.2.3b1" height="28"
 from xnano import render
 from xnano.components.text import Text
 
@@ -55,7 +55,7 @@ render(*rows)
 A Tailwind name is one option. Anywhere a color is accepted you can also pass a
 CSS name, a hex string, an `(r, g, b)` tuple, or a `Color` object.
 
-```pyodide install="xnano>=1.2.2" height="10"
+```pyodide install="xnano>=1.2.3b1" height="10"
 from xnano import render
 from xnano.components.text import Text
 
@@ -74,7 +74,7 @@ render(
 constructor. Nest it to style a run inside a line without breaking the surrounding
 flow — pass a list of `Text` where you'd otherwise pass a string.
 
-```pyodide install="xnano>=1.2.2" height="15"
+```pyodide install="xnano>=1.2.3b1" height="15"
 from xnano import render
 from xnano.components.text import Text
 
@@ -92,7 +92,7 @@ The same component can also parse its input. Pass `ansi`, `markdown`, or
 `language` and `Text` renders the result instead of the raw string. The three
 modes are mutually exclusive — pick one.
 
-```pyodide install="xnano>=1.2.2" height="36"
+```pyodide install="xnano>=1.2.3b1" height="36"
 from xnano import render
 from xnano.components.text import Text
 
@@ -122,7 +122,7 @@ A `Chart` takes a mapping of labels to data — either bare `y` values or explic
 `(x, y)` pairs. Declare a `Series` per key to set its label, color, and `kind`,
 and one chart can mix line, scatter, and bar. Try changing a `kind` below.
 
-```pyodide install="xnano>=1.2.2" height="27"
+```pyodide install="xnano>=1.2.3b1" height="27"
 from xnano import render
 from xnano.components.chart import Chart, Series
 
@@ -146,7 +146,7 @@ For a compact trend without a full plot, `Bar` renders a series inline in a
 single block. Set a fixed `max_value` so separate bars share a scale and stay
 comparable.
 
-```pyodide install="xnano>=1.2.2" height="22"
+```pyodide install="xnano>=1.2.3b1" height="22"
 from xnano import render
 from xnano.components.bar import Bar
 
@@ -164,7 +164,7 @@ the columns. For control, declare a `Column`: it takes a formatter, an accessor,
 alignment, and width. Pass a callable for `color` or `background` and it receives
 the cell value, so a column can style itself from its own data.
 
-```pyodide install="xnano>=1.2.2" height="30"
+```pyodide install="xnano>=1.2.3b1" height="30"
 from xnano import render
 from xnano.components.schema import Column
 from xnano.components.table import Table
@@ -202,7 +202,7 @@ render(table)
 
 Without any `Column` descriptors, `Table` infers columns straight from the keys:
 
-```pyodide install="xnano>=1.2.2" height="12"
+```pyodide install="xnano>=1.2.3b1" height="12"
 from xnano import render
 from xnano.components.table import Table
 
@@ -219,7 +219,7 @@ lines. Each child sets its own size with the sizing grammar — fractions (`"1/3
 `fr` units (`"2fr"`), `"fit"`, or a fixed cell count. Adjust the `width` values to
 re-balance the layout.
 
-```pyodide install="xnano>=1.2.2" height="25"
+```pyodide install="xnano>=1.2.3b1" height="25"
 from xnano import BaseGrid, Field, render
 
 class Sidebar(BaseGrid, direction="vertical", gap=1, border="rounded", title="nav"):
@@ -248,7 +248,7 @@ dispatch path as real input, so you can render a grid to attach its hooks,
 perform an action, and render again to see the updated state. This is also how
 you test a grid frame-by-frame. Here a counter increments twice between frames.
 
-```pyodide install="xnano>=1.2.2" height="24"
+```pyodide install="xnano>=1.2.3b1" height="24"
 from xnano import Action, BaseGrid, Field, Terminal, on_action
 
 INCREMENT = Action.keyboard("right")

--- a/examples/agent_chat.py
+++ b/examples/agent_chat.py
@@ -738,7 +738,7 @@ class AgentChat(BaseGrid, direction="vertical", gap=0):
 
     @on_keyboard
     def _character(self, ctx) -> None:
-        keyboard = ctx.keyboard
+        keyboard = ctx.keyboard_event
         if keyboard is None:
             return
         character = getattr(keyboard, "character", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.2.2"
+version = "1.2.3b1"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"
@@ -40,7 +40,7 @@ dependencies = [
     "markdown-it-py>=3.0.0",
     "pydantic-core>=2.0.0",
     "pygments>=2.17.0",
-    "xnano-core==0.0.16",
+    "xnano-core==0.0.17",
 ]
 
 [project.optional-dependencies]

--- a/tests/components/test_text.py
+++ b/tests/components/test_text.py
@@ -426,3 +426,17 @@ def test_multiline_editor_drives_composed_preview() -> None:
         assert editor.notes.cursor_position is not None
     finally:
         runtime.close()
+
+
+def test_wrapped_text_preserves_indentation_after_newline() -> None:
+    """Leading whitespace after a newline survives wrapping (#128).
+
+    ``Text`` wraps by default; the wrapping renderer used to trim leading
+    whitespace from every line, dropping authored indentation.
+    """
+    runtime = Runtime.offscreen(24, 4)
+    try:
+        frame = runtime.render(Text("a\n    indented"))
+        assert "    indented" in frame.text
+    finally:
+        runtime.close()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -41,8 +41,8 @@ def test_context_keyboard_and_focus_helpers() -> None:
     )
 
     assert ctx.has_keyboard_event()
-    assert ctx.keyboard is not None
-    assert ctx.keyboard.matches("enter")
+    assert ctx.keyboard_event is not None
+    assert ctx.keyboard_event.matches("enter")
     assert ctx.get_state() == {"ok": True}
     assert ctx.runtime is facade
     assert ctx.surface == "offscreen"

--- a/tests/test_grid_render_ctx.py
+++ b/tests/test_grid_render_ctx.py
@@ -29,9 +29,9 @@ def test_grid_render_receives_ctx_and_state() -> None:
 
     grid = App()
     state = {"model": "opus"}
-    terminal = Terminal.offscreen(cols=40, rows=4, state=state)
+    terminal = Terminal.offscreen(cols=40, rows=4)
     terminal.attach_grid(grid)
-    terminal.render()
+    terminal.render(state=state)
     terminal.close()
 
     assert seen and seen[0] == state

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -94,3 +94,19 @@ def test_render_and_run_accept_state() -> None:
     terminal.render("x", state={"n": 1})
     assert terminal.state == {"n": 1}
     terminal.close()
+
+
+def test_render_packs_multiple_items_by_content() -> None:
+    """Multiple top-level renderables pack to their content size with ``gap``
+    as literal spacing, rather than each taking an equal fill share that would
+    stretch one-line items across the whole viewport.
+    """
+    terminal = Terminal.offscreen(cols=20, rows=8)
+    lines = terminal.render("AAA", "BBB", "CCC", gap=0).text.split("\n")
+    assert lines[:3] == ["AAA", "BBB", "CCC"]
+    terminal.close()
+
+    terminal = Terminal.offscreen(cols=20, rows=8)
+    lines = terminal.render("AAA", "BBB", "CCC", gap=1).text.split("\n")
+    assert lines[:5] == ["AAA", "", "BBB", "", "CCC"]
+    terminal.close()

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -86,3 +86,11 @@ def test_terminal_live_run_skips_unused_frame_serialization(
 
     monkeypatch.setattr(terminal.runtime, "_snapshot_frame", fail_snapshot)
     terminal.run(App())
+
+
+def test_render_and_run_accept_state() -> None:
+    """State is supplied at paint time, not to the constructor (#103)."""
+    terminal = Terminal.offscreen(cols=20, rows=3)
+    terminal.render("x", state={"n": 1})
+    assert terminal.state == {"n": 1}
+    terminal.close()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,23 @@
+"""tests.test_types"""
+
+from __future__ import annotations
+
+import typing
+
+from xnano.types import Sizing, SizingKeyword, SizingPercentage
+
+
+def test_sizing_literal_members_all_parse() -> None:
+    """Every declared sizing literal resolves through ``Sizing.parse`` so the
+    autocomplete surface can never drift from the runtime parser (#102).
+    """
+    for token in typing.get_args(SizingKeyword):
+        assert Sizing.parse(token) is not None, token
+    for token in typing.get_args(SizingPercentage):
+        assert Sizing.parse(token) is not None, token
+
+
+def test_sizing_percentage_covers_0_to_100() -> None:
+    assert set(typing.get_args(SizingPercentage)) == {
+        f"{index}%" for index in range(101)
+    }

--- a/tests/test_user_compositions.py
+++ b/tests/test_user_compositions.py
@@ -314,7 +314,12 @@ def test_cli_workflow_composes_typed_arguments_options_and_subcommands(
     help_text = format_plain_help(command)
     assert all(
         text in help_text
-        for text in ("Usage: deploy", "Deployment target", "Commands:", "status")
+        for text in (
+            "Usage: deploy",
+            "Deployment target",
+            "Commands:",
+            "status",
+        )
     )
     assert render_help(command, stream=io.StringIO()) == help_text
 
@@ -435,9 +440,7 @@ def test_frame_export_combines_render_cursor_device_and_commands() -> None:
     assert frame.rows[0] == "ready"
     assert len(frame.rows) == 8
 
-    fallback = frame_from_terminal(
-        types.SimpleNamespace(size=lambda: (2, 2))
-    )
+    fallback = frame_from_terminal(types.SimpleNamespace(size=lambda: (2, 2)))
     assert fallback.rows == ("", "")
 
 
@@ -497,9 +500,7 @@ def test_browser_session_combines_shell_frames_events_and_request_hooks() -> (
         )
         response = connection.getresponse()
         assert response.status == 202
-        assert json.loads(response.read()) == {
-            "received": {"name": "backup"}
-        }
+        assert json.loads(response.read()) == {"received": {"name": "backup"}}
 
         connection.request(
             "POST",
@@ -566,12 +567,16 @@ def test_web_host_accepts_component_factory_and_managed_server(
         serve_application,
     )
     web = Web(
-        state={"tenant": "demo"},
         title="Status",
         width=100,
         height=30,
     )
-    web.run(callable_factory, host="0.0.0.0", port=9000)
+    web.run(
+        callable_factory,
+        state={"tenant": "demo"},
+        host="0.0.0.0",
+        port=9000,
+    )
     assert calls == [
         {
             "state": {"tenant": "demo"},
@@ -607,13 +612,13 @@ def test_terminal_facade_combines_lazy_runtime_state_focus_and_output(
         "supports_live_terminal",
         staticmethod(lambda: False),
     )
-    terminal = Terminal(state={"step": 1}, title="Signup")
-    assert terminal.state == {"step": 1}
+    terminal = Terminal(title="Signup")
     assert terminal.surface == "terminal"
 
     form = Form()
     terminal.attach_grid(form)
-    frame = terminal.render(form)
+    frame = terminal.render(form, state={"step": 1})
+    assert terminal.state == {"step": 1}
     assert frame.width == terminal.size[0]
     assert terminal.surface == "offscreen"
     assert terminal.device is terminal.runtime.device
@@ -631,7 +636,9 @@ def test_terminal_facade_combines_lazy_runtime_state_focus_and_output(
     terminal.blur()
     assert terminal.focused_group is None
     assert terminal.get_output() == terminal.runtime.get_output()
-    assert terminal.get_output_as_ansi() == terminal.runtime.get_output_as_ansi()
+    assert (
+        terminal.get_output_as_ansi() == terminal.runtime.get_output_as_ansi()
+    )
 
     terminal.request_exit()
     assert terminal.runtime._should_exit is True

--- a/tests/test_watch_hooks.py
+++ b/tests/test_watch_hooks.py
@@ -57,9 +57,9 @@ def test_on_state_bare_name_fires_once_per_mutation() -> None:
 
     app = App()
     state = State()
-    terminal = Terminal.offscreen(cols=20, rows=3, state=state)
+    terminal = Terminal.offscreen(cols=20, rows=3)
     try:
-        terminal.render(app)
+        terminal.render(app, state=state)
         terminal.render(app)
         assert fires == []
         state.value = 9
@@ -80,9 +80,9 @@ def test_on_state_bare_name_reads_dict_state_keys() -> None:
 
     app = App()
     state: dict[str, int] = {"value": 0}
-    terminal = Terminal.offscreen(cols=20, rows=3, state=state)
+    terminal = Terminal.offscreen(cols=20, rows=3)
     try:
-        terminal.render(app)
+        terminal.render(app, state=state)
         state["value"] = 3
         terminal.render(app)
         assert fires == [3]

--- a/uv.lock
+++ b/uv.lock
@@ -2377,7 +2377,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.2.2"
+version = "1.2.3b1"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },

--- a/xnano-core/Cargo.toml
+++ b/xnano-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xnano-core"
-version = "0.0.16"
+version = "0.0.17"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/hsaeed3/xnano"

--- a/xnano-core/rust/src/bindings/engine/render_ir.rs
+++ b/xnano-core/rust/src/bindings/engine/render_ir.rs
@@ -826,7 +826,9 @@ impl CoreRenderIR {
             RenderIrInner::Paragraph { text, style, align, wrap } => {
                 let (styled_text, para_style) = split_bg_to_content(text, style);
                 let mut para = Paragraph::new(styled_text).style(para_style);
-                if *wrap { para = para.wrap(Wrap { trim: true }); }
+                // trim: false preserves authored leading whitespace (indents
+                // after a newline). trim: true dropped it — see issue #128.
+                if *wrap { para = para.wrap(Wrap { trim: false }); }
                 if let Some(a) = align { para = para.alignment(*a); }
                 Widget::render(para, rect, buf);
             }

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -16,7 +16,7 @@ try:
 except (
     importlib.metadata.PackageNotFoundError
 ):  # pragma: no cover - editable / source trees
-    __version__ = "1.2.2"
+    __version__ = "1.2.3b1"
 
 if TYPE_CHECKING:
     from xnano import cli, components, core, events, hooks, requests

--- a/xnano/context.py
+++ b/xnano/context.py
@@ -35,9 +35,9 @@ StateT = TypeVar("StateT")
 class Context(Generic[StateT]):
     """Values and controls available inside an event hook.
 
-    Use the event-specific shortcuts such as ``keyboard`` and ``mouse``,
-    read or update application state, move focus, or access the current
-    cursor, device, actions, and stage.
+    Use the event-specific shortcuts such as ``keyboard_event`` and
+    ``mouse_event``, read or update application state, move focus, or access
+    the current cursor, device, actions, and stage.
 
     Attributes:
         event: Event that triggered the hook.
@@ -47,9 +47,9 @@ class Context(Generic[StateT]):
         runtime: Runtime handling the event.
         surface: Active presentation surface.
         request: HTTP request that triggered the hook, if any.
-        tick: Tick payload that triggered the hook, if any.
-        keyboard: Keyboard payload that triggered the hook, if any.
-        mouse: Mouse payload that triggered the hook, if any.
+        tick_event: Tick payload that triggered the hook, if any.
+        keyboard_event: Keyboard payload that triggered the hook, if any.
+        mouse_event: Mouse payload that triggered the hook, if any.
         cursor: Cursor controls for the active runtime.
         device: Device controls for the active runtime.
         actions: Synthetic action performer.
@@ -58,7 +58,7 @@ class Context(Generic[StateT]):
 
     Example:
         >>> def handle_key(ctx: Context[dict[str, int]]) -> None:
-        ...     if ctx.keyboard is not None:
+        ...     if ctx.keyboard_event is not None:
         ...         ctx.state["keys"] += 1
     """
 
@@ -68,6 +68,8 @@ class Context(Generic[StateT]):
     """Terminal or offscreen session handling the event."""
     state: StateT
     """Application state shared with the runtime."""
+    request: "Request | None" = None
+    """HTTP request that triggered the hook, if any."""
 
     @property
     def host(self) -> "Runtime[StateT]":
@@ -97,22 +99,17 @@ class Context(Generic[StateT]):
         return "terminal"
 
     @property
-    def request(self) -> "Request | None":
-        """HTTP request that triggered the hook, if any."""
-        return getattr(self.terminal, "_beta_request", None)
-
-    @property
-    def tick(self) -> "TickEventData | None":
+    def tick_event(self) -> "TickEventData | None":
         """Tick payload when this context was triggered by a tick."""
         return self.event.tick_event
 
     @property
-    def keyboard(self) -> "KeyboardEventData | None":
+    def keyboard_event(self) -> "KeyboardEventData | None":
         """Keyboard sub-event when triggered by a keyboard event."""
         return self.event.keyboard_event
 
     @property
-    def mouse(self) -> "MouseEventData | None":
+    def mouse_event(self) -> "MouseEventData | None":
         """Mouse sub-event when triggered by a mouse event."""
         return self.event.mouse_event
 

--- a/xnano/core/demo.py
+++ b/xnano/core/demo.py
@@ -60,7 +60,7 @@ def _delta_seconds(ctx: Any) -> float:
     animation advances identically under a live terminal and under synthetic
     ``Action.tick(ms)`` in tests.
     """
-    tick = ctx.tick
+    tick = ctx.tick_event
     return 0.0 if tick is None else tick.elapsed_ms / 1000.0
 
 
@@ -1242,7 +1242,9 @@ class Showcase(BaseGrid, direction="vertical", gap=0):
     def _select_tab(self, ctx) -> None:
         group, box = self._focused_box()
         select = getattr(box, "select_tab", None)
-        key = ctx.keyboard.key if ctx.keyboard is not None else None
+        key = (
+            ctx.keyboard_event.key if ctx.keyboard_event is not None else None
+        )
         if callable(select) and isinstance(key, str) and key.isdigit():
             select(int(key) - 1)
             self._log(f"{group}: tab {key}")

--- a/xnano/core/runtime.py
+++ b/xnano/core/runtime.py
@@ -404,6 +404,14 @@ class Runtime(Generic[StateT]):
 
             place_cursor_for_focus(self)
             return
+        panel_requested = (
+            border is not None
+            or border_sides is not None
+            or border_color is not None
+            or title is not None
+            or padding is not None
+            or background is not None
+        )
         styled_items = tuple(
             TextBlock(
                 text=item,
@@ -416,6 +424,44 @@ class Runtime(Generic[StateT]):
             else item
             for item in items
         )
+        if len(styled_items) > 1 and not panel_requested:
+            # Pack each renderable to its measured content size, with ``gap`` as
+            # the literal cells between them. A bare ``Stack`` gives every child
+            # an equal ``fill(1)`` share, which stretches one-line items across
+            # the whole viewport; measuring like a field slot and leaning on
+            # ``split_layout``'s ``Flex::Start`` anchors items to the top with
+            # the remainder left blank at the end.
+            # ponytail: bordered/paneled multi-render still uses the fill path
+            # below — revisit if a framed multi-render needs content packing.
+            from xnano.core.controller import TerminalController
+            from xnano.core.layout import LayoutConstraint
+            from xnano.types import Area
+
+            self._stage.areas.clear()
+            controller = TerminalController(self)
+            viewport = Area(x=0, y=0, width=self.size[0], height=self.size[1])
+            constraints = [
+                LayoutConstraint(
+                    "length",
+                    max(
+                        1,
+                        controller.measure_field_slot(
+                            item,
+                            direction,
+                            available_width=self.size[0],
+                        ),
+                    ),
+                )
+                for item in items
+            ]
+            for styled, item_area in zip(
+                styled_items,
+                controller.split_layout(viewport, direction, gap, constraints),
+            ):
+                controller._paint(styled, item_area)
+            controller.paint_stage()
+            controller.commit()
+            return
         content = (
             styled_items[0]
             if len(styled_items) == 1
@@ -425,14 +471,7 @@ class Runtime(Generic[StateT]):
                 gap=gap,
             )
         )
-        if (
-            border is not None
-            or border_sides is not None
-            or border_color is not None
-            or title is not None
-            or padding is not None
-            or background is not None
-        ):
+        if panel_requested:
             content = Panel(
                 child=content,
                 title=title,

--- a/xnano/markdown.py
+++ b/xnano/markdown.py
@@ -902,7 +902,7 @@ def _create_markdown_document(
             # Absolute cell coordinates: body is the full viewport minus
             # the reserved status row. Field-scoped mouse.field tagging is
             # not guaranteed on every host, so hit-test by geometry.
-            mouse = ctx.mouse
+            mouse = ctx.mouse_event
             if mouse is None:
                 return
             height = ctx.terminal.size[1]
@@ -913,7 +913,7 @@ def _create_markdown_document(
 
         @hooks.on_mouse(kind="press")
         def _pointer_click(self, ctx: Any) -> None:
-            mouse = ctx.mouse
+            mouse = ctx.mouse_event
             if mouse is None:
                 return
             height = ctx.terminal.size[1]

--- a/xnano/requests.py
+++ b/xnano/requests.py
@@ -485,41 +485,26 @@ def dispatch_request(
     last_response: Response | None = None
 
     facade = runtime if runtime is not None else grid
-    # Stash the request on the facade so Context.request can read it
-    # without inventing a parallel Event subclass during the transition window.
-    if request_obj is not None:
-        try:
-            object.__setattr__(facade, "_beta_request", request_obj)
-        except Exception:
-            setattr(facade, "_beta_request", request_obj)
-
     ctx = Context(
         event=Event.from_data(AbstractEventData()),
         terminal=facade,
         state=getattr(runtime, "state", getattr(grid, "state", None)),
+        request=request_obj,
     )
 
-    try:
-        for entry in routes:
-            if entry["method"] != method or entry["path"] != cleaned:
-                continue
-            name = getattr(entry["handler"], "__name__", "")
-            handler = getattr(grid, name, None)
-            if handler is None:
-                continue
-            result = invoke_hook(handler, grid, ctx)
-            matched = True
-            if isinstance(result, Response):
-                last_response = result
-            elif result is not None and not isinstance(result, bool):
-                last_response = Response(body=str(result))
-    finally:
-        if request_obj is not None:
-            try:
-                object.__setattr__(facade, "_beta_request", None)
-            except Exception:
-                if hasattr(facade, "_beta_request"):
-                    delattr(facade, "_beta_request")
+    for entry in routes:
+        if entry["method"] != method or entry["path"] != cleaned:
+            continue
+        name = getattr(entry["handler"], "__name__", "")
+        handler = getattr(grid, name, None)
+        if handler is None:
+            continue
+        result = invoke_hook(handler, grid, ctx)
+        matched = True
+        if isinstance(result, Response):
+            last_response = result
+        elif result is not None and not isinstance(result, bool):
+            last_response = Response(body=str(result))
 
     if runtime is not None:
         if last_response is not None:

--- a/xnano/terminal.py
+++ b/xnano/terminal.py
@@ -58,12 +58,13 @@ class Terminal(Generic[StateT]):
     def __init__(
         self,
         *,
-        state: StateT | None = None,
+        state_type: type[StateT] | None = None,
         title: str | None = None,
         tick_interval: int = 16,
         mouse_events: bool = False,
     ) -> None:
-        self._state = state
+        self._state: StateT | None = None
+        self._state_type = state_type
         self._title = title
         self._tick_interval = tick_interval
         self._mouse_events = mouse_events
@@ -76,15 +77,17 @@ class Terminal(Generic[StateT]):
         *,
         cols: int = 40,
         rows: int = 12,
-        state: StateT | None = None,
+        state_type: type[StateT] | None = None,
         title: str | None = None,
     ) -> "Terminal[StateT]":
-        """Create a terminal backed by an in-memory cell buffer."""
-        terminal = cls(state=state, title=title)
+        """Create a terminal backed by an in-memory cell buffer.
+
+        Pass application state at paint time via ``render(..., state=...)``.
+        """
+        terminal = cls(state_type=state_type, title=title)
         terminal._runtime = Runtime.offscreen(
             cols,
             rows,
-            state=state,
             title=title,
         )
         terminal.surface = "offscreen"
@@ -178,6 +181,7 @@ class Terminal(Generic[StateT]):
     def render(
         self,
         *renderables: Any,
+        state: StateT | None = None,
         color: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
@@ -196,6 +200,8 @@ class Terminal(Generic[StateT]):
         Args:
             *renderables: Grids, components, content primitives, or plain
                 values to paint.
+            state: Application state shared with event hooks. Replaces the
+                current state when provided.
             color: Foreground color applied to plain values.
             background: Background color for the rendered area.
             modifiers: Character modifiers applied to plain values.
@@ -212,6 +218,8 @@ class Terminal(Generic[StateT]):
         Returns:
             A snapshot of the rendered terminal frame.
         """
+        if state is not None:
+            self.state = state
         runtime = self._ensure_runtime()
         if renderables:
             runtime.set_root(renderables[0] if len(renderables) == 1 else None)
@@ -234,6 +242,7 @@ class Terminal(Generic[StateT]):
     def run(
         self,
         *renderables: Any,
+        state: StateT | None = None,
         color: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
@@ -252,6 +261,8 @@ class Terminal(Generic[StateT]):
         Args:
             *renderables: Grids, components, content primitives, or plain
                 values to paint.
+            state: Application state shared with event hooks. Replaces the
+                current state when provided.
             color: Foreground color applied to plain values.
             background: Background color for the rendered area.
             modifiers: Character modifiers applied to plain values.
@@ -265,6 +276,8 @@ class Terminal(Generic[StateT]):
             gap: Cells between multiple renderables.
             direction: Direction used to lay out multiple renderables.
         """
+        if state is not None:
+            self.state = state
         runtime = self._ensure_runtime(live=True)
         if renderables:
             runtime.set_root(renderables[0] if len(renderables) == 1 else None)

--- a/xnano/types.py
+++ b/xnano/types.py
@@ -520,6 +520,10 @@ class Sizing:
         token = value.strip().lower()
         if token in ("fit", "auto", "content"):
             return cls.fit()
+        if token == "full":
+            # Matches the tailwind ``w-full`` / ``h-full`` rewrite: 100% of
+            # the available axis length.
+            return cls.percent(100)
         if token in ("fill", "grow"):
             return cls.fraction()
         if token in _FLEX_CLASS_WEIGHTS:
@@ -541,9 +545,146 @@ class Sizing:
             raise ValueError(f"invalid sizing string: {value!r}") from error
 
 
-SizingLike: TypeAlias = Union[int, float, str, Sizing]
-"""Any value accepted where a ``Sizing`` is expected — see
-``Sizing.parse`` for the full list of accepted forms.
+SizingKeyword: TypeAlias = Literal[
+    "fit",
+    "auto",
+    "content",
+    "fill",
+    "grow",
+    "grow-0",
+    "shrink",
+    "shrink-0",
+    "flex-1",
+    "flex-auto",
+    "flex-initial",
+    "flex-none",
+    "full",
+]
+"""Named sizing keywords accepted by ``Sizing.parse`` (plus the tailwind
+``full`` rewrite). Exposed as a ``Literal`` so editors autocomplete the common
+string forms of ``width`` / ``height``.
+"""
+
+
+# ponytail: 101 members spelled out on purpose — a Literal can't be built at
+# type-check time from a range, and whole-percent autocomplete was the ask.
+SizingPercentage: TypeAlias = Literal[
+    "0%",
+    "1%",
+    "2%",
+    "3%",
+    "4%",
+    "5%",
+    "6%",
+    "7%",
+    "8%",
+    "9%",
+    "10%",
+    "11%",
+    "12%",
+    "13%",
+    "14%",
+    "15%",
+    "16%",
+    "17%",
+    "18%",
+    "19%",
+    "20%",
+    "21%",
+    "22%",
+    "23%",
+    "24%",
+    "25%",
+    "26%",
+    "27%",
+    "28%",
+    "29%",
+    "30%",
+    "31%",
+    "32%",
+    "33%",
+    "34%",
+    "35%",
+    "36%",
+    "37%",
+    "38%",
+    "39%",
+    "40%",
+    "41%",
+    "42%",
+    "43%",
+    "44%",
+    "45%",
+    "46%",
+    "47%",
+    "48%",
+    "49%",
+    "50%",
+    "51%",
+    "52%",
+    "53%",
+    "54%",
+    "55%",
+    "56%",
+    "57%",
+    "58%",
+    "59%",
+    "60%",
+    "61%",
+    "62%",
+    "63%",
+    "64%",
+    "65%",
+    "66%",
+    "67%",
+    "68%",
+    "69%",
+    "70%",
+    "71%",
+    "72%",
+    "73%",
+    "74%",
+    "75%",
+    "76%",
+    "77%",
+    "78%",
+    "79%",
+    "80%",
+    "81%",
+    "82%",
+    "83%",
+    "84%",
+    "85%",
+    "86%",
+    "87%",
+    "88%",
+    "89%",
+    "90%",
+    "91%",
+    "92%",
+    "93%",
+    "94%",
+    "95%",
+    "96%",
+    "97%",
+    "98%",
+    "99%",
+    "100%",
+]
+"""Whole-number percentage sizing strings ``"0%"`` – ``"100%"``. Fractions and
+``fr``/ratio forms are deliberately left to the open ``str`` branch.
+"""
+
+
+SizingLike: TypeAlias = Union[
+    int, float, SizingKeyword, SizingPercentage, str, Sizing
+]
+"""Any value accepted where a ``Sizing`` is expected — see ``Sizing.parse``
+for the full list of accepted forms.
+
+``SizingKeyword`` and ``SizingPercentage`` are folded in ahead of the bare
+``str`` so editors surface the common values as completions; arbitrary strings
+(``"1fr"``, ``"1/3"``, ``"37.5%"``) still typecheck via ``str``.
 """
 
 
@@ -806,8 +947,10 @@ __all__ = (
     "Size",
     "SizePercentage",
     "Sizing",
+    "SizingKeyword",
     "SizingKind",
     "SizingLike",
+    "SizingPercentage",
     "field_fills_background",
     "field_has_frame_chrome",
     "frame_from_field",

--- a/xnano/web.py
+++ b/xnano/web.py
@@ -7,7 +7,9 @@ Serve grids and components through an offscreen native cell runtime.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any, Callable, Generic, TypeVar
+
+StateT = TypeVar("StateT")
 
 
 def grid_factory(source: Any) -> tuple[Callable[[], Any], bool, type | None]:
@@ -37,11 +39,10 @@ def grid_factory(source: Any) -> tuple[Callable[[], Any], bool, type | None]:
     )
 
 
-class Web:
+class Web(Generic[StateT]):
     """Serve an application in a browser from an offscreen runtime.
 
     Attributes:
-        state: Application state shared with event and request hooks.
         title: Browser document title.
         width: Offscreen viewport width in cells.
         height: Offscreen viewport height in cells.
@@ -56,13 +57,13 @@ class Web:
     def __init__(
         self,
         *,
-        state: Any = None,
+        state_type: type[StateT] | None = None,
         title: str | None = None,
         width: int = 80,
         height: int = 24,
     ) -> None:
-        self.state = state
-        """Application state passed to the offscreen runtime."""
+        self._state_type = state_type
+        """Declared type of the application state (typing aid only)."""
         self.title = title or "xnano"
         """Browser document title."""
         self.width = width
@@ -77,6 +78,7 @@ class Web:
         self,
         source: Any,
         *,
+        state: StateT | None = None,
         host: str = "127.0.0.1",
         port: int = 8000,
     ) -> None:
@@ -84,6 +86,7 @@ class Web:
 
         Args:
             source: Grid/component instance, class, or factory.
+            state: Application state shared with event and request hooks.
             host: Bind address.
             port: Bind port.
         """
@@ -92,7 +95,7 @@ class Web:
         factory, _, _ = grid_factory(source)
         serve_native(
             factory,
-            state=self.state,
+            state=state,
             title=self.title,
             host=host,
             port=port,


### PR DESCRIPTION
Batched prerelease fixes for `1.2.3b1` — the five most recent issues plus a layout bug found while testing docs examples under Pyodide. Each concern is a separate commit.

## Fixes

- **`fix(xnano-core)` — #128 Text drops indentation after `\n`.** Root cause was `render_ir.rs` hard-coding `Wrap { trim: true }`; ratatui's `trim: true` strips leading whitespace from every laid-out line, so authored indentation vanished whenever a paragraph wrapped (`Text`'s default). Switched to `trim: false`. Requires a `maturin develop` rebuild of `xnano-core`.
- **`feat(fields)` — #102 Literal sizing types.** Added `SizingKeyword` and `SizingPercentage` (`"0%"`–`"100%"`) literals, folded into `SizingLike` for editor autocomplete; bare `str` stays in the union so open-ended forms (`"1fr"`, `"1/3"`) still typecheck. Also taught `Sizing.parse` the `"full"` keyword (→ `100%`, matching the `w-full` rewrite) so every literal member actually resolves.
- **`refactor(context)` — #104 + #105.** Renamed `Context.tick`/`keyboard`/`mouse` → `tick_event`/`keyboard_event`/`mouse_event` to match `xnano.events.Event`. Replaced the transitional `_beta_request` facade stash with a real `Context.request` field.
- **`feat(tui)!` — #103 host state ergonomics.** Moved `state` off the `Terminal`/`Web` constructors into `run()`/`render()`; constructors gain a `state_type` param (pydantic_ai style, typing only). `Web` is now generic over its state type. **Breaking:** `Terminal(state=x)` → `Terminal().run(app, state=x)`.
- **`fix(core)` — `render(gap=...)` over-spaced multiple items.** Not a gap bug (`gap=N` is genuinely N rows): top-level `render()` gave every item an equal `fill(1)` share, so one-line items floated across the viewport. Now measured and packed via the field controller's `split_layout` (`Flex::Start`), with `gap` as literal spacing.

## Verification

- `uv run pytest` — 899 passed, 6 skipped (adds regression tests for #128, #102, #103, and the gap fix).
- `uv run ty check` — clean.
- `uv run prek run --all-files` — clean.

Closes #128, #102, #104, #103, #105.
