### PR TITLE
release: xnano 1.2.3b2 — revert state move, deprecate event accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.2.3b1"
+pip install "xnano>=1.2.3b2"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.2.3b1"
+uv add "xnano>=1.2.3b2"
 ```
 
 > [!TIP]
@@ -56,7 +56,7 @@ session, no event loop. It writes styled content to the terminal and returns.
 
 ```python
 from xnano import render
-from xnano.components.text import Text
+from xnano.components import Text
 
 render(
     Text("Hello from xnano!", foreground="violet", modifiers=["bold"])
@@ -69,7 +69,7 @@ You can pass multiple renderables — they stack vertically:
 
 ```python
 from xnano import render
-from xnano.components.text import Text
+from xnano.components import Text
 
 render(
     Text("● Done: ", foreground="emerald-400", modifiers=["bold"]),
@@ -87,7 +87,7 @@ render(
 
 ```python
 from xnano import render
-from xnano.components.text import Text
+from xnano.components import Text
 
 message = Text([
     Text("● ", foreground="emerald-400"),
@@ -111,11 +111,7 @@ slots, then pass an instance to `Terminal().run()`. The terminal takes over
 the screen, renders each frame, and cleans up on exit.
 
 ```python
-from xnano.grids import BaseGrid
-from xnano.fields import Field
-from xnano.terminal import Terminal
-from xnano.context import Context
-from xnano.hooks import on_tick, on_keyboard
+from xnano import BaseGrid, Field, Terminal, Context, on_tick, on_keyboard
 
 class App(BaseGrid):
     message: str = Field(
@@ -159,11 +155,7 @@ are laid out. Use `width` / `height` (absolute cells, `"50%"`, or `"1fr"`) to
 proportion each slot.
 
 ```python
-from xnano.grids import BaseGrid
-from xnano.fields import Field
-from xnano.terminal import Terminal
-from xnano.context import Context
-from xnano.hooks import on_keyboard
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
 
 class SidebarTitle(BaseGrid, align="center"):
     title: str = Field("This is a title.", align="center")
@@ -205,11 +197,7 @@ State fields (`state=True`) hold app data without rendering — update them and
 reference them from layout fields.
 
 ```python
-from xnano.grids import BaseGrid
-from xnano.fields import Field
-from xnano.terminal import Terminal
-from xnano.context import Context
-from xnano.hooks import on_keyboard
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
 
 class Counter(BaseGrid, direction="vertical", gap=1):
     label: str = Field(
@@ -253,11 +241,7 @@ Live terminal sessions enable mouse input by default. Use
 specific field — the handler fires only when that region is clicked.
 
 ```python
-from xnano.grids import BaseGrid
-from xnano.fields import Field
-from xnano.terminal import Terminal
-from xnano.context import Context
-from xnano.hooks import on_click, on_keyboard
+from xnano import BaseGrid, Field, Terminal, Context, on_click, on_keyboard
 
 class App(BaseGrid, direction="vertical", gap=1):
     button: str = Field(
@@ -295,11 +279,7 @@ blocking the event loop.
 
 ```python
 import time
-from xnano.grids import BaseGrid
-from xnano.fields import Field
-from xnano.terminal import Terminal
-from xnano.context import Context
-from xnano.hooks import on_tick, on_keyboard
+from xnano import BaseGrid, Field, Terminal, Context, on_tick, on_keyboard
 
 class Clock(BaseGrid, direction="vertical", gap=1):
     time_display: str = Field(
@@ -342,11 +322,7 @@ display depends on state that changes externally.
 
 ```python
 from dataclasses import dataclass
-from xnano.grids import BaseGrid
-from xnano.fields import Field
-from xnano.terminal import Terminal
-from xnano.context import Context
-from xnano.hooks import on_keyboard
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
 
 @dataclass
 class AppState:
@@ -387,13 +363,8 @@ Components slot into `BaseGrid` fields like any other value.
 
 ```python
 import dataclasses
-from xnano.grids import BaseGrid
-from xnano.fields import Field
-from xnano.terminal import Terminal
-from xnano.context import Context
-from xnano.hooks import on_keyboard
-from xnano.components.component import Component
-from xnano.core.content import TextBlock
+from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
+from xnano.components import Component, TextBlock
 
 @dataclasses.dataclass
 class Badge(Component):

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -201,7 +201,7 @@ class Notes: # (1)!
     current: int | None = None
 ```
 
-1. A plain dataclass — no [xnano]{data-preview} base class required. Anything you pass to `run(state=...)` becomes the shared state.
+1. A plain dataclass — no [xnano]{data-preview} base class required. Anything you pass to `Terminal(state=...)` becomes the shared state.
 2. We track whether the editor is open (`editing`) and, when editing an existing note, its index (`current`). `None` means we're writing a brand-new note.
 
 Every event handler receives a `Context`, and `ctx.state` *is* this object — the same instance, everywhere.
@@ -349,7 +349,7 @@ Right now the `editor` is an ordinary field, so it claims its own slice of the l
 [xnano]{data-preview} apps are keyboard-first, but a click or a hover is often the most natural thing to reach for. Mouse input is **opt-in** — turn it on when you run:
 
 ```python title="Enabling the Mouse"
-Terminal(mouse_events=True).run(NotesApp(), state=Notes())
+Terminal(state=Notes(), mouse_events=True).run(NotesApp())
 ```
 
 With mouse events on, two behaviors come for free:
@@ -510,7 +510,7 @@ class NotesApp(BaseGrid, direction="vertical"):
         ctx.runtime.request_exit()
 
 if __name__ == "__main__":
-    Terminal(mouse_events=True).run(NotesApp(), state=Notes())
+    Terminal(state=Notes(), mouse_events=True).run(NotesApp())
 ```
 
 Run it with `python notes.py`, and you have a complete little application: browse your notes on the left, watch the count on the right, pop open the editor to write or edit, and every keybind in reach along the bottom.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,13 +32,13 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "pip"
 
     ```bash title="Install with pip"
-    pip install "xnano>=1.2.3b1"
+    pip install "xnano>=1.2.3b2"
     ```
 
 === "uv"
 
     ```bash title="Install with uv"
-    uv pip install "xnano>=1.2.3b1"
+    uv pip install "xnano>=1.2.3b2"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -47,7 +47,7 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "poetry"
 
     ```bash title="Install with poetry"
-    poetry install "xnano>=1.2.3b1"
+    poetry install "xnano>=1.2.3b2"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -56,7 +56,7 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "conda"
 
     ```bash title="Install with conda"
-    conda install "xnano>=1.2.3b1"
+    conda install "xnano>=1.2.3b2"
     ```
 
 ## Notetaking Application

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -20,7 +20,7 @@ and so on — every family, every shade from `50` to `950`. The grid below rende
 all of them. Change a shade in `shades` or drop a family from `palettes` to see
 the effect.
 
-```pyodide install="xnano>=1.2.3b1" height="28"
+```pyodide install="xnano>=1.2.3b2" height="28"
 from xnano import render
 from xnano.components.text import Text
 
@@ -55,7 +55,7 @@ render(*rows)
 A Tailwind name is one option. Anywhere a color is accepted you can also pass a
 CSS name, a hex string, an `(r, g, b)` tuple, or a `Color` object.
 
-```pyodide install="xnano>=1.2.3b1" height="10"
+```pyodide install="xnano>=1.2.3b2" height="10"
 from xnano import render
 from xnano.components.text import Text
 
@@ -74,7 +74,7 @@ render(
 constructor. Nest it to style a run inside a line without breaking the surrounding
 flow — pass a list of `Text` where you'd otherwise pass a string.
 
-```pyodide install="xnano>=1.2.3b1" height="15"
+```pyodide install="xnano>=1.2.3b2" height="15"
 from xnano import render
 from xnano.components.text import Text
 
@@ -92,7 +92,7 @@ The same component can also parse its input. Pass `ansi`, `markdown`, or
 `language` and `Text` renders the result instead of the raw string. The three
 modes are mutually exclusive — pick one.
 
-```pyodide install="xnano>=1.2.3b1" height="36"
+```pyodide install="xnano>=1.2.3b2" height="36"
 from xnano import render
 from xnano.components.text import Text
 
@@ -122,7 +122,7 @@ A `Chart` takes a mapping of labels to data — either bare `y` values or explic
 `(x, y)` pairs. Declare a `Series` per key to set its label, color, and `kind`,
 and one chart can mix line, scatter, and bar. Try changing a `kind` below.
 
-```pyodide install="xnano>=1.2.3b1" height="27"
+```pyodide install="xnano>=1.2.3b2" height="27"
 from xnano import render
 from xnano.components.chart import Chart, Series
 
@@ -146,7 +146,7 @@ For a compact trend without a full plot, `Bar` renders a series inline in a
 single block. Set a fixed `max_value` so separate bars share a scale and stay
 comparable.
 
-```pyodide install="xnano>=1.2.3b1" height="22"
+```pyodide install="xnano>=1.2.3b2" height="22"
 from xnano import render
 from xnano.components.bar import Bar
 
@@ -164,7 +164,7 @@ the columns. For control, declare a `Column`: it takes a formatter, an accessor,
 alignment, and width. Pass a callable for `color` or `background` and it receives
 the cell value, so a column can style itself from its own data.
 
-```pyodide install="xnano>=1.2.3b1" height="30"
+```pyodide install="xnano>=1.2.3b2" height="30"
 from xnano import render
 from xnano.components.schema import Column
 from xnano.components.table import Table
@@ -202,7 +202,7 @@ render(table)
 
 Without any `Column` descriptors, `Table` infers columns straight from the keys:
 
-```pyodide install="xnano>=1.2.3b1" height="12"
+```pyodide install="xnano>=1.2.3b2" height="12"
 from xnano import render
 from xnano.components.table import Table
 
@@ -219,7 +219,7 @@ lines. Each child sets its own size with the sizing grammar — fractions (`"1/3
 `fr` units (`"2fr"`), `"fit"`, or a fixed cell count. Adjust the `width` values to
 re-balance the layout.
 
-```pyodide install="xnano>=1.2.3b1" height="25"
+```pyodide install="xnano>=1.2.3b2" height="25"
 from xnano import BaseGrid, Field, render
 
 class Sidebar(BaseGrid, direction="vertical", gap=1, border="rounded", title="nav"):
@@ -248,7 +248,7 @@ dispatch path as real input, so you can render a grid to attach its hooks,
 perform an action, and render again to see the updated state. This is also how
 you test a grid frame-by-frame. Here a counter increments twice between frames.
 
-```pyodide install="xnano>=1.2.3b1" height="24"
+```pyodide install="xnano>=1.2.3b2" height="24"
 from xnano import Action, BaseGrid, Field, Terminal, on_action
 
 INCREMENT = Action.keyboard("right")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.2.3b1"
+version = "1.2.3b2"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import cast
 
+import pytest
+
 from xnano.context import Context
 from xnano.core.runtime import Runtime
 from xnano.events import AbstractEventData, Event, KeyboardEventData
@@ -111,3 +113,25 @@ def test_real_hook_context_combines_state_runtime_and_rendering() -> None:
         assert frame.contains("Ada:offscreen:small")
     finally:
         runtime.close()
+
+
+def test_deprecated_event_aliases_warn_and_delegate() -> None:
+    """``tick``/``keyboard``/``mouse`` stay as deprecated aliases of the
+    ``*_event`` accessors: they emit a ``DeprecationWarning`` (which also
+    renders a strikethrough in editors via ``@deprecated``) while returning
+    the same payload.
+    """
+    facade = _Facade()
+    event = Event.from_data(KeyboardEventData.from_binding("enter"))
+    ctx = Context(
+        event=event,
+        terminal=cast(Runtime[dict[str, bool]], facade),
+        state={"ok": True},
+    )
+
+    with pytest.warns(DeprecationWarning, match="keyboard_event"):
+        assert ctx.keyboard is ctx.keyboard_event
+    with pytest.warns(DeprecationWarning, match="mouse_event"):
+        assert ctx.mouse is ctx.mouse_event
+    with pytest.warns(DeprecationWarning, match="tick_event"):
+        assert ctx.tick is ctx.tick_event

--- a/tests/test_grid_render_ctx.py
+++ b/tests/test_grid_render_ctx.py
@@ -29,9 +29,9 @@ def test_grid_render_receives_ctx_and_state() -> None:
 
     grid = App()
     state = {"model": "opus"}
-    terminal = Terminal.offscreen(cols=40, rows=4)
+    terminal = Terminal.offscreen(cols=40, rows=4, state=state)
     terminal.attach_grid(grid)
-    terminal.render(state=state)
+    terminal.render()
     terminal.close()
 
     assert seen and seen[0] == state

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -88,14 +88,6 @@ def test_terminal_live_run_skips_unused_frame_serialization(
     terminal.run(App())
 
 
-def test_render_and_run_accept_state() -> None:
-    """State is supplied at paint time, not to the constructor (#103)."""
-    terminal = Terminal.offscreen(cols=20, rows=3)
-    terminal.render("x", state={"n": 1})
-    assert terminal.state == {"n": 1}
-    terminal.close()
-
-
 def test_render_packs_multiple_items_by_content() -> None:
     """Multiple top-level renderables pack to their content size with ``gap``
     as literal spacing, rather than each taking an equal fill share that would

--- a/tests/test_user_compositions.py
+++ b/tests/test_user_compositions.py
@@ -314,12 +314,7 @@ def test_cli_workflow_composes_typed_arguments_options_and_subcommands(
     help_text = format_plain_help(command)
     assert all(
         text in help_text
-        for text in (
-            "Usage: deploy",
-            "Deployment target",
-            "Commands:",
-            "status",
-        )
+        for text in ("Usage: deploy", "Deployment target", "Commands:", "status")
     )
     assert render_help(command, stream=io.StringIO()) == help_text
 
@@ -440,7 +435,9 @@ def test_frame_export_combines_render_cursor_device_and_commands() -> None:
     assert frame.rows[0] == "ready"
     assert len(frame.rows) == 8
 
-    fallback = frame_from_terminal(types.SimpleNamespace(size=lambda: (2, 2)))
+    fallback = frame_from_terminal(
+        types.SimpleNamespace(size=lambda: (2, 2))
+    )
     assert fallback.rows == ("", "")
 
 
@@ -500,7 +497,9 @@ def test_browser_session_combines_shell_frames_events_and_request_hooks() -> (
         )
         response = connection.getresponse()
         assert response.status == 202
-        assert json.loads(response.read()) == {"received": {"name": "backup"}}
+        assert json.loads(response.read()) == {
+            "received": {"name": "backup"}
+        }
 
         connection.request(
             "POST",
@@ -567,16 +566,12 @@ def test_web_host_accepts_component_factory_and_managed_server(
         serve_application,
     )
     web = Web(
+        state={"tenant": "demo"},
         title="Status",
         width=100,
         height=30,
     )
-    web.run(
-        callable_factory,
-        state={"tenant": "demo"},
-        host="0.0.0.0",
-        port=9000,
-    )
+    web.run(callable_factory, host="0.0.0.0", port=9000)
     assert calls == [
         {
             "state": {"tenant": "demo"},
@@ -612,13 +607,13 @@ def test_terminal_facade_combines_lazy_runtime_state_focus_and_output(
         "supports_live_terminal",
         staticmethod(lambda: False),
     )
-    terminal = Terminal(title="Signup")
+    terminal = Terminal(state={"step": 1}, title="Signup")
+    assert terminal.state == {"step": 1}
     assert terminal.surface == "terminal"
 
     form = Form()
     terminal.attach_grid(form)
-    frame = terminal.render(form, state={"step": 1})
-    assert terminal.state == {"step": 1}
+    frame = terminal.render(form)
     assert frame.width == terminal.size[0]
     assert terminal.surface == "offscreen"
     assert terminal.device is terminal.runtime.device
@@ -636,9 +631,7 @@ def test_terminal_facade_combines_lazy_runtime_state_focus_and_output(
     terminal.blur()
     assert terminal.focused_group is None
     assert terminal.get_output() == terminal.runtime.get_output()
-    assert (
-        terminal.get_output_as_ansi() == terminal.runtime.get_output_as_ansi()
-    )
+    assert terminal.get_output_as_ansi() == terminal.runtime.get_output_as_ansi()
 
     terminal.request_exit()
     assert terminal.runtime._should_exit is True

--- a/tests/test_watch_hooks.py
+++ b/tests/test_watch_hooks.py
@@ -57,9 +57,9 @@ def test_on_state_bare_name_fires_once_per_mutation() -> None:
 
     app = App()
     state = State()
-    terminal = Terminal.offscreen(cols=20, rows=3)
+    terminal = Terminal.offscreen(cols=20, rows=3, state=state)
     try:
-        terminal.render(app, state=state)
+        terminal.render(app)
         terminal.render(app)
         assert fires == []
         state.value = 9
@@ -80,9 +80,9 @@ def test_on_state_bare_name_reads_dict_state_keys() -> None:
 
     app = App()
     state: dict[str, int] = {"value": 0}
-    terminal = Terminal.offscreen(cols=20, rows=3)
+    terminal = Terminal.offscreen(cols=20, rows=3, state=state)
     try:
-        terminal.render(app, state=state)
+        terminal.render(app)
         state["value"] = 3
         terminal.render(app)
         assert fires == [3]

--- a/uv.lock
+++ b/uv.lock
@@ -2377,7 +2377,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.2.3b1"
+version = "1.2.3b2"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -16,7 +16,7 @@ try:
 except (
     importlib.metadata.PackageNotFoundError
 ):  # pragma: no cover - editable / source trees
-    __version__ = "1.2.3b1"
+    __version__ = "1.2.3b2"
 
 if TYPE_CHECKING:
     from xnano import cli, components, core, events, hooks, requests

--- a/xnano/context.py
+++ b/xnano/context.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 
+from xnano.utils.deprecation import warn_renamed_attribute
+
 if TYPE_CHECKING:
     from xnano.actions import Actions
     from xnano.core.runtime import Runtime
@@ -111,6 +113,24 @@ class Context(Generic[StateT]):
     @property
     def mouse_event(self) -> "MouseEventData | None":
         """Mouse sub-event when triggered by a mouse event."""
+        return self.event.mouse_event
+
+    @property
+    @warn_renamed_attribute("Context.tick", "Context.tick_event")
+    def tick(self) -> "TickEventData | None":
+        """Deprecated alias for :attr:`tick_event`."""
+        return self.event.tick_event
+
+    @property
+    @warn_renamed_attribute("Context.keyboard", "Context.keyboard_event")
+    def keyboard(self) -> "KeyboardEventData | None":
+        """Deprecated alias for :attr:`keyboard_event`."""
+        return self.event.keyboard_event
+
+    @property
+    @warn_renamed_attribute("Context.mouse", "Context.mouse_event")
+    def mouse(self) -> "MouseEventData | None":
+        """Deprecated alias for :attr:`mouse_event`."""
         return self.event.mouse_event
 
     def get_state(self) -> StateT:

--- a/xnano/terminal.py
+++ b/xnano/terminal.py
@@ -58,13 +58,12 @@ class Terminal(Generic[StateT]):
     def __init__(
         self,
         *,
-        state_type: type[StateT] | None = None,
+        state: StateT | None = None,
         title: str | None = None,
         tick_interval: int = 16,
         mouse_events: bool = False,
     ) -> None:
-        self._state: StateT | None = None
-        self._state_type = state_type
+        self._state = state
         self._title = title
         self._tick_interval = tick_interval
         self._mouse_events = mouse_events
@@ -77,17 +76,15 @@ class Terminal(Generic[StateT]):
         *,
         cols: int = 40,
         rows: int = 12,
-        state_type: type[StateT] | None = None,
+        state: StateT | None = None,
         title: str | None = None,
     ) -> "Terminal[StateT]":
-        """Create a terminal backed by an in-memory cell buffer.
-
-        Pass application state at paint time via ``render(..., state=...)``.
-        """
-        terminal = cls(state_type=state_type, title=title)
+        """Create a terminal backed by an in-memory cell buffer."""
+        terminal = cls(state=state, title=title)
         terminal._runtime = Runtime.offscreen(
             cols,
             rows,
+            state=state,
             title=title,
         )
         terminal.surface = "offscreen"
@@ -181,7 +178,6 @@ class Terminal(Generic[StateT]):
     def render(
         self,
         *renderables: Any,
-        state: StateT | None = None,
         color: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
@@ -200,8 +196,6 @@ class Terminal(Generic[StateT]):
         Args:
             *renderables: Grids, components, content primitives, or plain
                 values to paint.
-            state: Application state shared with event hooks. Replaces the
-                current state when provided.
             color: Foreground color applied to plain values.
             background: Background color for the rendered area.
             modifiers: Character modifiers applied to plain values.
@@ -218,8 +212,6 @@ class Terminal(Generic[StateT]):
         Returns:
             A snapshot of the rendered terminal frame.
         """
-        if state is not None:
-            self.state = state
         runtime = self._ensure_runtime()
         if renderables:
             runtime.set_root(renderables[0] if len(renderables) == 1 else None)
@@ -242,7 +234,6 @@ class Terminal(Generic[StateT]):
     def run(
         self,
         *renderables: Any,
-        state: StateT | None = None,
         color: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
@@ -261,8 +252,6 @@ class Terminal(Generic[StateT]):
         Args:
             *renderables: Grids, components, content primitives, or plain
                 values to paint.
-            state: Application state shared with event hooks. Replaces the
-                current state when provided.
             color: Foreground color applied to plain values.
             background: Background color for the rendered area.
             modifiers: Character modifiers applied to plain values.
@@ -276,8 +265,6 @@ class Terminal(Generic[StateT]):
             gap: Cells between multiple renderables.
             direction: Direction used to lay out multiple renderables.
         """
-        if state is not None:
-            self.state = state
         runtime = self._ensure_runtime(live=True)
         if renderables:
             runtime.set_root(renderables[0] if len(renderables) == 1 else None)

--- a/xnano/utils/deprecation.py
+++ b/xnano/utils/deprecation.py
@@ -11,8 +11,14 @@ dataclass or callable that pairs a foreground color with a
 from __future__ import annotations
 
 import functools
+import sys
 import warnings
 from typing import Any, Callable, TypeVar
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated as _deprecated
+else:
+    from typing_extensions import deprecated as _deprecated
 
 _ClassT = TypeVar("_ClassT", bound=type)
 _CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
@@ -59,6 +65,27 @@ def resolve_color_alias(
     return foreground
 
 
+def warn_renamed_attribute(
+    old: str, new: str
+) -> Callable[[_CallableT], _CallableT]:
+    """Decorate a renamed attribute/property getter as deprecated.
+
+    Applies PEP 702 ``@deprecated``, so type checkers render callers of the
+    old name with a strikethrough and a ``DeprecationWarning`` is emitted at
+    runtime when it is used. Apply below ``@property`` on the getter.
+
+    Args:
+        old: Fully qualified deprecated name (e.g. ``"Context.keyboard"``).
+        new: Fully qualified replacement name.
+
+    Returns:
+        The ``@deprecated`` decorator carrying the rename message.
+    """
+    # Message is dynamic, not a LiteralString; deprecated() accepts any str.
+    message = f"'{old}' is deprecated; use '{new}' instead."
+    return _deprecated(message)  # ty: ignore[invalid-argument-type]
+
+
 def color_alias_dataclass(cls: _ClassT) -> _ClassT:
     """Add a deprecated ``color`` alias for a dataclass ``foreground`` field.
 
@@ -102,4 +129,5 @@ __all__ = (
     "color_alias_dataclass",
     "resolve_color_alias",
     "warn_color_alias",
+    "warn_renamed_attribute",
 )

--- a/xnano/web.py
+++ b/xnano/web.py
@@ -7,9 +7,7 @@ Serve grids and components through an offscreen native cell runtime.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Generic, TypeVar
-
-StateT = TypeVar("StateT")
+from typing import Any, Callable
 
 
 def grid_factory(source: Any) -> tuple[Callable[[], Any], bool, type | None]:
@@ -39,10 +37,11 @@ def grid_factory(source: Any) -> tuple[Callable[[], Any], bool, type | None]:
     )
 
 
-class Web(Generic[StateT]):
+class Web:
     """Serve an application in a browser from an offscreen runtime.
 
     Attributes:
+        state: Application state shared with event and request hooks.
         title: Browser document title.
         width: Offscreen viewport width in cells.
         height: Offscreen viewport height in cells.
@@ -57,13 +56,13 @@ class Web(Generic[StateT]):
     def __init__(
         self,
         *,
-        state_type: type[StateT] | None = None,
+        state: Any = None,
         title: str | None = None,
         width: int = 80,
         height: int = 24,
     ) -> None:
-        self._state_type = state_type
-        """Declared type of the application state (typing aid only)."""
+        self.state = state
+        """Application state passed to the offscreen runtime."""
         self.title = title or "xnano"
         """Browser document title."""
         self.width = width
@@ -78,7 +77,6 @@ class Web(Generic[StateT]):
         self,
         source: Any,
         *,
-        state: StateT | None = None,
         host: str = "127.0.0.1",
         port: int = 8000,
     ) -> None:
@@ -86,7 +84,6 @@ class Web(Generic[StateT]):
 
         Args:
             source: Grid/component instance, class, or factory.
-            state: Application state shared with event and request hooks.
             host: Bind address.
             port: Bind port.
         """
@@ -95,7 +92,7 @@ class Web(Generic[StateT]):
         factory, _, _ = grid_factory(source)
         serve_native(
             factory,
-            state=state,
+            state=self.state,
             title=self.title,
             host=host,
             port=port,


### PR DESCRIPTION
Follow-up to the `1.2.3b1` prerelease (#132). Softens the two API breaks it introduced.

## Changes

- **`revert(tui)` — restore `Terminal(state=...)` / `Web(state=...)`.** I liked it more the way it used to be. Thats my explanation here.
- **`feat(context)` — deprecate the old event accessors instead of removing them.** #104 renamed `ctx.tick`/`keyboard`/`mouse` → `*_event`. The old names come back as **deprecated aliases** via PEP 702 `@deprecated`: editors strike them through, a `DeprecationWarning` fires at runtime, and they delegate to the new accessors. `Terminal(state=...)` was one of the earliest patterns, so nothing is removed for several versions.
- **`docs(readme)` — prefer top-level imports.** README examples now import everything the top-level `xnano` namespace re-exports from `xnano` directly, leaving `from xnano.components import ...` for the genuine special cases.
- **`release` — bump to `1.2.3b2`.**

## Verification

- `uv run pytest` — 899 passed, 6 skipped (adds a test asserting the deprecated aliases warn and delegate).
- `uv run ty check` — clean.
- `uv run prek run --all-files` — clean.

## Note

The `@deprecated` decorator resolves to `warnings.deprecated` on Python 3.13+ and `typing_extensions.deprecated` below that. `typing-extensions` is not declared directly but is guaranteed transitively via `pydantic-core`; add an explicit pin if you'd rather not rely on that.
