### PR TITLE
feat: improve grid ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ proportion each slot.
 ```python
 from xnano import BaseGrid, Field, Terminal, Context, on_keyboard
 
-class SidebarTitle(BaseGrid, align="center"):
-    title: str = Field("This is a title.", align="center")
+class SidebarTitle(BaseGrid, horizontal_align="center"):
+    title: str = Field("This is a title.", horizontal_align="center")
 
 class Sidebar(BaseGrid, direction="vertical"):
     title: SidebarTitle = Field(

--- a/docs/core-concepts/actions.md
+++ b/docs/core-concepts/actions.md
@@ -163,7 +163,7 @@ from xnano import Action, BaseGrid, Field, Terminal, on_action
 INCREMENT = Action.keyboard("right")
 
 class Counter(BaseGrid, border="rounded", title=" action ", padding=1):
-    label: str = Field(default="count: 0", align="center")
+    label: str = Field(default="count: 0", horizontal_align="center")
     count: int = Field(default=0, state=True)
 
     @on_action(INCREMENT)

--- a/docs/core-concepts/components.md
+++ b/docs/core-concepts/components.md
@@ -202,10 +202,10 @@ class Services(Table):
         width=14,
     )
     status: str = Column(
-        color=lambda value: "green-300" if value == "ok" else "red-300",
-        align="center",
+        foreground=lambda value: "green-300" if value == "ok" else "red-300",
+        horizontal_align="center",
     )
-    latency: int = Column(format="{} ms", align="right", width=12)
+    latency: int = Column(format="{} ms", horizontal_align="right", width=12)
 
 table = Services(data=[
     {"meta": {"name": "api"}, "status": "ok", "latency": 12},
@@ -264,7 +264,7 @@ class Badge(Component):
     foreground: str = "cyan"
 
     def compose(self, ctx):  # (1)!
-        return TextBlock.from_plain(self.text, color=self.foreground)
+        return TextBlock.from_plain(self.text, foreground=self.foreground)
 ```
 
 1. The paint hook is how a component turns attributes into content. Built-ins

--- a/docs/core-concepts/effects.md
+++ b/docs/core-concepts/effects.md
@@ -33,7 +33,7 @@ a panel appears. They need an active runtime and painted field geometry.
   <line class="gcd-arrow" x1="240" y1="120" x2="300" y2="120" marker-end="url(#fx-arrow)" />
 
   <rect class="gcd-panel gcd-panel-accent" x="312" y="72" width="160" height="96" rx="12" />
-  <text class="gcd-label gcd-label-accent" x="392" y="112" text-anchor="middle">grid_play_effect</text>
+  <text class="gcd-label gcd-label-accent" x="392" y="112" text-anchor="middle">grid_effect</text>
   <text class="gcd-chrome-label" x="392" y="140" text-anchor="middle">fields=[…]</text>
 
   <line class="gcd-arrow" x1="472" y1="120" x2="532" y2="120" marker-end="url(#fx-arrow)" />
@@ -54,12 +54,12 @@ a panel appears. They need an active runtime and painted field geometry.
 ## Playing effects on fields
 
 The usual entrypoint is
-[`BaseGrid.grid_play_effect`](../api/xnano/grids.md){data-preview}. Pass a known
+[`BaseGrid.grid_effect`](../api/xnano/grids.md){data-preview}. Pass a known
 kind string (or a built effect instance) and the **field names** to animate.
 Field names match the attributes on the grid; during paint those slots are
 tagged so the runtime can target their rects.
 
-```python title="grid_play_effect" hl_lines="10 11 12 13 14"
+```python title="grid_effect" hl_lines="10 11 12 13 14"
 from xnano import BaseGrid, Field, Terminal, on_keyboard
 
 class Panel(BaseGrid, direction="vertical"):
@@ -68,7 +68,7 @@ class Panel(BaseGrid, direction="vertical"):
 
     @on_keyboard("f")
     def fade_body(self) -> None:
-        self.grid_play_effect(
+        self.grid_effect(
             "fade", # (1)!
             color="violet-400", # (2)!
             duration_ms=300,
@@ -85,7 +85,7 @@ Terminal().run(Panel())
 3. `fields` is required for work to start. An empty list or omit means no
    effect runs. Multiple names are allowed.
 
-`grid_play_effect` returns `True` when at least one field area was found and
+`grid_effect` returns `True` when at least one field area was found and
 the runtime accepted the effect. It returns `False` when there is no active
 runtime (for example outside a session) or the fields could not be resolved.
 
@@ -129,21 +129,21 @@ Fades interpolate color on the target field area.
 | `"fade_from_both"` | `FadeFromBothEffect` | Fade foreground and background **from** sources |
 
 ```python title="Fade kinds"
-self.grid_play_effect(
+self.grid_effect(
     "fade",
     color="emerald-400",
     duration_ms=250,
     fields=["body"],
 )
 
-self.grid_play_effect(
+self.grid_effect(
     "fade_from",
     color="slate-700",
     duration_ms=250,
     fields=["body"],
 )
 
-self.grid_play_effect(
+self.grid_effect(
     "fade_to",
     color="white",
     background="slate-900",
@@ -151,7 +151,7 @@ self.grid_play_effect(
     fields=["body"],
 )
 
-self.grid_play_effect(
+self.grid_effect(
     "fade_from_both",
     color="violet-400",
     background="black",
@@ -190,8 +190,8 @@ Cell-level transitions without a motion direction.
 | `"coalesce"` | `CoalesceEffect` | Typewriter-style cell assembly |
 
 ```python title="Dissolve and coalesce"
-self.grid_play_effect("dissolve", duration_ms=400, fields=["body"])
-self.grid_play_effect("coalesce", duration_ms=500, fields=["body"])
+self.grid_effect("dissolve", duration_ms=400, fields=["body"])
+self.grid_effect("coalesce", duration_ms=500, fields=["body"])
 ```
 
 ```python
@@ -230,7 +230,7 @@ Directional sweeps reveal or hide content with a motion gradient.
 `color` (gradient accent).
 
 ```python title="Sweep in and out"
-self.grid_play_effect(
+self.grid_effect(
     "sweep_in",
     direction="left_to_right",
     gradient_length=14,
@@ -240,7 +240,7 @@ self.grid_play_effect(
     fields=["body"],
 )
 
-self.grid_play_effect(
+self.grid_effect(
     "sweep_out",
     direction="up_to_down",
     duration_ms=350,
@@ -271,14 +271,14 @@ Directional slides, same motion parameters as sweeps.
 | `"slide_out"` | `SlideOutEffect` | Directional slide **hiding** content |
 
 ```python title="Slide in and out"
-self.grid_play_effect(
+self.grid_effect(
     "slide_in",
     direction="down_to_up",
     duration_ms=350,
     fields=["body"],
 )
 
-self.grid_play_effect(
+self.grid_effect(
     "slide_out",
     direction="right_to_left",
     color="sky-300",
@@ -309,7 +309,7 @@ Paints set colors on the target area (as opposed to fading through them).
 | `"paint_bg"` | `PaintBackgroundEffect` | Paint background only |
 
 ```python title="Paint kinds"
-self.grid_play_effect(
+self.grid_effect(
     "paint",
     color="white",
     background="slate-800",
@@ -317,14 +317,14 @@ self.grid_play_effect(
     fields=["body"],
 )
 
-self.grid_play_effect(
+self.grid_effect(
     "paint_fg",
     color="amber-300",
     duration_ms=200,
     fields=["title"],
 )
 
-self.grid_play_effect(
+self.grid_effect(
     "paint_bg",
     background="slate-900",
     duration_ms=200,
@@ -364,7 +364,7 @@ DelayEffect(
 )
 
 # Same idea via kind strings
-self.grid_play_effect(
+self.grid_effect(
     "delay",
     duration_ms=200,
     child=Effect("fade", color="violet-400", duration_ms=250),
@@ -407,7 +407,7 @@ self.grid_play_effect(
 ```python title="Sequence, parallel, repeat"
 from xnano.effects import Effect, ParallelEffect, RepeatEffect, SequenceEffect
 
-self.grid_play_effect(
+self.grid_effect(
     "sequence",
     effects=(
         Effect("sweep_in", direction="up_to_down", duration_ms=350),
@@ -416,7 +416,7 @@ self.grid_play_effect(
     fields=["body"],
 )
 
-self.grid_play_effect(
+self.grid_effect(
     "parallel",
     effects=(
         Effect("fade", color="emerald-400", duration_ms=300),
@@ -425,7 +425,7 @@ self.grid_play_effect(
     fields=["body"],
 )
 
-self.grid_play_effect(
+self.grid_effect(
     "repeat",
     child=Effect("fade", color="violet-400", duration_ms=200),
     times=3,
@@ -453,7 +453,7 @@ together = ParallelEffect(
     ),
 )
 
-self.grid_play_effect(intro, fields=["title", "body"])
+self.grid_effect(intro, fields=["title", "body"])
 ```
 
 ## Duration, easing, and filters
@@ -480,16 +480,16 @@ Notes:
 
 - `duration_ms`, `interpolation`, `color`, `background`, `direction`,
   `gradient_length`, `randomness`, `effects`, `child`, `times`, and `key` can
-  be passed as kwargs on kind-string calls to `grid_play_effect` / `Effect(...)`.
+  be passed as kwargs on kind-string calls to `grid_effect` / `Effect(...)`.
 - `cell_filter` is set on a typed instance (for example
   `FadeEffect(color="cyan", cell_filter="text")`), not as a kind-string kwarg.
 - When `effect` is already an instance, set `key` on that instance; the
-  `key=` kwarg on `grid_play_effect` is only used for kind strings.
+  `key=` kwarg on `grid_effect` is only used for kind strings.
 
 ## When effects run
 
 Effects need an active runtime and a painted field geometry, so call
-`grid_play_effect` from hooks, after the grid is attached to a live
+`grid_effect` from hooks, after the grid is attached to a live
 `Terminal` / `Web` session, or from other runtime-bound code — not at module
 import time.
 
@@ -505,7 +505,7 @@ class Banner(BaseGrid, direction="vertical"):
         if self._intro_done:
             return
         self._intro_done = True
-        self.grid_play_effect(
+        self.grid_effect(
             "coalesce",
             duration_ms=450,
             fields=["label"],
@@ -513,7 +513,7 @@ class Banner(BaseGrid, direction="vertical"):
 
     @on_keyboard("r")
     def replay(self) -> None:
-        self.grid_play_effect(
+        self.grid_effect(
             "sweep_in",
             direction="left_to_right",
             duration_ms=350,
@@ -528,7 +528,7 @@ Terminal().run(Banner())
    the in-flight effect instead of stacking another.
 
 [`Runtime.play_effect`](../api/xnano/core/runtime.md){data-preview} is the
-lower-level API. Grids wrap it as `grid_play_effect` so field names resolve
+lower-level API. Grids wrap it as `grid_effect` so field names resolve
 against that grid's layout after paint.
 
 Effects are terminal-native in implementation detail (tachyonfx-backed under
@@ -555,11 +555,11 @@ fade_too = FadeEffect(color="emerald-400", duration_ms=250)
 sweep_too = SweepInEffect(direction="left_to_right", duration_ms=400)
 ```
 
-Pass either form into `grid_play_effect`:
+Pass either form into `grid_effect`:
 
 ```python
-self.grid_play_effect(fade, fields=["body"])
-self.grid_play_effect("fade", color="emerald-400", fields=["body"])
+self.grid_effect(fade, fields=["body"])
+self.grid_effect("fade", color="emerald-400", fields=["body"])
 ```
 
 Prefer kind strings at the call site for one-off triggers. Prefer typed classes
@@ -574,7 +574,7 @@ when you store, compose, or type-check effect values.
 ??? abstract "API"
 
     [`xnano.effects`](../api/xnano/effects.md){data-preview} ·
-    [`BaseGrid.grid_play_effect`](../api/xnano/grids.md){data-preview} ·
+    [`BaseGrid.grid_effect`](../api/xnano/grids.md){data-preview} ·
     [`Runtime.play_effect`](../api/xnano/core/runtime.md){data-preview}
 
 [effect]: ../api/xnano/effects.md

--- a/docs/core-concepts/grids.md
+++ b/docs/core-concepts/grids.md
@@ -298,7 +298,7 @@ Useful grid methods:
 |--------|------|
 | `grid_render` / `grid_render_*` | Refresh fields each frame (or per size tier) |
 | `grid_set_field(name, ...)` | Mutate a field value or layout metadata at runtime |
-| `grid_play_effect(...)` | Animate field areas — [Effects](effects.md) |
+| `grid_effect(...)` | Animate field areas — [Effects](effects.md) |
 
 ## Displaying Content
 

--- a/docs/core-concepts/terminal.md
+++ b/docs/core-concepts/terminal.md
@@ -87,13 +87,13 @@ control. It does not run the event loop.
 ```pyodide install="xnano>=1.2.3b2" height="3"
 from xnano import render
 
-render("hello, terminal!", color="blue")
+render("hello, terminal!", foreground="blue")
 ```
 
 ```python title="render()"
 from xnano import render
 
-render("hello, terminal!", color="blue") # (1)!
+render("hello, terminal!", foreground="blue") # (1)!
 ```
 
 1. Opens a short-lived paint path, writes the frame, then stops.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -398,7 +398,7 @@ class NotesApp(BaseGrid, direction="vertical"): # (2)!
         default="[n] new   [↑/↓] browse   [enter] open   [ctrl+s] save   [esc] cancel   [q] quit",
         height=1,
         background="dimgray",
-        align="center",
+        horizontal_align="center",
     )
 ```
 
@@ -477,7 +477,7 @@ class NotesApp(BaseGrid, direction="vertical"):
         width="60%",
         height="60%",
     )
-    footer: str = Field(default=KEYS, height=1, background="dimgray", align="center")
+    footer: str = Field(default=KEYS, height=1, background="dimgray", horizontal_align="center")
 
     def grid_render(self, ctx: Context[Notes]) -> None:
         self.grid_set_field("editor", visible=ctx.state.editing)

--- a/examples/agent_chat.py
+++ b/examples/agent_chat.py
@@ -355,7 +355,7 @@ class AgentChat(BaseGrid, direction="vertical", gap=0):
     header: str = Field(
         default="  ◆ xnano agent  ·  sonnet-4.6  ·  ~/projects/xnano",
         height=1,
-        color=tailwind_color("sky", 400),
+        foreground=tailwind_color("sky", 400),
         modifiers=["bold"],
     )
     history: Text = Field(
@@ -379,7 +379,7 @@ class AgentChat(BaseGrid, direction="vertical", gap=0):
         border_color=tailwind_color("slate", 700),
         title=" Prompt ",
         title_position="top",
-        color=tailwind_color("slate", 100),
+        foreground=tailwind_color("slate", 100),
     )
     footer: str = Field(
         default=(
@@ -387,7 +387,7 @@ class AgentChat(BaseGrid, direction="vertical", gap=0):
             "[enter] send  [q] quit"
         ),
         height=1,
-        color=tailwind_color("slate", 600),
+        foreground=tailwind_color("slate", 600),
     )
 
     input_text: str = Field(default="", state=True)

--- a/examples/dashboard.py
+++ b/examples/dashboard.py
@@ -182,7 +182,7 @@ class Dashboard(BaseGrid, direction="vertical"):
     header: str = Field(
         default="   SUPER COOL VERY IMPORTANT DASHBOARD   ",
         height=1,
-        color="white",
+        foreground="white",
         background=tailwind_color("violet", 950),
         modifiers=["bold"],
     )
@@ -190,7 +190,7 @@ class Dashboard(BaseGrid, direction="vertical"):
     footer: str = Field(
         default="  [Ctrl+C] Quit  ●  [Up/Down] Navigate Table  ",
         height=1,
-        color=tailwind_color("slate", 500),
+        foreground=tailwind_color("slate", 500),
     )
 
     cpu_history: list = Field(

--- a/examples/effects_demo.py
+++ b/examples/effects_demo.py
@@ -93,7 +93,7 @@ class EffectsDemo(BaseGrid, direction="vertical"):
     header: str = Field(
         default="  TACHYONFX VISUAL EFFECTS ANIMATION DEMO  ",
         height=1,
-        color="white",
+        foreground="white",
         background=tailwind_color("teal", 900),
         modifiers=["bold"],
     )
@@ -110,7 +110,7 @@ class EffectsDemo(BaseGrid, direction="vertical"):
             "  [Ctrl+C] Quit Demo"
         ),
         height=3,
-        color=tailwind_color("slate", 400),
+        foreground=tailwind_color("slate", 400),
         modifiers=["italic"],
     )
 
@@ -121,7 +121,7 @@ class EffectsDemo(BaseGrid, direction="vertical"):
     def _switch_effect(self, key: str) -> None:
         self.current_key = key
         self.phase = 0.0
-        self.grid_play_effect(_build_canvas_effect(key), fields=["canvas"])
+        self.grid_effect(_build_canvas_effect(key), fields=["canvas"])
 
     @on_keyboard("c")
     def _coalesce(self) -> None:

--- a/examples/feed.py
+++ b/examples/feed.py
@@ -218,7 +218,7 @@ class ServiceGraph(Component):
                 CanvasPrint(
                     x=0.5,
                     y=val,
-                    content=Run(text=label, color=axis_c),
+                    content=Run(text=label, foreground=axis_c),
                 )
             )
 
@@ -242,11 +242,11 @@ class ServiceTable(Component):
         dim = tailwind_color("slate", 500)
         header = TableRow(
             cells=(
-                TableCell(content="", color=dim),
-                TableCell(content=" Service ", color=dim),
-                TableCell(content=" RPS  ", color=dim),
-                TableCell(content=" Err% ", color=dim),
-                TableCell(content=" p95 ", color=dim),
+                TableCell(content="", foreground=dim),
+                TableCell(content=" Service ", foreground=dim),
+                TableCell(content=" RPS  ", foreground=dim),
+                TableCell(content=" Err% ", foreground=dim),
+                TableCell(content=" p95 ", foreground=dim),
             ),
             height=1,
         )
@@ -267,29 +267,29 @@ class ServiceTable(Component):
                         TableCell(
                             content=Run(
                                 text=f" {sym} ",
-                                color=sc,
+                                foreground=sc,
                                 modifiers=("bold",),
                             )
                         ),
                         TableCell(
                             content=Run(
                                 text=f" {svc:<7}",
-                                color=_SVC_TEXT[svc],
+                                foreground=_SVC_TEXT[svc],
                                 modifiers=("bold",),
                             )
                         ),
                         TableCell(
                             content=f" {rps:>5.0f} ",
-                            color=tailwind_color("slate", 600),
+                            foreground=tailwind_color("slate", 600),
                         ),
                         TableCell(
                             content=Run(
-                                text=f" {err_pct:>4.1f}% ", color=err_c
+                                text=f" {err_pct:>4.1f}% ", foreground=err_c
                             )
                         ),
                         TableCell(
                             content=f" {p95:>3.0f}ms",
-                            color=tailwind_color("slate", 600),
+                            foreground=tailwind_color("slate", 600),
                         ),
                     ),
                     height=1,
@@ -328,7 +328,7 @@ class ErrorGauge(Component):
             label=f"  {self.service:<7}  {self.ratio * 100:.1f}%",
             filled_color=filled,
             unfilled_color=tailwind_color("slate", 500),
-            color=tailwind_color("slate", 700),
+            foreground=tailwind_color("slate", 700),
         )
 
 
@@ -377,12 +377,14 @@ class EventLog(Component):
         dim = tailwind_color("slate", 500)
         header = TableRow(
             cells=(
-                TableCell(content=" Time    ", color=dim),
-                TableCell(content=" Method ", color=dim),
-                TableCell(content=" Endpoint                  ", color=dim),
-                TableCell(content=" Status ", color=dim),
-                TableCell(content=" Latency ", color=dim),
-                TableCell(content=" Service ", color=dim),
+                TableCell(content=" Time    ", foreground=dim),
+                TableCell(content=" Method ", foreground=dim),
+                TableCell(
+                    content=" Endpoint                  ", foreground=dim
+                ),
+                TableCell(content=" Status ", foreground=dim),
+                TableCell(content=" Latency ", foreground=dim),
+                TableCell(content=" Service ", foreground=dim),
             ),
             height=1,
         )
@@ -410,28 +412,30 @@ class EventLog(Component):
                     cells=(
                         TableCell(
                             content=f" {ts}  ",
-                            color=tailwind_color("slate", 600),
+                            foreground=tailwind_color("slate", 600),
                         ),
                         TableCell(
-                            content=Run(text=f" {method:<6} ", color=mc)
+                            content=Run(text=f" {method:<6} ", foreground=mc)
                         ),
                         TableCell(
                             content=f" {endpoint:<28}",
-                            color=tailwind_color("slate", 600),
+                            foreground=tailwind_color("slate", 600),
                         ),
                         TableCell(
                             content=Run(
                                 text=f"  {status}  ",
-                                color=sc,
+                                foreground=sc,
                                 modifiers=("bold",),
                             )
                         ),
                         TableCell(
-                            content=Run(text=f" {latency:>5}ms ", color=lc)
+                            content=Run(
+                                text=f" {latency:>5}ms ", foreground=lc
+                            )
                         ),
                         TableCell(
                             content=Run(
-                                text=f" {svc:<8}", color=_SVC_TEXT[svc]
+                                text=f" {svc:<8}", foreground=_SVC_TEXT[svc]
                             )
                         ),
                     ),
@@ -560,14 +564,14 @@ class ApiMonitor(BaseGrid, direction="vertical"):
     header: str = Field(
         default="  API HEALTH MONITOR",
         height=1,
-        color=tailwind_color("sky", 500),
+        foreground=tailwind_color("sky", 500),
         modifiers=["bold"],
     )
     main: MainArea = Field(default_factory=MainArea)
     footer: str = Field(
         default="  [↑↓] Select service  [q] Quit",
         height=1,
-        color=tailwind_color("slate", 600),
+        foreground=tailwind_color("slate", 600),
     )
 
     rps_history: dict = Field(default_factory=_seed_rps, state=True)

--- a/examples/kanban.py
+++ b/examples/kanban.py
@@ -168,14 +168,16 @@ class BoardTabs(Component):
             parts.append(
                 Run(
                     text=f"  {name}  ({self.counts[i]})  ",
-                    color=accent if active else tailwind_color("slate", 600),
+                    foreground=accent
+                    if active
+                    else tailwind_color("slate", 600),
                     background=_COL_HL_BG[i] if active else None,
                     modifiers=("bold",) if active else (),
                 )
             )
             if i < len(_COL_NAMES) - 1:
                 parts.append(
-                    Run(text=" │ ", color=tailwind_color("slate", 600))
+                    Run(text=" │ ", foreground=tailwind_color("slate", 600))
                 )
         return TextBlock.from_lines((tuple(parts),))
 
@@ -193,9 +195,9 @@ class TaskList(Component):
         dim = tailwind_color("slate", 500)
         header = TableRow(
             cells=(
-                TableCell(content=" Pri  ", color=dim),
-                TableCell(content="Task", color=dim),
-                TableCell(content="Tag   ", color=dim),
+                TableCell(content=" Pri  ", foreground=dim),
+                TableCell(content="Task", foreground=dim),
+                TableCell(content="Tag   ", foreground=dim),
             ),
             height=1,
         )
@@ -210,18 +212,18 @@ class TaskList(Component):
                         TableCell(
                             content=Run(
                                 text=f" {sym} {task.priority[:3]} ",
-                                color=pc,
+                                foreground=pc,
                                 modifiers=("bold",),
                             )
                         ),
                         TableCell(
                             content=f"  {task.title}",
-                            color=tailwind_color("slate", 700),
+                            foreground=tailwind_color("slate", 700),
                         ),
                         TableCell(
                             content=Run(
                                 text=f" #{task.tag}",
-                                color=tailwind_color("slate", 500),
+                                foreground=tailwind_color("slate", 500),
                             )
                         ),
                     ),
@@ -259,18 +261,18 @@ class ActivityFeed(Component):
                     cells=(
                         TableCell(
                             content=f" {ts} ",
-                            color=tailwind_color("slate", 600),
+                            foreground=tailwind_color("slate", 600),
                         ),
                         TableCell(
                             content=Run(
                                 text=f" {icon} ",
-                                color=_COL_ACCENTS[col_idx],
+                                foreground=_COL_ACCENTS[col_idx],
                                 modifiers=("bold",),
                             )
                         ),
                         TableCell(
                             content=f" {action}",
-                            color=tailwind_color("slate", 700),
+                            foreground=tailwind_color("slate", 700),
                         ),
                     ),
                     height=1,
@@ -331,7 +333,7 @@ class VelocityChart(Component):
                 CanvasPrint(
                     x=0.3,
                     y=val,
-                    content=Run(text=f"{val:.0f}", color=axis_c),
+                    content=Run(text=f"{val:.0f}", foreground=axis_c),
                 )
             )
 
@@ -406,7 +408,7 @@ class SprintGauge(Component):
             label=self.label,
             filled_color=self.filled or tailwind_color("violet", 500),
             unfilled_color=tailwind_color("slate", 600),
-            color=tailwind_color("slate", 700),
+            foreground=tailwind_color("slate", 700),
         )
 
 
@@ -487,14 +489,14 @@ class KanbanApp(BaseGrid, direction="vertical"):
     header: str = Field(
         default="  BOARD",
         height=1,
-        color=tailwind_color("violet", 500),
+        foreground=tailwind_color("violet", 500),
         modifiers=["bold"],
     )
     main: MainArea = Field(default_factory=MainArea)
     footer: str = Field(
         default="",
         height=1,
-        color=tailwind_color("slate", 600),
+        foreground=tailwind_color("slate", 600),
     )
 
     task_data: list = Field(

--- a/examples/tabs_nav.py
+++ b/examples/tabs_nav.py
@@ -146,14 +146,14 @@ class TabNav(BaseGrid, direction="vertical"):
         default=Text(""),
         border="rounded",
         border_color=tailwind_color("emerald", 500),
-        color=tailwind_color("slate", 300),
+        foreground=tailwind_color("slate", 300),
     )
     status: str = Field(
         default="",
         height=3,
         border="rounded",
         border_color=tailwind_color("slate", 700),
-        color=tailwind_color("slate", 400),
+        foreground=tailwind_color("slate", 400),
     )
 
     selected_tab: int = Field(default=0, state=True)

--- a/examples/web_counter.py
+++ b/examples/web_counter.py
@@ -48,7 +48,7 @@ class Counter(BaseGrid, direction="vertical", gap=1):
     body: str = Field(
         default="Click me (or press ↑)", border="rounded", title="counter"
     )
-    clock: str = Field(default="uptime: 0s", height=1, color="gray")
+    clock: str = Field(default="uptime: 0s", height=1, foreground="gray")
     count: int = Field(default=0, state=True)
     seconds: int = Field(default=0, state=True)
 

--- a/scripts/generate_component_demos.py
+++ b/scripts/generate_component_demos.py
@@ -200,7 +200,7 @@ DEMOS: tuple[Demo, ...] = (
                 status: str = Column(
                     color=lambda v: "green" if v == "ok" else "red"
                 )
-                latency: int = Column(align="right", format="{}ms")
+                latency: int = Column(horizontal_align="right", format="{}ms")
 
             Terminal.offscreen(cols=80, rows=5).render(
                 Services(

--- a/scripts/generate_hook_demos.py
+++ b/scripts/generate_hook_demos.py
@@ -76,7 +76,7 @@ def build_action_demo(
                 message: str = Field(
                     default="{before}",
                     height=1,
-                    align="center",
+                    horizontal_align="center",
                     color="slate-400",
                 )
 
@@ -138,13 +138,13 @@ def build_render_demo(
                 message: str = Field(
                     default="{message}",
                     height=1,
-                    align="center",
+                    horizontal_align="center",
                     color="violet-400",
                 )
                 detail: str = Field(
                     default="{detail}",
                     height=1,
-                    align="center",
+                    horizontal_align="center",
                     color="slate-400",
                 )
 
@@ -178,13 +178,13 @@ DEMOS: tuple[Demo, ...] = (
                 message: str = Field(
                     default="waiting for OPEN",
                     height=1,
-                    align="center",
+                    horizontal_align="center",
                     color="slate-400",
                 )
                 detail: str = Field(
                     default="one trigger · one dispatch path",
                     height=1,
-                    align="center",
+                    horizontal_align="center",
                     color="violet-400",
                 )
 

--- a/scripts/generate_readme_demos.py
+++ b/scripts/generate_readme_demos.py
@@ -231,8 +231,8 @@ DEMOS: tuple[Demo, ...] = (
             from xnano.context import Context
             from xnano.hooks import on_keyboard
 
-            class SidebarTitle(BaseGrid, align="center"):
-                title: str = Field("This is a title.", align="center")
+            class SidebarTitle(BaseGrid, horizontal_align="center"):
+                title: str = Field("This is a title.", horizontal_align="center")
 
             class Sidebar(BaseGrid, direction="vertical"):
                 title: SidebarTitle = Field(

--- a/scripts/generate_tutorial_demos.py
+++ b/scripts/generate_tutorial_demos.py
@@ -713,7 +713,7 @@ DEMOS: tuple[Demo, ...] = (
                 status: str = Column(
                     color=lambda v: "green" if v == "ok" else "red"
                 )
-                latency: int = Column(align="right", format="{}ms")
+                latency: int = Column(horizontal_align="right", format="{}ms")
 
             ROWS = [
                 {"service": "api", "status": "ok", "latency": 12},

--- a/tests/benchmarks/test_options_performance.py
+++ b/tests/benchmarks/test_options_performance.py
@@ -8,11 +8,11 @@ Track large dynamic option-list filtering and rendering.
 import sys
 from typing import Any
 
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.options import Option, Options
 from xnano.core.content import Items
 from xnano.core.runtime import Runtime
-from xnano.types import Area
 
 _ITEMS = tuple(
     Option(label=f"model-{index:04d}", value=index) for index in range(3_000)

--- a/tests/components/test_bar.py
+++ b/tests/components/test_bar.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 import pytest
 
+from xnano.area import Area
 from xnano.components.bar import (
     Bar,
     Sparkline,
@@ -15,7 +16,6 @@ from xnano.components.component import ComponentRenderContext
 from xnano.core import Runtime
 from xnano.core.content import CellCanvas
 from xnano.core.content import Sparkline as SparklineContent
-from xnano.types import Area
 
 
 def _ctx(width: int = 20, height: int = 3) -> ComponentRenderContext[Any]:

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from xnano.actions import Action
+from xnano.area import Area
 from xnano.components.button import Button
 from xnano.components.component import ComponentRenderContext
 from xnano.components.dropdown import Dropdown
@@ -14,7 +15,7 @@ from xnano.core.runtime import Runtime
 from xnano.fields import Field
 from xnano.grids import BaseGrid
 from xnano.hooks import on_click
-from xnano.types import Area, is_focusable_component
+from xnano.types import is_focusable_component
 
 
 def _ctx() -> ComponentRenderContext[Any]:

--- a/tests/components/test_chart.py
+++ b/tests/components/test_chart.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from xnano.area import Area
 from xnano.components.chart import Chart, Series
 from xnano.components.component import ComponentRenderContext
 from xnano.core import Runtime
 from xnano.core.content import Plot
-from xnano.types import Area
 
 
 def _ctx() -> ComponentRenderContext[Any]:

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -6,9 +6,9 @@ import sys
 from typing import Any, cast
 
 import xnano.components as components
+from xnano.area import Area, Size
 from xnano.components.component import Component, ComponentRenderContext
 from xnano.components.schema import Column
-from xnano.types import Area, Size
 
 
 def test_public_component_exports_are_resolvable() -> None:

--- a/tests/components/test_dropdown.py
+++ b/tests/components/test_dropdown.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.dropdown import Dropdown
 from xnano.components.options import Option
 from xnano.components.text import Text
 from xnano.core.content import Items, Stack, TextBlock
-from xnano.types import Area
 
 
 def _ctx() -> ComponentRenderContext[Any]:

--- a/tests/components/test_image.py
+++ b/tests/components/test_image.py
@@ -10,11 +10,11 @@ from typing import Any, cast
 import pytest
 
 import xnano.components.image as image_module
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.image import Image, ImageData, ImageFit, ImageFrame
 from xnano.core import Runtime
 from xnano.core.content import CellCanvas
-from xnano.types import Area
 
 
 def _ctx(width: int = 4, height: int = 2) -> ComponentRenderContext[Any]:
@@ -73,7 +73,7 @@ def test_compact_image_decodes_and_resizes_for_terminal_cells() -> None:
     assert isinstance(canvas, CellCanvas)
     assert len(canvas.rows) == 2
     assert len(canvas.rows[0]) == 4
-    assert {cell.color for row in canvas.rows for cell in row} >= {
+    assert {cell.foreground for row in canvas.rows for cell in row} >= {
         "#ff0000",
         "#00ff00",
     }
@@ -175,7 +175,7 @@ def test_image_data_frame_index_and_seek() -> None:
     assert image.get_frame_index(40) == 1
     image.seek(40)
     canvas = image.compose(_ctx(1, 1))
-    assert canvas.rows[0][0].color == "#0000ff"
+    assert canvas.rows[0][0].foreground == "#0000ff"
 
 
 def test_play_pause_preserves_position() -> None:
@@ -188,7 +188,7 @@ def test_play_pause_preserves_position() -> None:
     image.pause()
     assert image.playing is False
     canvas = image.compose(_ctx(1, 1))
-    assert canvas.rows[0][0].color == "#0000ff"
+    assert canvas.rows[0][0].foreground == "#0000ff"
     image.play()
     assert image.playing is True
 
@@ -273,7 +273,7 @@ def test_position_ms_override() -> None:
         position_ms=40,
     )
     canvas = image.compose(_ctx(1, 1))
-    assert canvas.rows[0][0].color == "#0000ff"
+    assert canvas.rows[0][0].foreground == "#0000ff"
 
 
 def test_source_change_resets_playback_and_canvas_cache() -> None:
@@ -294,7 +294,7 @@ def test_source_change_resets_playback_and_canvas_cache() -> None:
     image.source = green
     second = image.compose(_ctx(1, 1))
     assert second is not first
-    assert second.rows[0][0].color == "#00ff00"
+    assert second.rows[0][0].foreground == "#00ff00"
     assert image._paused_elapsed_ms == 0.0
 
 
@@ -387,4 +387,4 @@ def test_transparent_stream_composites_over_configured_background() -> None:
 
     image = Image(source=stream, background=(255, 0, 0))
     canvas = image.compose(_ctx(1, 1))
-    assert canvas.rows[0][0].color == "#ff0000"
+    assert canvas.rows[0][0].foreground == "#ff0000"

--- a/tests/components/test_input.py
+++ b/tests/components/test_input.py
@@ -6,12 +6,12 @@ from typing import Any, cast
 
 import pytest
 
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.input import Input
 from xnano.components.text import Text
 from xnano.core import Runtime
 from xnano.core.content import TextBlock
-from xnano.types import Area
 
 
 def test_input_forces_input_true() -> None:

--- a/tests/components/test_link.py
+++ b/tests/components/test_link.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from xnano.actions import Action
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.link import Link
 from xnano.components.text import Text
@@ -13,7 +14,6 @@ from xnano.core.content import TextBlock
 from xnano.fields import Field
 from xnano.grids import BaseGrid
 from xnano.hooks import on_keyboard
-from xnano.types import Area
 
 
 def _ctx() -> ComponentRenderContext[None]:
@@ -27,7 +27,7 @@ def test_link_defaults() -> None:
     assert link.content == "docs"
     assert link.focusable is True
     assert link.underline is True
-    assert link.color == "blue"
+    assert link.foreground == "blue"
     assert link.visited is False
     assert link.input is False
 
@@ -52,7 +52,7 @@ def test_link_compose_underline_and_color() -> None:
     content = link.compose(_ctx())
     assert isinstance(content, TextBlock)
     assert content.text == "docs"
-    assert content.color == "blue"
+    assert content.foreground == "blue"
     assert "underline" in content.modifiers
 
 
@@ -65,14 +65,14 @@ def test_link_focused_color() -> None:
     link._input_focused = True
     content = link.compose(_ctx())
     assert isinstance(content, TextBlock)
-    assert content.color == "cyan"
+    assert content.foreground == "cyan"
 
 
 def test_visited_link_uses_default_visited_cue() -> None:
     link = Link("docs", url="/docs", visited=True)
     content = link.compose(_ctx())
     assert isinstance(content, TextBlock)
-    assert content.color == "magenta"
+    assert content.foreground == "magenta"
 
 
 def test_link_activation_keys_not_consumed() -> None:
@@ -127,7 +127,7 @@ def test_link_activation_updates_composed_navigation() -> None:
         frame = runtime.render()
         assert navigation.docs.visited is True
         assert "https://example.com/docs" in frame.text
-        assert navigation.docs.color == "blue"
+        assert navigation.docs.foreground == "blue"
         assert navigation.docs.modifiers == ()
     finally:
         runtime.close()

--- a/tests/components/test_loader.py
+++ b/tests/components/test_loader.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import pytest
 
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.loader import (
     Loader,
@@ -16,7 +17,6 @@ from xnano.components.loader import (
 from xnano.components.text import Text
 from xnano.core import Runtime
 from xnano.core.content import Gauge, LineGauge, TextBlock
-from xnano.types import Area
 
 
 def _ctx() -> ComponentRenderContext[Any]:

--- a/tests/components/test_markdown_component.py
+++ b/tests/components/test_markdown_component.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import pathlib
 
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.markdown import Markdown
 from xnano.components.text import Text
 from xnano.core import Runtime
 from xnano.core.content import TextBlock
-from xnano.types import Area
 
 
 def _ctx() -> ComponentRenderContext[None]:

--- a/tests/components/test_options.py
+++ b/tests/components/test_options.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.options import (
     Option,
@@ -13,7 +14,7 @@ from xnano.components.options import (
 )
 from xnano.components.text import Text
 from xnano.core.content import Items, Stack
-from xnano.types import Area, is_focusable_component
+from xnano.types import is_focusable_component
 
 
 def _ctx() -> ComponentRenderContext[Any]:

--- a/tests/components/test_scrollbar.py
+++ b/tests/components/test_scrollbar.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.scrollbar import Scrollbar
 from xnano.core import Runtime
 from xnano.core.content import Scrollbar as ScrollbarContent
-from xnano.types import Area
 
 
 def _ctx() -> ComponentRenderContext[Any]:

--- a/tests/components/test_table.py
+++ b/tests/components/test_table.py
@@ -7,11 +7,11 @@ from typing import Any, cast
 
 import pytest
 
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.table import Column, Table
 from xnano.core import Runtime
 from xnano.core.content import TableGrid
-from xnano.types import Area
 
 
 def _ctx() -> ComponentRenderContext[Any]:
@@ -76,7 +76,11 @@ def test_columns_dict_with_column_spec() -> None:
     node = _node(
         Table(
             data=_ROWS,
-            columns={"latency": Column(format="{}ms", align="right", width=6)},
+            columns={
+                "latency": Column(
+                    format="{}ms", horizontal_align="right", width=6
+                )
+            },
         )
     )
     assert _cell_text(node.rows[0].cells[0]).strip() == "12ms"
@@ -123,8 +127,8 @@ def test_callable_column_and_object_rows_form_a_projection() -> None:
 
 class Services(Table):
     service: str = Column()
-    status: str = Column(color=lambda v: "green" if v == "ok" else "red")
-    latency: int = Column(align="right", format="{}ms", width=8)
+    status: str = Column(foreground=lambda v: "green" if v == "ok" else "red")
+    latency: int = Column(horizontal_align="right", format="{}ms", width=8)
 
 
 def test_subclass_captures_declared_columns() -> None:
@@ -215,7 +219,7 @@ def test_fixed_width_alignment(align: str, expected: str) -> None:
     node = _node(
         Table(
             data=[{"value": "x"}],
-            columns={"value": Column(width=4, align=align)},  # type: ignore[arg-type]
+            columns={"value": Column(width=4, horizontal_align=align)},  # type: ignore[arg-type]
         )
     )
     assert _cell_text(node.rows[0].cells[0]) == expected

--- a/tests/components/test_text.py
+++ b/tests/components/test_text.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from xnano.actions import Action
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.text import Text
 from xnano.core import Runtime
@@ -14,7 +15,6 @@ from xnano.core.content import Panel, TextBlock
 from xnano.fields import Field
 from xnano.grids import BaseGrid
 from xnano.hooks import on_keyboard
-from xnano.types import Area
 
 
 def _ctx() -> ComponentRenderContext[Any]:
@@ -207,7 +207,7 @@ def test_placeholder_when_empty_unfocused() -> None:
     content = text.compose(_ctx())
     assert isinstance(content, TextBlock)
     assert content.text == "type here"
-    assert content.color == "gray"
+    assert content.foreground == "gray"
 
 
 def test_styled_placeholder_keeps_component_color() -> None:
@@ -219,7 +219,7 @@ def test_styled_placeholder_keeps_component_color() -> None:
     content = text.compose(_ctx())
     assert isinstance(content, TextBlock)
     assert content.text == "search logs"
-    assert content.color == "yellow"
+    assert content.foreground == "yellow"
     assert "dim" in content.modifiers
 
 
@@ -270,7 +270,7 @@ def test_compose_plain() -> None:
     content = text.compose(_ctx())
     assert isinstance(content, TextBlock)
     assert content.text == "hello"
-    assert content.color == "cyan"
+    assert content.foreground == "cyan"
 
 
 def test_nested_text_shapes_preserve_rows_and_styles() -> None:
@@ -290,7 +290,7 @@ def test_nested_text_shapes_preserve_rows_and_styles() -> None:
         "second",
         "third",
     ]
-    assert lines.lines[0][0].color == "cyan"
+    assert lines.lines[0][0].foreground == "cyan"
 
     leaf = Text("leaf", foreground="green")
     assert leaf._as_children() == [leaf]

--- a/tests/core/test_core_public_compositions.py
+++ b/tests/core/test_core_public_compositions.py
@@ -152,7 +152,7 @@ def test_canvas_overview_combines_geometry_and_styled_annotations() -> None:
                     y=5,
                     content=Run(
                         text="LIVE",
-                        color="white",
+                        foreground="white",
                         modifiers=("bold",),
                     ),
                 ),

--- a/tests/stress/test_options_scale.py
+++ b/tests/stress/test_options_scale.py
@@ -9,11 +9,11 @@ import sys
 import threading
 from typing import Any
 
+from xnano.area import Area
 from xnano.components.component import ComponentRenderContext
 from xnano.components.options import Option, Options
 from xnano.core.content import Items, Stack
 from xnano.core.runtime import Runtime
-from xnano.types import Area
 
 
 def _large_items(prefix: str = "model") -> tuple[Option, ...]:

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,0 +1,222 @@
+"""tests.test_alignment
+
+---
+
+Covers ``horizontal_align``/``vertical_align`` on fields and the shared
+`xnano.area.align_area` helper they route through, plus the deprecated
+``align`` alias.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from xnano.area import Alignment, Area, VerticalAlignment, align_area
+from xnano.components.text import Text
+from xnano.fields import Field
+from xnano.grids import BaseGrid
+from xnano.terminal import Terminal
+
+
+def _row_of(text: str, needle: str) -> int:
+    """Return the 0-indexed row containing ``needle``."""
+    for index, line in enumerate(text.splitlines()):
+        if needle in line:
+            return index
+    raise AssertionError(f"{needle!r} not found in frame:\n{text}")
+
+
+def _column_of(text: str, needle: str) -> int:
+    for line in text.splitlines():
+        if needle in line:
+            return line.index(needle)
+    raise AssertionError(f"{needle!r} not found in frame:\n{text}")
+
+
+def test_align_area_places_box_on_both_axes() -> None:
+    outer = Area(x=0, y=0, width=10, height=9)
+    assert align_area(outer, 4, 3) == Area(x=0, y=0, width=4, height=3)
+    assert align_area(
+        outer, 4, 3, horizontal="center", vertical="middle"
+    ) == Area(x=3, y=3, width=4, height=3)
+    assert align_area(
+        outer, 4, 3, horizontal="right", vertical="bottom"
+    ) == Area(x=6, y=6, width=4, height=3)
+
+
+def test_align_area_clamps_to_the_outer_area() -> None:
+    outer = Area(x=2, y=1, width=5, height=4)
+    assert align_area(
+        outer, 99, 99, horizontal="right", vertical="bottom"
+    ) == (Area(x=2, y=1, width=5, height=4))
+
+
+@pytest.mark.parametrize(
+    ("vertical_align", "expected_row"),
+    (("top", 0), ("middle", 5), ("bottom", 11)),
+)
+def test_vertical_align_moves_content_down_the_slot(
+    vertical_align: VerticalAlignment, expected_row: int
+) -> None:
+    class App(BaseGrid):
+        body: str = Field(
+            default="MARK",
+            vertical_align=vertical_align,
+        )
+
+    terminal = Terminal.offscreen(cols=20, rows=12)
+    try:
+        terminal.attach_grid(App())
+        frame = terminal.render()
+        assert _row_of(frame.text, "MARK") == expected_row
+    finally:
+        terminal.close()
+
+
+@pytest.mark.parametrize(
+    ("horizontal_align", "expected_column"),
+    (("left", 0), ("center", 8), ("right", 16)),
+)
+def test_horizontal_align_moves_content_across_the_slot(
+    horizontal_align: Alignment, expected_column: int
+) -> None:
+    class App(BaseGrid):
+        body: str = Field(
+            default="MARK",
+            horizontal_align=horizontal_align,
+        )
+
+    terminal = Terminal.offscreen(cols=20, rows=4)
+    try:
+        terminal.attach_grid(App())
+        frame = terminal.render()
+        assert _column_of(frame.text, "MARK") == expected_column
+    finally:
+        terminal.close()
+
+
+def test_both_axes_compose_independently() -> None:
+    class App(BaseGrid):
+        body: str = Field(
+            default="MARK",
+            horizontal_align="right",
+            vertical_align="bottom",
+        )
+
+    terminal = Terminal.offscreen(cols=20, rows=8)
+    try:
+        terminal.attach_grid(App())
+        frame = terminal.render()
+        assert _row_of(frame.text, "MARK") == 7
+        assert _column_of(frame.text, "MARK") == 16
+    finally:
+        terminal.close()
+
+
+def test_vertical_align_never_clips_multiline_content() -> None:
+    """Alignment only moves the origin; it must not shrink the slot.
+
+    A value taller than its measured height would otherwise lose rows.
+    """
+
+    class App(BaseGrid):
+        body: str = Field(default="A\nB\nC", vertical_align="middle")
+
+    terminal = Terminal.offscreen(cols=12, rows=9)
+    try:
+        terminal.attach_grid(App())
+        frame = terminal.render()
+        for line in ("A", "B", "C"):
+            assert line in frame.text
+        assert _row_of(frame.text, "A") == 3
+    finally:
+        terminal.close()
+
+
+def test_component_values_honor_field_vertical_align() -> None:
+    """A component's height is measured from its text, not ``get_size``.
+
+    ``Text.get_size`` reports 0 for the zero-height probe area, which
+    would silently skip alignment for every component field.
+    """
+
+    class App(BaseGrid):
+        header: str = Field(default="HEAD", height=1)
+        body: Text = Field(
+            default_factory=lambda: Text("MARK"),
+            vertical_align="middle",
+        )
+
+    terminal = Terminal.offscreen(cols=20, rows=9)
+    try:
+        terminal.attach_grid(App())
+        frame = terminal.render()
+        # header owns row 0; the 8 remaining rows centre a 1-line body.
+        assert _row_of(frame.text, "MARK") == 4
+    finally:
+        terminal.close()
+
+
+def test_align_alias_warns_and_sets_horizontal_align() -> None:
+    with pytest.warns(DeprecationWarning):
+        field = Field(default="", align="center")
+    assert getattr(field, "horizontal_align") == "center"
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        canonical = Field(default="", horizontal_align="right")
+    assert getattr(canonical, "horizontal_align") == "right"
+
+
+def test_horizontal_align_wins_over_deprecated_align() -> None:
+    with pytest.warns(DeprecationWarning):
+        field = Field(default="", horizontal_align="right", align="center")
+    assert getattr(field, "horizontal_align") == "right"
+
+
+def test_text_component_align_alias_round_trips() -> None:
+    with pytest.warns(DeprecationWarning):
+        text = Text("x", align="center")  # ty: ignore[unknown-argument]
+    assert text.horizontal_align == "center"
+    assert text.align == "center"  # ty: ignore[unresolved-attribute]
+
+
+def test_grid_set_field_align_alias() -> None:
+    class App(BaseGrid):
+        body: str = Field(default="hi")
+
+    grid = App()
+    with pytest.warns(DeprecationWarning):
+        grid.grid_set_field("body", align="center")
+    overrides = grid._grid_field_overrides  # ty: ignore[unresolved-attribute]
+    assert overrides["body"].horizontal_align == "center"
+
+
+def test_wrapped_text_measures_its_real_row_count() -> None:
+    """Wrapping makes a one-line string taller than ``splitlines()`` says."""
+    from xnano.core.controller import wrapped_line_count
+
+    assert wrapped_line_count("short", 20) == 1
+    assert wrapped_line_count("a\nb\nc", 20) == 3
+    assert wrapped_line_count("word " * 12, 20) > 1
+    assert wrapped_line_count("x" * 45, 10) == 5
+    assert wrapped_line_count("anything", 0) == 1
+
+
+def test_vertical_align_accounts_for_wrapping() -> None:
+    text = "lorem ipsum dolor sit amet consectetur adipiscing elit sed do"
+
+    class App(BaseGrid):
+        body: str = Field(default=text, vertical_align="bottom")
+
+    terminal = Terminal.offscreen(cols=20, rows=12)
+    try:
+        terminal.attach_grid(App())
+        frame = terminal.render()
+        # Bottom-aligned wrapped text must still show its last word.
+        assert "do" in frame.text
+        assert _row_of(frame.text, "lorem") > 0
+    finally:
+        terminal.close()

--- a/tests/test_color_alias_and_text_default.py
+++ b/tests/test_color_alias_and_text_default.py
@@ -105,6 +105,120 @@ def test_color_forms_flow_through_field_component_and_terminal() -> None:
         terminal.close()
 
 
+def test_grid_set_field_color_alias_warns_and_sets_foreground() -> None:
+    class App(BaseGrid):
+        label: str = Field(default="hi")
+
+    grid = App()
+    with pytest.warns(DeprecationWarning):
+        grid.grid_set_field(
+            "label",
+            color="cyan",
+        )
+    overrides = grid._grid_field_overrides  # ty: ignore[unresolved-attribute]
+    assert overrides["label"].foreground == "cyan"
+
+
+def test_grid_update_field_foreground_wins_over_color() -> None:
+    class App(BaseGrid):
+        label: str = Field(default="hi")
+
+    grid = App()
+    with pytest.warns(DeprecationWarning):
+        grid.grid_update_field(
+            "label",
+            foreground="red",
+            color="blue",
+        )
+    overrides = grid._grid_field_overrides  # ty: ignore[unresolved-attribute]
+    assert overrides["label"].foreground == "red"
+
+
+def test_grid_settings_color_class_kwarg_maps_to_foreground() -> None:
+    with pytest.warns(DeprecationWarning):
+
+        class Aliased(BaseGrid, color="red"):
+            pass
+
+    assert Aliased.grid_settings["foreground"] == "red"
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        class Canonical(BaseGrid, foreground="blue"):
+            pass
+
+    assert Canonical.grid_settings["foreground"] == "blue"
+
+
+def test_content_primitive_color_alias_round_trips() -> None:
+    from xnano.core.content import Run, TextBlock
+
+    with pytest.warns(DeprecationWarning):
+        run = Run(
+            text="x",
+            color="cyan",  # ty: ignore[unknown-argument]
+        )
+    assert run.foreground == "cyan"
+    assert run.color == "cyan"  # ty: ignore[unresolved-attribute]
+
+    # Classmethod constructors carry the alias too — the dataclass
+    # decorator only wraps ``__init__``.
+    with pytest.warns(DeprecationWarning):
+        block = TextBlock.from_plain(
+            "x",
+            color="lime",
+        )
+    assert block.foreground == "lime"
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert (
+            TextBlock.from_plain("x", foreground="lime").foreground == "lime"
+        )
+
+
+def test_paint_cell_color_alias_maps_to_foreground() -> None:
+    from xnano.core.stage import Stage
+
+    stage = Stage()
+    with pytest.warns(DeprecationWarning):
+        stage.paint_cell(
+            0,
+            0,
+            "!",
+            color="yellow",
+        )
+    assert stage._commands[0]["foreground"] == "yellow"
+
+
+def test_link_foreground_is_not_shadowed_by_color() -> None:
+    """``Link`` redeclared ``color``, shadowing ``Text``'s alias property.
+
+    That made ``Link(foreground=...)`` silently render the default blue.
+    """
+    from xnano.components.link import Link
+
+    assert Link(content="x").foreground == "blue"
+    assert Link(content="x", foreground="red").foreground == "red"
+    with pytest.warns(DeprecationWarning):
+        aliased = Link(
+            content="x",
+            color="green",  # ty: ignore[unknown-argument]
+        )
+    assert aliased.foreground == "green"
+
+
+def test_effect_surfaces_keep_color_without_warning() -> None:
+    """Effects intentionally keep ``color``/``background`` — no rename."""
+    from xnano.effects import Effect, FadeEffect
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert FadeEffect(color="violet").color == "violet"
+        assert Effect("fade", color="violet", duration_ms=10) is not None
+
+
 def test_color_inputs_share_one_conversion_contract() -> None:
     assert Color.parse("red").as_rgb_tuple() == (255, 0, 0)
     assert Color.parse("#0f08").as_hex(include_alpha=True) == "#00ff0088"

--- a/tests/test_component_base.py
+++ b/tests/test_component_base.py
@@ -15,7 +15,7 @@ class Badge(Component):
     color: str = "cyan"
 
     def compose(self, ctx):
-        return TextBlock.from_plain(self.text, color=self.color)
+        return TextBlock.from_plain(self.text, foreground=self.color)
 
 
 def test_minimum_custom_component() -> None:

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,0 +1,252 @@
+"""tests.test_effects
+
+---
+
+Covers ``grid_effect`` end to end through the public API: that an effect
+actually changes rendered output, that it advances across frames without
+blocking hook logic, and that the handle's ``cancel``/context-manager
+forms stop it.
+
+Existing effect coverage asserted only that ``grid_play_effect`` returned
+``True`` — which merely means the field had a painted rect. These tests
+inspect the rendered cells instead.
+"""
+
+from __future__ import annotations
+
+import time
+import warnings
+
+import pytest
+
+from xnano.actions import TickAction
+from xnano.effects import Effect, EffectHandle, FadeEffect
+from xnano.fields import Field
+from xnano.grids import BaseGrid
+from xnano.hooks import on_tick
+from xnano.terminal import Terminal
+
+
+class _App(BaseGrid):
+    body: str = Field(default="EFFECTTEXT", background="black")
+
+
+def _attached(cols: int = 24, rows: int = 6):
+    terminal = Terminal.offscreen(cols=cols, rows=rows)
+    grid = _App()
+    terminal.attach_grid(grid)
+    terminal.render()  # records effect areas for the fields
+    return terminal, grid
+
+
+def test_effect_changes_rendered_cells() -> None:
+    """The whole point: playing an effect must alter painted output."""
+    terminal, grid = _attached()
+    try:
+        before = terminal.get_output_as_ansi()
+        handle = grid.grid_effect(
+            "paint_fg", color="#ff0000", duration_ms=400, fields=["body"]
+        )
+        assert handle
+        terminal.render()
+        after = terminal.get_output_as_ansi()
+        assert after != before
+        assert "38;2;255;0;0" in after
+    finally:
+        terminal.close()
+
+
+def test_effect_advances_across_frames_and_completes() -> None:
+    terminal, grid = _attached()
+    try:
+        grid.grid_effect("fade", duration_ms=60, fields=["body"])
+        terminal.render()
+        assert terminal.runtime.is_animating()
+        time.sleep(0.12)
+        terminal.render()
+        assert not terminal.runtime.is_animating()
+    finally:
+        terminal.close()
+
+
+def test_starting_an_effect_does_not_block() -> None:
+    """``duration_ms`` is an animation length, never a sleep."""
+    terminal, grid = _attached()
+    try:
+        started = time.monotonic()
+        grid.grid_effect("fade", duration_ms=5_000, fields=["body"])
+        assert time.monotonic() - started < 1.0
+    finally:
+        terminal.close()
+
+
+def test_handle_cancel_stops_the_effect() -> None:
+    terminal, grid = _attached()
+    try:
+        handle = grid.grid_effect("fade", duration_ms=5_000, fields=["body"])
+        terminal.render()
+        assert terminal.runtime.is_animating()
+        assert handle.active
+        handle.cancel()
+        terminal.render()
+        assert not terminal.runtime.is_animating()
+        assert not handle.active
+    finally:
+        terminal.close()
+
+
+def test_cancel_is_idempotent() -> None:
+    terminal, grid = _attached()
+    try:
+        handle = grid.grid_effect("fade", duration_ms=500, fields=["body"])
+        handle.cancel()
+        handle.cancel()
+        assert not handle.active
+    finally:
+        terminal.close()
+
+
+def test_context_manager_scopes_the_effect_to_the_block() -> None:
+    terminal, grid = _attached()
+    try:
+        with grid.grid_effect("fade", fields=["body"]) as handle:
+            terminal.render()
+            assert terminal.runtime.is_animating()
+            assert handle.active
+        terminal.render()
+        assert not terminal.runtime.is_animating()
+    finally:
+        terminal.close()
+
+
+def test_context_manager_effect_outlives_its_default_duration() -> None:
+    """Without an explicit duration the block-scoped effect loops.
+
+    A plain 300ms effect would finish on its own well inside this block.
+    """
+    terminal, grid = _attached()
+    try:
+        with grid.grid_effect("fade", fields=["body"]):
+            terminal.render()
+            time.sleep(0.45)
+            terminal.render()
+            assert terminal.runtime.is_animating()
+        terminal.render()
+        assert not terminal.runtime.is_animating()
+    finally:
+        terminal.close()
+
+
+def test_context_manager_cancels_even_when_the_block_raises() -> None:
+    terminal, grid = _attached()
+    try:
+        with pytest.raises(RuntimeError):
+            with grid.grid_effect("fade", fields=["body"]):
+                terminal.render()
+                raise RuntimeError("boom")
+        terminal.render()
+        assert not terminal.runtime.is_animating()
+    finally:
+        terminal.close()
+
+
+def test_key_dedupes_repeated_starts_instead_of_stacking() -> None:
+    terminal, grid = _attached()
+    try:
+        first = grid.grid_effect(
+            "fade", duration_ms=500, fields=["body"], key="spin"
+        )
+        for _ in range(5):
+            grid.grid_effect(
+                "fade", duration_ms=500, fields=["body"], key="spin"
+            )
+        assert first.keys == ("spin:body",)
+        # One key means one registered effect; cancelling it stops
+        # everything rather than leaving four more running.
+        terminal.render()
+        assert terminal.runtime.is_animating()
+        first.cancel()
+        terminal.render()
+        assert not terminal.runtime.is_animating()
+    finally:
+        terminal.close()
+
+
+def test_effect_from_on_tick_does_not_stall_other_hook_logic() -> None:
+    class TickApp(BaseGrid):
+        body: str = Field(default="TICKING", background="black")
+        ticks: int = Field(default=0, state=True)
+
+        @on_tick
+        def _pulse(self) -> None:
+            self.ticks += 1
+            self.grid_effect(
+                "fade", duration_ms=200, fields=["body"], key="pulse"
+            )
+
+    terminal = Terminal.offscreen(cols=24, rows=6)
+    try:
+        grid = TickApp()
+        terminal.attach_grid(grid)
+        terminal.render()
+        for _ in range(5):
+            terminal.runtime.perform(TickAction(interval_ms=16))
+            terminal.render()
+        # The hook kept running on every tick while the effect played.
+        assert grid.ticks >= 5
+    finally:
+        terminal.close()
+
+
+def test_handle_is_falsy_when_no_field_matched() -> None:
+    terminal, grid = _attached()
+    try:
+        handle = grid.grid_effect("fade", fields=["does_not_exist"])
+        assert not handle
+        assert handle.keys == ()
+        assert not handle.active
+        handle.cancel()
+    finally:
+        terminal.close()
+
+
+def test_handle_without_runtime_is_inert() -> None:
+    handle = EffectHandle()
+    assert not handle
+    assert not handle.active
+    handle.cancel()
+
+
+def test_effect_instances_are_accepted_alongside_kind_strings() -> None:
+    terminal, grid = _attached()
+    try:
+        assert grid.grid_effect(FadeEffect(duration_ms=50), fields=["body"])
+        assert grid.grid_effect(
+            Effect("coalesce", duration_ms=50), fields=["body"]
+        )
+    finally:
+        terminal.close()
+
+
+def test_grid_play_effect_still_works_and_warns() -> None:
+    terminal, grid = _attached()
+    try:
+        with pytest.warns(DeprecationWarning):
+            played = grid.grid_play_effect(
+                "fade", duration_ms=100, fields=["body"]
+            )
+        assert played is True
+        with pytest.warns(DeprecationWarning):
+            assert grid.grid_play_effect("fade", fields=["missing"]) is False
+    finally:
+        terminal.close()
+
+
+def test_grid_effect_is_the_non_deprecated_path() -> None:
+    terminal, grid = _attached()
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert grid.grid_effect("fade", fields=["body"])
+    finally:
+        terminal.close()

--- a/tests/test_field_component_matrix.py
+++ b/tests/test_field_component_matrix.py
@@ -91,7 +91,8 @@ _FIELD_PROFILES: tuple[tuple[str, dict[str, Any]], ...] = (
             "height": "75%",
             "gap": 1,
             "direction": "horizontal",
-            "align": "center",
+            "horizontal_align": "center",
+            "vertical_align": "middle",
         },
     ),
     (
@@ -173,9 +174,10 @@ def test_every_field_parameter_is_explicitly_covered() -> None:
         "strict",
         "init",
         "visible",
-        # Deprecated alias for ``foreground`` (covered via the ``style``
-        # profile); kept in the signature for backward compatibility.
+        # Deprecated aliases (covered via the ``style`` and ``layout``
+        # profiles); kept in the signature for backward compatibility.
         "color",
+        "align",
         # Out-of-flow overlay: exercised on its own in test_grids, not through
         # the in-flow render matrix (it would remove the field from layout).
         "overlay",
@@ -208,7 +210,7 @@ def test_field_options_work_together_on_container_values() -> None:
             height="fit",
             gap=1,
             direction="vertical",
-            align="center",
+            horizontal_align="center",
             border="double",
             border_color="cyan",
             title="Rows",

--- a/tests/test_grid_namespacing.py
+++ b/tests/test_grid_namespacing.py
@@ -1,0 +1,118 @@
+"""tests.test_grid_namespacing
+
+---
+
+Covers the ``grid_*`` / ``__xnano_*__`` naming convention on ``BaseGrid``
+and ``AbstractInterface``: every public member follows it, the previous
+names still work as deprecated aliases, and ``__xnano_grid__`` identifies
+a grid without importing ``BaseGrid``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from xnano.components.text import Text
+from xnano.fields import Field
+from xnano.grids import BaseGrid
+from xnano.types import is_grid
+
+_EXEMPT = frozenset({"z", "rows", "columns", "visible"})
+
+
+class _App(BaseGrid):
+    body: str = Field(default="hi")
+
+
+def _is_deprecated(member: object) -> bool:
+    """Whether a class member carries PEP 702 deprecation metadata."""
+    if isinstance(member, property):
+        member = member.fget
+    return hasattr(member, "__deprecated__")
+
+
+def test_every_public_grid_member_follows_the_convention() -> None:
+    offenders = [
+        name
+        for name in dir(BaseGrid)
+        if not name.startswith("_")
+        and name not in _EXEMPT
+        and not name.startswith("grid_")
+        # Deprecated aliases are kept deliberately; they carry PEP 702
+        # metadata so type checkers strike them through.
+        and not _is_deprecated(getattr(BaseGrid, name, None))
+    ]
+    assert offenders == []
+
+
+def test_dunder_members_are_xnano_namespaced_or_python_protocol() -> None:
+    xnano_dunders = [
+        name
+        for name in vars(BaseGrid)
+        if name.startswith("__") and name.endswith("__") and "xnano" in name
+    ]
+    assert "__xnano_grid__" in xnano_dunders
+
+
+def test_is_grid_identifies_grids_without_importing_basegrid() -> None:
+    assert is_grid(_App())
+    assert not is_grid(Text("x"))
+    assert not is_grid("plain")
+    assert not is_grid(None)
+
+
+def test_grid_focused_and_grid_state_are_the_canonical_names() -> None:
+    grid = _App()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert grid.grid_focused is False
+        assert grid.grid_state is None
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    (
+        ("focused", "grid_focused"),
+        ("state", "grid_state"),
+    ),
+)
+def test_deprecated_properties_still_read_through(old: str, new: str) -> None:
+    grid = _App()
+    with pytest.warns(DeprecationWarning):
+        value = getattr(grid, old)
+    assert value == getattr(grid, new)
+
+
+def test_deprecated_methods_delegate_to_their_new_names() -> None:
+    grid = _App()
+    with pytest.warns(DeprecationWarning):
+        grid.set_background("black")
+    assert grid._grid_frame is not None
+    assert grid._grid_frame.background == "black"
+
+    calls: list[str] = []
+    with pytest.warns(DeprecationWarning):
+        grid.schedule_update(lambda: calls.append("ran"))
+    assert calls == ["ran"]
+
+
+def test_interface_state_helpers_are_renamed_with_aliases() -> None:
+    grid = _App()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        state = grid.grid_get_field_state("body")
+        assert state is not None
+        grid.grid_mark_field_dirty("body")
+
+    with pytest.warns(DeprecationWarning):
+        assert grid.get_field_state("body") is state
+    with pytest.warns(DeprecationWarning):
+        grid.mark_field_dirty("body")
+
+
+def test_field_state_storage_is_grid_namespaced() -> None:
+    grid = _App()
+    assert isinstance(grid._grid_field_states, dict)
+    assert "body" in grid._grid_field_states

--- a/tests/test_pyodide_docs.py
+++ b/tests/test_pyodide_docs.py
@@ -1,11 +1,17 @@
-"""Execute every runnable cell in ``docs/sandbox.md``.
+"""Execute every runnable ``pyodide`` cell across ``docs/``.
 
-The sandbox page is a gallery of ``pyodide`` fences that visitors run in the
+The docs site renders ``pyodide`` fences as galleries visitors run in the
 browser. Pyodide imports the same pure-Python ``xnano`` these tests do (only
 the ``xnano-core`` build differs), so if a cell drifts from the current API —
 a renamed import, a dropped keyword, a removed component — it breaks silently
 on the docs site. This module extracts each fence and executes it under the
 desktop build, turning "the docs still run" into a checked invariant.
+
+Pages are discovered by globbing ``docs/**/*.md`` rather than naming files,
+so reorganising the docs cannot silently disable this suite — the same
+approach ``scripts/set_version.py`` takes for its version pins. The
+``test_docs_have_runnable_cells`` floor is what catches a glob that stops
+matching.
 
 Only import/exec is asserted, not rendered output: these cells reach the same
 offscreen buffer path Pyodide uses (no ``.run()``, no live loop), and any API
@@ -23,17 +29,18 @@ from typing import Any
 
 import pytest
 
-_SANDBOX = pathlib.Path(__file__).resolve().parents[1] / "docs" / "sandbox.md"
+_DOCS = pathlib.Path(__file__).resolve().parents[1] / "docs"
 _FENCE = re.compile(r"^```pyodide[^\n]*\n(.*?)^```", re.MULTILINE | re.DOTALL)
 
 
-def _extract_cells() -> list[tuple[str, str]]:
-    """Return ``(test_id, code)`` for every pyodide fence, in page order.
+def _extract_page_cells(path: pathlib.Path) -> list[tuple[str, str]]:
+    """Return ``(test_id, code)`` for one page's fences, in page order.
 
-    Each id is the nearest preceding ``##`` heading (slugged) plus a counter,
-    so a failing cell points straight at its section.
+    Each id is the page stem plus the nearest preceding ``##`` heading
+    (slugged) and a counter, so a failing cell points straight at its
+    section on the site.
     """
-    text = _SANDBOX.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8")
     headings: dict[int, str] = {
         match.start(): match.group(1).strip()
         for match in re.finditer(r"^## (.+)$", text, re.MULTILINE)
@@ -43,22 +50,30 @@ def _extract_cells() -> list[tuple[str, str]]:
         prior = [pos for pos in headings if pos < fence.start()]
         section = headings[max(prior)] if prior else "intro"
         slug = re.sub(r"[^a-z0-9]+", "-", section.lower()).strip("-")
-        cells.append((f"{index}-{slug}", fence.group(1)))
+        cells.append((f"{path.stem}-{index}-{slug}", fence.group(1)))
+    return cells
+
+
+def _extract_cells() -> list[tuple[str, str]]:
+    """Return ``(test_id, code)`` for every pyodide fence under ``docs/``."""
+    cells: list[tuple[str, str]] = []
+    for path in sorted(_DOCS.rglob("*.md")):
+        cells.extend(_extract_page_cells(path))
     return cells
 
 
 _CELLS = _extract_cells()
 
 
-def test_sandbox_has_runnable_cells() -> None:
-    # Guard against a silently empty extraction (moved file, changed fence).
+def test_docs_have_runnable_cells() -> None:
+    # Guard against a silently empty extraction (moved docs, changed fence).
     assert len(_CELLS) >= 8
 
 
 @pytest.mark.parametrize(
     "code", [code for _, code in _CELLS], ids=[cid for cid, _ in _CELLS]
 )
-def test_sandbox_cell_executes(code: str) -> None:
+def test_docs_cell_executes(code: str) -> None:
     namespace: dict[str, Any] = {"__name__": "__sandbox__"}
     with contextlib.redirect_stdout(io.StringIO()):
-        exec(compile(code, "<sandbox.md>", "exec"), namespace)
+        exec(compile(code, "<docs>", "exec"), namespace)

--- a/tests/test_pyodide_render.py
+++ b/tests/test_pyodide_render.py
@@ -176,7 +176,7 @@ def test_single_non_grid_renderable_with_border() -> None:
 def test_cell_styles_are_preserved_as_ansi() -> None:
     with Terminal.offscreen(cols=12, rows=1) as terminal:
         ansi = terminal.render(
-            "painted", color="violet", modifiers=["bold"]
+            "painted", foreground="violet", modifiers=["bold"]
         ).ansi
 
     assert "\x1b[38;2;238;130;238m" in ansi  # violet foreground

--- a/tests/test_reactivity_threading.py
+++ b/tests/test_reactivity_threading.py
@@ -48,7 +48,9 @@ def test_schedule_update_runs_callback_and_marks_dirty() -> None:
         app = App()
         runtime.set_root(app)
         runtime.enter()
-        app.schedule_update(lambda: setattr(app, "body", "b"), field="body")
+        app.grid_schedule_update(
+            lambda: setattr(app, "body", "b"), field="body"
+        )
         runtime.pump(0.0)
         assert app.body == "b"
     finally:
@@ -62,8 +64,8 @@ def test_grid_update_field_missing_is_noop() -> None:
 
     app = App()
     # Missing field, and a state field: both are no-ops, no exception.
-    app.grid_update_field("does_not_exist", color="red")
-    app.grid_update_field("count", color="red")
+    app.grid_update_field("does_not_exist", foreground="red")
+    app.grid_update_field("count", foreground="red")
 
 
 def test_loader_inline_frame_is_a_glyph() -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -354,7 +354,7 @@ def test_grid_effect_uses_recorded_field_area() -> None:
         app = App()
         runtime.set_root(app)
         runtime.render()
-        assert app.grid_play_effect(FadeEffect(), fields=["body"])
+        assert app.grid_effect(FadeEffect(), fields=["body"])
         runtime.render()
     finally:
         runtime.close()

--- a/tests/test_showcase_rendering.py
+++ b/tests/test_showcase_rendering.py
@@ -209,7 +209,7 @@ def test_effects_target_every_focusable_box() -> None:
         runtime.set_root(app)
         runtime.render()
         for parent, field_name in app._effect_targets.values():
-            assert parent.grid_play_effect(
+            assert parent.grid_effect(
                 "fade", duration_ms=200, fields=[field_name]
             )
     finally:

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from xnano.area import Area
 from xnano.core.stage import LayoutMap, Stage
-from xnano.types import Area
 
 
 def test_stage_registers_and_returns_areas() -> None:
@@ -16,14 +16,14 @@ def test_stage_registers_and_returns_areas() -> None:
 
 def test_stage_queues_paint_commands() -> None:
     stage = Stage()
-    stage.paint_cell(2, 1, "!", color="yellow", modifiers=("bold",))
+    stage.paint_cell(2, 1, "!", foreground="yellow", modifiers=("bold",))
     stage.paint_cell(0, 0, "x")
     assert len(stage._commands) == 2
     first = stage._commands[0]
     assert first["x"] == 2
     assert first["y"] == 1
     assert first["value"] == "!"
-    assert first["color"] == "yellow"
+    assert first["foreground"] == "yellow"
     assert first["modifiers"] == ("bold",)
 
 

--- a/tests/test_user_compositions.py
+++ b/tests/test_user_compositions.py
@@ -373,7 +373,7 @@ def test_nested_workspace_combines_layout_focus_overlay_and_effects() -> None:
         notice: Text = Field(
             default_factory=lambda: Text("Saved"),
             overlay=True,
-            align="center",
+            horizontal_align="center",
             width=12,
             height=3,
             border="rounded",
@@ -398,7 +398,7 @@ def test_nested_workspace_combines_layout_focus_overlay_and_effects() -> None:
         assert workspace.navigation.pages.value == "Logs"
         runtime.perform(Action.keyboard("s"))
         assert "Saved now" in runtime.render().text
-        assert workspace.grid_play_effect(
+        assert workspace.grid_effect(
             Effect("coalesce", duration_ms=20),
             fields=["content"],
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,7 +46,7 @@ def test_parse_ansi_lines_carries_color() -> None:
     lines = parse_ansi_lines("\x1b[31mred\x1b[0m plain")
     runs = lines[0]
     assert runs[0].text == "red"
-    assert runs[0].color is not None
+    assert runs[0].foreground is not None
     assert "".join(run.text for run in runs) == "red plain"
 
 
@@ -64,11 +64,11 @@ def test_parse_ansi_lines_preserves_terminal_log_styles() -> None:
     error, plain = lines[0]
 
     assert error.text == "error"
-    assert error.color == "#ff0000"
+    assert error.foreground == "#ff0000"
     assert error.background == "#010203"
     assert error.modifiers == ("bold",)
     assert plain.text == " plain"
-    assert plain.color is None
+    assert plain.foreground is None
     assert plain.background is None
     assert plain.modifiers == ()
 

--- a/xnano/area.py
+++ b/xnano/area.py
@@ -1,0 +1,255 @@
+"""xnano.area
+
+---
+
+Geometry primitives shared by every layer: rectangular areas, measured
+sizes, padding, and the alignment arithmetic that places one inside
+another.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Literal, TypeAlias, Union, cast
+
+VerticalAlignment: TypeAlias = Literal["top", "middle", "bottom"]
+"""Vertical (y-axis) alignment of a grid field or area.
+
+Values:
+    ``"top"``: Aligned to the top edge.
+    ``"middle"``: Centered vertically.
+    ``"bottom"``: Aligned to the bottom edge.
+"""
+
+Alignment: TypeAlias = Literal["left", "right", "center"]
+"""Horizontal (x-axis) alignment of a grid field or area.
+
+Values:
+    ``"left"``: Aligned to the left.
+    ``"right"``: Aligned to the right.
+    ``"center"``: Centered.
+"""
+
+
+Coordinate: TypeAlias = tuple[int, int]
+"""A single ``(x, y)`` cell coordinate within the terminal grid."""
+
+
+PaddingLike: TypeAlias = Union[
+    int,
+    tuple[int, int],
+    tuple[int | None, int | None, int | None, int | None],
+    "Padding",
+]
+"""Padding around a rectangular area, in any accepted input form:
+
+    - A single integer, applied to all four sides.
+    - A ``(vertical, horizontal)`` tuple of two integers.
+    - A ``(top, right, bottom, left)`` tuple of four integers.
+    - A ``Padding`` instance.
+"""
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class Padding:
+    """Padding around a rectangular area.
+
+    Attributes:
+        top: Cells above the content.
+        right: Cells to the right of the content.
+        bottom: Cells below the content.
+        left: Cells to the left of the content.
+
+    Examples:
+        ```python
+        padding = Padding.parse((1, 2))
+        ```
+    """
+
+    top: int = 0
+    """Cells above the content."""
+    right: int = 0
+    """Cells to the right of the content."""
+    bottom: int = 0
+    """Cells below the content."""
+    left: int = 0
+    """Cells to the left of the content."""
+
+    @classmethod
+    def parse(cls, padding: PaddingLike | None) -> "Padding":
+        """Normalize a padding value."""
+        if padding is None:
+            return cls()
+        if isinstance(padding, cls):
+            return padding
+        if isinstance(padding, int):
+            return cls(
+                top=padding,
+                right=padding,
+                bottom=padding,
+                left=padding,
+            )
+        values = cast(
+            tuple[int, int]
+            | tuple[int | None, int | None, int | None, int | None],
+            padding,
+        )
+        if len(values) == 2:
+            vertical, horizontal = values
+            return cls(
+                top=vertical or 0,
+                right=horizontal or 0,
+                bottom=vertical or 0,
+                left=horizontal or 0,
+            )
+        top, right, bottom, left = values
+        return cls(
+            top=top or 0,
+            right=right or 0,
+            bottom=bottom or 0,
+            left=left or 0,
+        )
+
+    @property
+    def horizontal(self) -> int:
+        """Total horizontal padding."""
+        return self.left + self.right
+
+    @property
+    def vertical(self) -> int:
+        """Total vertical padding."""
+        return self.top + self.bottom
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class Size:
+    """Resolved width and height in cells.
+
+    Attributes:
+        width: Width in cells.
+        height: Height in cells.
+    """
+
+    width: int
+    """Width in cells."""
+    height: int
+    """Height in cells."""
+
+    @classmethod
+    def from_tuple(cls, size: tuple[int, int]) -> "Size":
+        """Create a size from ``(width, height)``."""
+        return cls(width=size[0], height=size[1])
+
+    @classmethod
+    def from_int(cls, size: int) -> "Size":
+        """Create a square size."""
+        return cls(width=size, height=size)
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class Area:
+    """Rectangular region of a cell grid.
+
+    Attributes:
+        x: Left column.
+        y: Top row.
+        width: Width in cells.
+        height: Height in cells.
+    """
+
+    x: int
+    """Left column."""
+    y: int
+    """Top row."""
+    width: int
+    """Width in cells."""
+    height: int
+    """Height in cells."""
+
+    @property
+    def size(self) -> Size:
+        """Width and height of this area."""
+        return Size(width=self.width, height=self.height)
+
+    def contains(self, coordinate: Coordinate) -> bool:
+        """Return whether ``coordinate`` lies inside this area."""
+        column, row = coordinate
+        return (
+            self.x <= column < self.x + self.width
+            and self.y <= row < self.y + self.height
+        )
+
+    def fit_content(
+        self,
+        content: Size,
+        horizontal: "Alignment | None" = None,
+        vertical: "VerticalAlignment | None" = None,
+    ) -> "Area":
+        """Fit a measured size inside this area on both axes.
+
+        Args:
+            content: Measured content size, clamped to this area.
+            horizontal: Horizontal placement (default ``"left"``).
+            vertical: Vertical placement (default ``"top"``).
+
+        Returns:
+            The fitted, aligned area.
+        """
+        return align_area(
+            self,
+            min(self.width, max(content.width, 1)),
+            min(self.height, max(content.height, 1)),
+            horizontal=horizontal,
+            vertical=vertical,
+        )
+
+
+def align_area(
+    outer: Area,
+    width: int,
+    height: int,
+    *,
+    horizontal: "Alignment | None" = None,
+    vertical: "VerticalAlignment | None" = None,
+) -> Area:
+    """Place a ``width`` x ``height`` box inside ``outer`` on both axes.
+
+    ``None`` on an axis anchors to its leading edge.
+
+    Args:
+        outer: The area to place the box within.
+        width: Box width, clamped to ``outer``.
+        height: Box height, clamped to ``outer``.
+        horizontal: Horizontal placement (default ``"left"``).
+        vertical: Vertical placement (default ``"top"``).
+
+    Returns:
+        The placed area, always inside ``outer``.
+    """
+    width = max(0, min(width, outer.width))
+    height = max(0, min(height, outer.height))
+    if horizontal == "right":
+        x = outer.x + outer.width - width
+    elif horizontal == "center":
+        x = outer.x + (outer.width - width) // 2
+    else:
+        x = outer.x
+    if vertical == "bottom":
+        y = outer.y + outer.height - height
+    elif vertical == "middle":
+        y = outer.y + (outer.height - height) // 2
+    else:
+        y = outer.y
+    return Area(x=x, y=y, width=width, height=height)
+
+
+__all__ = (
+    "Alignment",
+    "Area",
+    "Coordinate",
+    "Padding",
+    "PaddingLike",
+    "Size",
+    "VerticalAlignment",
+    "align_area",
+)

--- a/xnano/components/bar.py
+++ b/xnano/components/bar.py
@@ -199,7 +199,7 @@ class Bar(Component):
             data=data,
             bars=bars,
             max_value=max_value,
-            color=self.foreground,
+            foreground=self.foreground,
             background=self.background,
             absent_value_color=self.absent_color,
             absent_value_symbol=self.absent_glyph,
@@ -234,7 +234,7 @@ class Bar(Component):
             spans.append(
                 CellSpan(
                     glyph,
-                    color=color,
+                    foreground=color,
                     background=self.background,
                 )
             )

--- a/xnano/components/button.py
+++ b/xnano/components/button.py
@@ -137,12 +137,12 @@ class Button(Component):
                 (
                     Run(
                         text=caption,
-                        color=foreground,
+                        foreground=foreground,
                         background=background,
                     ),
                 ),
             ),
-            color=foreground,
+            foreground=foreground,
             background=background,
             z=self.z,
             visible=self.visible,

--- a/xnano/components/component.py
+++ b/xnano/components/component.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
+from xnano.area import Size
 from xnano.core.content import (
     Bars,
     Canvas,
@@ -30,16 +31,15 @@ from xnano.core.content import (
 from xnano.core.content import (
     Scrollbar as ScrollbarContent,
 )
-from xnano.types import Size
 from xnano.utils.responsive import (
     collect_responsive_overrides,
     responsive_noop,
 )
 
 if TYPE_CHECKING:
+    from xnano.area import Area
     from xnano.events import KeyboardEventData
     from xnano.terminal import Terminal
-    from xnano.types import Area
 
 
 StateT = TypeVar("StateT")

--- a/xnano/components/dropdown.py
+++ b/xnano/components/dropdown.py
@@ -188,7 +188,7 @@ class Dropdown(Options):
                     (
                         Run(
                             text="select…",
-                            color="gray",
+                            foreground="gray",
                             modifiers=("dim",),
                         ),
                     ),
@@ -203,8 +203,10 @@ class Dropdown(Options):
             else self.background
         )
         return TextBlock(
-            lines=((Run(text=label, color=color, background=background),),),
-            color=color,
+            lines=(
+                (Run(text=label, foreground=color, background=background),),
+            ),
+            foreground=color,
             background=background,
         )
 

--- a/xnano/components/image.py
+++ b/xnano/components/image.py
@@ -16,9 +16,9 @@ import time
 import zlib
 from typing import BinaryIO, Literal, TypeAlias
 
+from xnano.area import Size
 from xnano.components.component import Component, ComponentRenderContext
 from xnano.core.content import CellCanvas, CellSpan
-from xnano.types import Size
 
 ImageFit: TypeAlias = Literal[
     "crop",
@@ -405,7 +405,9 @@ def _get_frame_as_canvas(
             ):
                 spans.append(
                     CellSpan(
-                        run_text, color=run_color, background=run_background
+                        run_text,
+                        foreground=run_color,
+                        background=run_background,
                     )
                 )
                 run_text = ""
@@ -416,7 +418,7 @@ def _get_frame_as_canvas(
             spans.append(
                 CellSpan(
                     run_text,
-                    color=run_color,
+                    foreground=run_color,
                     background=run_background,
                 )
             )

--- a/xnano/components/input.py
+++ b/xnano/components/input.py
@@ -11,8 +11,8 @@ import dataclasses
 import math
 from typing import TYPE_CHECKING, Sequence
 
+from xnano.area import Size
 from xnano.components.text import Text
-from xnano.types import Size
 
 if TYPE_CHECKING:
     from xnano.components.component import ComponentRenderContext

--- a/xnano/components/link.py
+++ b/xnano/components/link.py
@@ -13,12 +13,14 @@ from typing import TYPE_CHECKING, Any
 from xnano.components.component import ComponentRenderContext
 from xnano.components.text import Text
 from xnano.core.content import TextBlock
+from xnano.utils.deprecation import color_alias_dataclass
 
 if TYPE_CHECKING:
     from xnano.colors import ColorLike
     from xnano.events import KeyboardEventData
 
 
+@color_alias_dataclass
 @dataclasses.dataclass
 class Link(Text):
     """Focusable hyperlink label.
@@ -40,7 +42,7 @@ class Link(Text):
     """Destination address exposed to hooks; never auto-opened."""
     underline: bool = True
     """When ``True``, compose with the underline modifier."""
-    color: ColorLike | None = "blue"
+    foreground: ColorLike | None = "blue"
     """Default link foreground color."""
     focused_color: ColorLike | None = None
     """Foreground override while this link holds focus."""
@@ -84,7 +86,7 @@ class Link(Text):
         if self.underline and "underline" not in modifiers:
             modifiers = modifiers + ("underline",)
 
-        color = self.color
+        color = self.foreground
         if self.focused and self.focused_color is not None:
             color = self.focused_color
         elif self.visited and self.focused_color is None:
@@ -98,10 +100,11 @@ class Link(Text):
             label = self.content if self.content else self.url
             return TextBlock.from_plain(
                 label,
-                color=color,
+                foreground=color,
                 background=self.background,
                 modifiers=modifiers,
-                align=self.align,
+                horizontal_align=self.horizontal_align,
+                vertical_align=self.vertical_align,
                 wrap=self.wrap,
                 z=self.z,
                 visible=self.visible,
@@ -109,14 +112,14 @@ class Link(Text):
 
         # Nested content: style via a short-lived attribute swap.
         previous_modifiers = self.modifiers
-        previous_color = self.color
+        previous_color = self.foreground
         object.__setattr__(self, "modifiers", modifiers)
-        object.__setattr__(self, "color", color)
+        object.__setattr__(self, "foreground", color)
         try:
             return Text.compose(self, ctx)
         finally:
             object.__setattr__(self, "modifiers", previous_modifiers)
-            object.__setattr__(self, "color", previous_color)
+            object.__setattr__(self, "foreground", previous_color)
 
     def handle_keyboard(self, keyboard: "KeyboardEventData") -> bool:
         """Leave activation keys for application hooks.

--- a/xnano/components/loader.py
+++ b/xnano/components/loader.py
@@ -223,7 +223,7 @@ class Loader(Component):
         text = frame if not label else f"{frame} {label}"
         return TextBlock(
             text=text,
-            color=self.foreground,
+            foreground=self.foreground,
             background=self.background,
             z=self.z,
             visible=self.visible,
@@ -236,7 +236,7 @@ class Loader(Component):
             return LineGauge(
                 progress=ratio,
                 label=label,
-                color=self.foreground,
+                foreground=self.foreground,
                 filled_color=self.filled_color or self.foreground,
                 unfilled_color=self.unfilled_color,
                 background=self.background,
@@ -246,7 +246,7 @@ class Loader(Component):
         return Gauge(
             progress=ratio,
             label=label,
-            color=self.foreground,
+            foreground=self.foreground,
             background=self.background,
             z=self.z,
             visible=self.visible,
@@ -270,7 +270,7 @@ class Loader(Component):
                 return LineGauge(
                     progress=0.0,
                     label=pulse_label,
-                    color=self.foreground,
+                    foreground=self.foreground,
                     filled_color=self.filled_color or self.foreground,
                     unfilled_color=self.unfilled_color,
                     background=self.background,
@@ -280,7 +280,7 @@ class Loader(Component):
             return Gauge(
                 progress=0.0,
                 label=pulse_label,
-                color=self.foreground,
+                foreground=self.foreground,
                 background=self.background,
                 z=self.z,
                 visible=self.visible,

--- a/xnano/components/options.py
+++ b/xnano/components/options.py
@@ -613,7 +613,7 @@ class Options(Component):
         def make_run(segment: str, emphasized: bool) -> Run:
             return Run(
                 text=segment,
-                color=self.match_color if emphasized else None,
+                foreground=self.match_color if emphasized else None,
                 modifiers=("bold",) if emphasized else (),
             )
 
@@ -664,7 +664,7 @@ class Options(Component):
         return Items(
             items=entries,
             selected=selected,
-            color=self.foreground,
+            foreground=self.foreground,
             background=self.background,
             highlight_color=self.highlight_color,
             highlight_background=self.highlight_background,
@@ -688,7 +688,7 @@ class Options(Component):
                 (
                     Run(
                         text="type to filter",
-                        color="gray",
+                        foreground="gray",
                         modifiers=query_modifiers,
                     ),
                 ),

--- a/xnano/components/schema.py
+++ b/xnano/components/schema.py
@@ -10,9 +10,15 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, Callable, TypeAlias
 
+from xnano.utils.deprecation import (
+    align_alias_dataclass,
+    color_alias_dataclass,
+)
+
 if TYPE_CHECKING:
+    from xnano.area import Alignment
     from xnano.colors import ColorLike
-    from xnano.types import Alignment, CanvasMarkerLike, GraphTypeLike
+    from xnano.types import CanvasMarkerLike, GraphTypeLike
 
 ColorResolver: TypeAlias = Any
 FormatResolver: TypeAlias = str | Callable[[Any], str] | None
@@ -30,6 +36,8 @@ class ComponentDescriptor:
     """Attribute name assigned by the component class."""
 
 
+@align_alias_dataclass
+@color_alias_dataclass
 @dataclasses.dataclass
 class Column(ComponentDescriptor):
     """Describe one table column.
@@ -38,9 +46,9 @@ class Column(ComponentDescriptor):
         header: Header displayed for the column.
         accessor: Row attribute, mapping key, or value callback.
         format: Optional format string or value callback.
-        color: Cell foreground color.
+        foreground: Cell foreground color.
         background: Cell background color.
-        align: Cell alignment.
+        horizontal_align: Cell alignment.
         width: Fixed or proportional column width.
     """
 
@@ -50,11 +58,11 @@ class Column(ComponentDescriptor):
     """Custom row value accessor."""
     format: FormatResolver = None
     """Value formatter."""
-    color: ColorResolver = None
+    foreground: ColorResolver = None
     """Foreground color or resolver."""
     background: ColorResolver = None
     """Background color or resolver."""
-    align: "Alignment | None" = None
+    horizontal_align: "Alignment | None" = None
     """Cell text alignment."""
     width: int | float | None = None
     """Fixed width or fractional width."""
@@ -87,7 +95,8 @@ class Column(ComponentDescriptor):
 
     def resolve_color(self, value: Any) -> Any:
         """Resolve the foreground color for a value."""
-        return self.color(value) if callable(self.color) else self.color
+        resolver = self.foreground
+        return resolver(value) if callable(resolver) else resolver
 
     def resolve_background(self, value: Any) -> Any:
         """Resolve the background color for a value."""

--- a/xnano/components/table.py
+++ b/xnano/components/table.py
@@ -109,9 +109,9 @@ class Table(Component):
                         header=spec.header,
                         accessor=spec.accessor,
                         format=spec.format,
-                        color=spec.color,
+                        foreground=spec.foreground,
                         background=spec.background,
-                        align=spec.align,
+                        horizontal_align=spec.horizontal_align,
                         width=spec.width,
                     )
                     column.name = name
@@ -166,12 +166,14 @@ class Table(Component):
 
     @staticmethod
     def _align_text(text: str, column: Column) -> str:
-        if column.align is None or not isinstance(column.width, int):
+        if column.horizontal_align is None or not isinstance(
+            column.width, int
+        ):
             return text
         width = column.width
-        if column.align == "right":
+        if column.horizontal_align == "right":
             return text.rjust(width)
-        if column.align == "center":
+        if column.horizontal_align == "center":
             return text.center(width)
         return text.ljust(width)
 
@@ -263,7 +265,7 @@ class Table(Component):
                 cells.append(
                     TableCell(
                         content=text,
-                        color=column.resolve_color(value),
+                        foreground=column.resolve_color(value),
                         background=column.resolve_background(value),
                     )
                 )

--- a/xnano/components/text.py
+++ b/xnano/components/text.py
@@ -10,17 +10,22 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, Sequence
 
+from xnano.area import Alignment, VerticalAlignment
 from xnano.components.component import Component, ComponentRenderContext
 from xnano.core.content import Native, Panel, Run, TextBlock
-from xnano.types import Alignment, CharacterModifier
-from xnano.utils.deprecation import color_alias_dataclass
+from xnano.types import CharacterModifier
+from xnano.utils.deprecation import (
+    align_alias_dataclass,
+    color_alias_dataclass,
+)
 
 if TYPE_CHECKING:
+    from xnano.area import Area
     from xnano.colors import ColorLike
     from xnano.events import KeyboardEventData
-    from xnano.types import Area
 
 
+@align_alias_dataclass
 @color_alias_dataclass
 @dataclasses.dataclass
 class Text(Component):
@@ -38,7 +43,8 @@ class Text(Component):
         foreground: Foreground color (deprecated alias: ``color``).
         background: Background color.
         modifiers: Character modifiers such as bold or underline.
-        align: Horizontal alignment at the paragraph level.
+        horizontal_align: Horizontal alignment at the paragraph level.
+        vertical_align: Vertical alignment within the painted area.
         wrap: Whether long lines may wrap.
         input: When ``True`` on a leaf, participates in field focus.
         placeholder: Shown when input is empty and unfocused.
@@ -65,8 +71,10 @@ class Text(Component):
     """Background color."""
     modifiers: tuple[CharacterModifier, ...] = ()
     """Character modifiers such as bold or underline."""
-    align: Alignment | None = None
+    horizontal_align: Alignment | None = None
     """Horizontal alignment at the paragraph level."""
+    vertical_align: VerticalAlignment | None = None
+    """Vertical alignment within the painted area."""
     wrap: bool = True
     """Whether long lines may wrap."""
     input: bool = False
@@ -375,7 +383,7 @@ class Text(Component):
             text_str = ""
         return Run(
             text=text_str,
-            color=self.foreground,
+            foreground=self.foreground,
             background=self.background,
             modifiers=tuple(self.modifiers),
         )
@@ -404,7 +412,7 @@ class Text(Component):
                     (
                         Run(
                             text=segment,
-                            color=child.foreground,
+                            foreground=child.foreground,
                             background=child.background,
                             modifiers=tuple(child.modifiers),
                         ),
@@ -417,7 +425,7 @@ class Text(Component):
         if isinstance(self.content, str):
             return TextBlock(
                 text=self.content,
-                color=self.foreground,
+                foreground=self.foreground,
                 background=self.background,
                 modifiers=tuple(self.modifiers),
             )
@@ -425,7 +433,7 @@ class Text(Component):
         spans = [child._to_span_node() for child in children]
         return TextBlock(
             lines=(tuple(spans),),
-            color=self.foreground,
+            foreground=self.foreground,
             background=self.background,
             modifiers=tuple(self.modifiers),
         )
@@ -461,10 +469,11 @@ class Text(Component):
         if self._editor is not None:
             return TextBlock(
                 text=self.value,
-                color=self.foreground,
+                foreground=self.foreground,
                 background=self.background,
                 modifiers=self.modifiers,
-                align=self.align,
+                horizontal_align=self.horizontal_align,
+                vertical_align=self.vertical_align,
                 wrap=self.wrap,
                 z=self.z,
                 visible=self.visible,
@@ -474,10 +483,11 @@ class Text(Component):
         if markup_lines is not None:
             return TextBlock(
                 lines=markup_lines,
-                color=self.foreground,
+                foreground=self.foreground,
                 background=self.background,
                 modifiers=self.modifiers,
-                align=self.align,
+                horizontal_align=self.horizontal_align,
+                vertical_align=self.vertical_align,
                 wrap=self.wrap,
                 z=self.z,
                 visible=self.visible,
@@ -497,10 +507,11 @@ class Text(Component):
                     modifiers = ("dim",)
             return TextBlock.from_plain(
                 text_str,
-                color=color,
+                foreground=color,
                 background=self.background,
                 modifiers=modifiers,
-                align=self.align,
+                horizontal_align=self.horizontal_align,
+                vertical_align=self.vertical_align,
                 wrap=self.wrap,
                 z=self.z,
                 visible=self.visible,
@@ -521,17 +532,18 @@ class Text(Component):
                     runs.append(
                         Run(
                             text=child.content,
-                            color=child.foreground,
+                            foreground=child.foreground,
                             background=child.background,
                             modifiers=tuple(child.modifiers),
                         )
                     )
             return TextBlock(
                 lines=(tuple(runs),),
-                color=self.foreground,
+                foreground=self.foreground,
                 background=self.background,
                 modifiers=tuple(self.modifiers),
-                align=self.align,
+                horizontal_align=self.horizontal_align,
+                vertical_align=self.vertical_align,
                 wrap=self.wrap,
                 z=self.z,
                 visible=self.visible,
@@ -544,10 +556,11 @@ class Text(Component):
             lines.extend(child._build_line_nodes_from_leaf_children([child]))
         return TextBlock(
             lines=tuple(lines),
-            color=self.foreground,
+            foreground=self.foreground,
             background=self.background,
             modifiers=self.modifiers,
-            align=self.align,
+            horizontal_align=self.horizontal_align,
+            vertical_align=self.vertical_align,
             wrap=self.wrap,
             z=self.z,
             visible=self.visible,

--- a/xnano/context.py
+++ b/xnano/context.py
@@ -15,6 +15,7 @@ from xnano.utils.deprecation import warn_renamed_attribute
 
 if TYPE_CHECKING:
     from xnano.actions import Actions
+    from xnano.area import Area
     from xnano.core.runtime import Runtime
     from xnano.core.stage import Stage
     from xnano.cursor import Cursor
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
         TickEventData,
     )
     from xnano.requests import Request
-    from xnano.types import Area, ScrollHandle
+    from xnano.types import ScrollHandle
     from xnano.utils.responsive import Breakpoint
 
 

--- a/xnano/core/content.py
+++ b/xnano/core/content.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Sequence, TypeAlias
 
+from xnano.area import Alignment, PaddingLike, VerticalAlignment
 from xnano.colors import ColorLike
 from xnano.tailwind import Style
 from xnano.types import (
-    Alignment,
     Border,
     CanvasMarkerLike,
     CharacterModifier,
@@ -21,9 +21,13 @@ from xnano.types import (
     FrameTitlePosition,
     GraphTypeLike,
     LegendPositionLike,
-    PaddingLike,
     ScrollbarOrientationLike,
     Side,
+)
+from xnano.utils.deprecation import (
+    align_alias_dataclass,
+    color_alias_dataclass,
+    resolve_color_alias,
 )
 
 
@@ -48,23 +52,24 @@ class ContentBase:
 AbstractContent = ContentBase
 
 
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class Run(ContentBase):
     """One styled text run.
 
     Example:
-        ``Run(text="Ready", color="green", modifiers=("bold",))``
+        ``Run(text="Ready", foreground="green", modifiers=("bold",))``
 
     Attributes:
         text: Text displayed by the run.
-        color: Foreground color.
+        foreground: Foreground color.
         background: Background color.
         modifiers: Character modifiers.
     """
 
     text: str
     """Text displayed by the run."""
-    color: ColorLike | None = None
+    foreground: ColorLike | None = None
     """Foreground color."""
     background: ColorLike | None = None
     """Background color."""
@@ -76,30 +81,33 @@ class Run(ContentBase):
         cls,
         text: str,
         *,
-        color: ColorLike | None = None,
+        foreground: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
         style: Style | None = None,
         z: int = 0,
         visible: bool = True,
+        color: ColorLike | None = None,
     ) -> "Run":
         """Create a plain styled run.
 
         Args:
             text: Text displayed by the run.
-            color: Foreground color.
+            foreground: Foreground color.
             background: Background color.
             modifiers: Character modifiers.
             style: Optional shared style.
             z: Sibling-local paint order.
             visible: Whether the run paints.
+            color: Deprecated alias for ``foreground``.
 
         Returns:
             A run containing ``text``.
         """
+        foreground = resolve_color_alias(foreground, color, stacklevel=3)
         return cls(
             text=text,
-            color=color,
+            foreground=foreground,
             background=background,
             modifiers=tuple(modifiers or ()),
             style=style,
@@ -108,20 +116,23 @@ class Run(ContentBase):
         )
 
 
+@align_alias_dataclass
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class TextBlock(ContentBase):
     """Wrapped plain text or lines of styled runs.
 
     Example:
-        ``TextBlock(text="Hello", align="center")``
+        ``TextBlock(text="Hello", horizontal_align="center")``
 
     Attributes:
         text: Plain text content.
         lines: Styled text lines.
-        color: Default foreground color.
+        foreground: Default foreground color.
         background: Default background color.
         modifiers: Default character modifiers.
-        align: Horizontal alignment.
+        horizontal_align: Horizontal alignment.
+        vertical_align: Vertical alignment within the painted area.
         wrap: Whether long lines wrap.
     """
 
@@ -129,14 +140,16 @@ class TextBlock(ContentBase):
     """Plain text content."""
     lines: tuple[tuple[Run, ...], ...] = ()
     """Styled text lines."""
-    color: ColorLike | None = None
+    foreground: ColorLike | None = None
     """Default foreground color."""
     background: ColorLike | None = None
     """Default background color."""
     modifiers: tuple[CharacterModifier, ...] = ()
     """Default character modifiers."""
-    align: Alignment | None = None
+    horizontal_align: Alignment | None = None
     """Horizontal alignment."""
+    vertical_align: VerticalAlignment | None = None
+    """Vertical alignment within the painted area."""
     wrap: bool = True
     """Whether long lines wrap."""
 
@@ -145,22 +158,29 @@ class TextBlock(ContentBase):
         cls,
         text: str,
         *,
-        color: ColorLike | None = None,
+        foreground: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
-        align: Alignment | None = None,
+        horizontal_align: Alignment | None = None,
+        vertical_align: VerticalAlignment | None = None,
         wrap: bool = True,
         style: Style | None = None,
         z: int = 0,
         visible: bool = True,
+        color: ColorLike | None = None,
     ) -> "TextBlock":
-        """Create a block from plain text and explicit style values."""
+        """Create a block from plain text and explicit style values.
+
+        ``color`` is a deprecated alias for ``foreground``.
+        """
+        foreground = resolve_color_alias(foreground, color, stacklevel=3)
         return cls(
             text=text,
-            color=color,
+            foreground=foreground,
             background=background,
             modifiers=tuple(modifiers or ()),
-            align=align,
+            horizontal_align=horizontal_align,
+            vertical_align=vertical_align,
             wrap=wrap,
             style=style,
             z=z,
@@ -172,16 +192,22 @@ class TextBlock(ContentBase):
         cls,
         lines: Sequence[Sequence[Run] | Run | str],
         *,
-        color: ColorLike | None = None,
+        foreground: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
-        align: Alignment | None = None,
+        horizontal_align: Alignment | None = None,
+        vertical_align: VerticalAlignment | None = None,
         wrap: bool = True,
         style: Style | None = None,
         z: int = 0,
         visible: bool = True,
+        color: ColorLike | None = None,
     ) -> "TextBlock":
-        """Create a block from styled line sequences."""
+        """Create a block from styled line sequences.
+
+        ``color`` is a deprecated alias for ``foreground``.
+        """
+        foreground = resolve_color_alias(foreground, color, stacklevel=3)
         normalized: list[tuple[Run, ...]] = []
         for line in lines:
             if isinstance(line, str):
@@ -192,10 +218,11 @@ class TextBlock(ContentBase):
                 normalized.append(tuple(line))
         return cls(
             lines=tuple(normalized),
-            color=color,
+            foreground=foreground,
             background=background,
             modifiers=tuple(modifiers or ()),
-            align=align,
+            horizontal_align=horizontal_align,
+            vertical_align=vertical_align,
             wrap=wrap,
             style=style,
             z=z,
@@ -260,6 +287,7 @@ class Panel(ContentBase):
     """Space between border and child."""
 
 
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class Gauge(ContentBase):
     """Render a filled progress gauge.
@@ -270,7 +298,7 @@ class Gauge(ContentBase):
     Attributes:
         progress: Completion ratio from zero to one.
         label: Text displayed inside the gauge.
-        color: Filled-region color.
+        foreground: Filled-region color.
         background: Gauge background color.
     """
 
@@ -278,12 +306,13 @@ class Gauge(ContentBase):
     """Completion ratio from zero to one."""
     label: str | None = None
     """Text displayed inside the gauge."""
-    color: ColorLike = "green"
+    foreground: ColorLike = "green"
     """Filled-region color."""
     background: ColorLike | None = None
     """Gauge background color."""
 
 
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class LineGauge(ContentBase):
     """Render progress as a single horizontal line.
@@ -291,7 +320,7 @@ class LineGauge(ContentBase):
     Attributes:
         progress: Completion ratio from zero to one.
         label: Text displayed with the line.
-        color: Default foreground color.
+        foreground: Default foreground color.
         filled_color: Completed-region color.
         unfilled_color: Remaining-region color.
         background: Line background color.
@@ -301,7 +330,7 @@ class LineGauge(ContentBase):
     """Completion ratio from zero to one."""
     label: str | None = None
     """Text displayed with the line."""
-    color: ColorLike | None = None
+    foreground: ColorLike | None = None
     """Default foreground color."""
     filled_color: ColorLike | None = None
     """Completed-region color."""
@@ -479,18 +508,19 @@ class SparklineBar:
     """Sample color."""
 
 
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class Sparkline(ContentBase):
     """Render a compact sequence of vertical samples.
 
     Example:
-        ``Sparkline(data=(2, 5, 3, 8), color="cyan")``
+        ``Sparkline(data=(2, 5, 3, 8), foreground="cyan")``
 
     Attributes:
         data: Sample values.
         bars: Individually styled samples.
         max_value: Explicit sample ceiling.
-        color: Default sample color.
+        foreground: Default sample color.
         background: Sparkline background.
         absent_value_color: Color for missing or zero samples.
         absent_value_symbol: Symbol for missing or zero samples.
@@ -502,7 +532,7 @@ class Sparkline(ContentBase):
     """Individually styled samples."""
     max_value: int | None = None
     """Explicit sample ceiling."""
-    color: ColorLike | None = None
+    foreground: ColorLike | None = None
     """Default sample color."""
     background: ColorLike | None = None
     """Sparkline background."""
@@ -512,20 +542,21 @@ class Sparkline(ContentBase):
     """Symbol for missing or zero samples."""
 
 
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class TableCell:
     """Styled content in one table column.
 
     Attributes:
         content: Cell content.
-        color: Foreground color.
+        foreground: Foreground color.
         background: Background color.
         modifiers: Character modifiers.
     """
 
     content: str | Run | TextBlock = ""
     """Cell content."""
-    color: ColorLike | None = None
+    foreground: ColorLike | None = None
     """Foreground color."""
     background: ColorLike | None = None
     """Background color."""
@@ -533,20 +564,21 @@ class TableCell:
     """Character modifiers."""
 
 
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class TableRow:
     """One styled table row.
 
     Attributes:
         cells: Cells in column order.
-        color: Default row foreground.
+        foreground: Default row foreground.
         background: Default row background.
         height: Row height in cells.
     """
 
     cells: tuple[TableCell | str, ...] = ()
     """Cells in column order."""
-    color: ColorLike | None = None
+    foreground: ColorLike | None = None
     """Default row foreground."""
     background: ColorLike | None = None
     """Default row background."""
@@ -596,6 +628,7 @@ class TableGrid(ContentBase):
     """Symbol prefixed to the selected row."""
 
 
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class Items(ContentBase):
     """Render a selectable list of text items.
@@ -606,7 +639,7 @@ class Items(ContentBase):
     Attributes:
         items: List entries.
         selected: Selected entry index.
-        color: Default foreground.
+        foreground: Default foreground.
         background: Default background.
         highlight_color: Selected-entry foreground.
         highlight_background: Selected-entry background.
@@ -617,7 +650,7 @@ class Items(ContentBase):
     """List entries."""
     selected: int | None = None
     """Selected entry index."""
-    color: ColorLike | None = None
+    foreground: ColorLike | None = None
     """Default foreground."""
     background: ColorLike | None = None
     """Default background."""
@@ -820,20 +853,21 @@ class Clear(ContentBase):
     """
 
 
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True)
 class CellSpan:
     """A styled run inside a cell canvas row.
 
     Attributes:
         text: Characters covered by the span.
-        color: Foreground color.
+        foreground: Foreground color.
         background: Background color.
         modifiers: Character modifiers.
     """
 
     text: str = " "
     """Characters covered by the span."""
-    color: ColorLike | None = None
+    foreground: ColorLike | None = None
     """Foreground color."""
     background: ColorLike | None = None
     """Background color."""

--- a/xnano/core/controller.py
+++ b/xnano/core/controller.py
@@ -9,15 +9,17 @@ from __future__ import annotations
 
 import collections.abc
 import copy
+import textwrap
 from typing import Any
 
 import xnano_core.rust.native as native
 from xnano_core import core
 
+from xnano.area import Area, Padding
 from xnano.core.content import Clear, Panel, TextBlock
 from xnano.core.layout import LayoutConstraint
 from xnano.core.rendering import lower_content
-from xnano.types import Area, Frame, Padding
+from xnano.types import Frame, is_grid
 from xnano.utils.responsive import resolve_responsive_variant
 
 
@@ -27,6 +29,39 @@ def _string_content(value: Any) -> str | None:
         return value
     content = getattr(value, "content", None)
     return content if isinstance(content, str) else None
+
+
+def wrapped_line_count(text: str, width: int) -> int:
+    """Return how many rows ``text`` occupies when wrapped at ``width``.
+
+    ratatui wraps on word boundaries, so a raw ``splitlines()`` count is
+    short for any line longer than its slot. ``textwrap`` matches that
+    behavior closely enough to place content; it is not a substitute for
+    ratatui's own measurement.
+
+    ponytail: approximates unicode width as one cell per character. Bind
+    ratatui's ``Paragraph::line_count`` if wide glyphs need exact rows.
+    """
+    lines = text.splitlines() or [""]
+    if width <= 0:
+        return len(lines)
+    total = 0
+    for line in lines:
+        if len(line) <= width:
+            total += 1
+        else:
+            total += (
+                len(
+                    textwrap.wrap(
+                        line,
+                        width=width,
+                        break_long_words=True,
+                        break_on_hyphens=False,
+                    )
+                )
+                or 1
+            )
+    return total
 
 
 def content_scroll_extent(value: Any, axis: str) -> int:
@@ -232,6 +267,57 @@ class TerminalController:
             return size.height if direction == "vertical" else size.width
         return 1
 
+    def align_slot_content(
+        self,
+        value: Any,
+        area: Area,
+        field: Any,
+        *,
+        parent_z: int = 0,
+    ) -> Area:
+        """Return the sub-area a field's content paints into.
+
+        Vertical alignment has no ratatui equivalent — ``Paragraph`` only
+        aligns horizontally — so a non-``"top"`` ``vertical_align`` is
+        resolved here by offsetting the slot's origin. Nested grids are
+        excluded: they fill their slot and have no intrinsic height.
+        """
+        vertical = getattr(field, "vertical_align", None)
+        if vertical is None or vertical == "top":
+            return area
+        if is_grid(value):
+            return area
+        # Prefer the value's own text: a component's ``get_size`` reports 0
+        # for the zero-height probe area ``measure_field_slot`` builds, which
+        # would silently skip alignment.
+        text = _string_content(value)
+        if text is not None:
+            height = wrapped_line_count(text, area.width)
+        elif callable(getattr(value, "get_size", None)):
+            height = self.measure_field_slot(
+                value, "vertical", field, available_width=area.width
+            )
+        else:
+            return area
+        if height <= 0 or height >= area.height:
+            return area
+        leftover = area.height - height
+        offset = leftover // 2 if vertical == "middle" else leftover
+        if offset <= 0:
+            return area
+        # Only the origin moves; the content keeps every remaining row so an
+        # under-measured value (a component whose real height exceeds its
+        # declared size) is never clipped by alignment alone.
+        background = getattr(field, "background", None)
+        if background is not None:
+            self._paint(TextBlock(background=background), area, z=parent_z - 1)
+        return Area(
+            x=area.x,
+            y=area.y + offset,
+            width=area.width,
+            height=area.height - offset,
+        )
+
     def paint_field_slot(
         self,
         value: Any,
@@ -247,6 +333,7 @@ class TerminalController:
     ) -> None:
         if scroll_offset > 0:
             value = window_scroll_value(value, scroll_offset, scroll_axis)
+        area = self.align_slot_content(value, area, field, parent_z=parent_z)
         if isinstance(value, collections.abc.Sequence) and not isinstance(
             value, (str, bytes)
         ):
@@ -270,7 +357,7 @@ class TerminalController:
                     effect_key=effect_key,
                 )
             return
-        if isinstance(getattr(type(value), "_grid_fields", None), dict):
+        if is_grid(value):
             # Register the field's area under its effect key so effects can
             # target a nested-grid slot too, not only leaf components. Without
             # this transparent anchor, ``effect_area_for(name)`` finds nothing
@@ -334,10 +421,10 @@ class TerminalController:
         self._paint(
             TextBlock(
                 text=str(value),
-                color=getattr(field, "color", None),
+                foreground=getattr(field, "foreground", None),
                 background=getattr(field, "background", None),
                 modifiers=tuple(getattr(field, "modifiers", ()) or ()),
-                align=getattr(field, "align", None),
+                horizontal_align=getattr(field, "horizontal_align", None),
             ),
             area,
             z=parent_z,
@@ -351,7 +438,7 @@ class TerminalController:
         self._paint(
             TextBlock(
                 text="\n".join("·" * area.width for _ in range(area.height)),
-                color="slate-500",
+                foreground="slate-500",
                 modifiers=("dim",),
                 wrap=False,
             ),
@@ -364,7 +451,7 @@ class TerminalController:
             self._paint(
                 TextBlock(
                     text=str(command["value"])[:1],
-                    color=command["color"],
+                    foreground=command["foreground"],
                     background=command["background"],
                     modifiers=command["modifiers"],
                     wrap=False,

--- a/xnano/core/demo.py
+++ b/xnano/core/demo.py
@@ -136,7 +136,7 @@ def build_plasma_frame(
             color = palette[
                 (column_index + row_index + drift) % palette_length
             ]
-            spans.append(CellSpan(text=glyphs[level], color=color))
+            spans.append(CellSpan(text=glyphs[level], foreground=color))
         rows.append(tuple(spans))
     return CellCanvas(rows=tuple(rows), width=width, height=height)
 
@@ -167,10 +167,12 @@ def build_orbit_frame(
         for column_index in range(width):
             level = grid[row_index][column_index]
             if level < 0:
-                spans.append(CellSpan(text="·", color="#182234"))
+                spans.append(CellSpan(text="·", foreground="#182234"))
             else:
                 glyph = "●" if level >= trail_length - 1 else "•"
-                spans.append(CellSpan(text=glyph, color=_ORBIT_TRAIL[level]))
+                spans.append(
+                    CellSpan(text=glyph, foreground=_ORBIT_TRAIL[level])
+                )
         rows.append(tuple(spans))
     return CellCanvas(rows=tuple(rows), width=width, height=height)
 
@@ -201,9 +203,11 @@ def build_spiral_frame(
         for column_index in range(width):
             level = grid[row_index][column_index]
             if level < 0:
-                spans.append(CellSpan(text="·", color="#182234"))
+                spans.append(CellSpan(text="·", foreground="#182234"))
             else:
-                spans.append(CellSpan(text="✦", color=_ORBIT_TRAIL[level]))
+                spans.append(
+                    CellSpan(text="✦", foreground=_ORBIT_TRAIL[level])
+                )
         rows.append(tuple(spans))
     return CellCanvas(rows=tuple(rows), width=width, height=height)
 
@@ -231,7 +235,7 @@ def build_ripple_frame(
             wave = math.sin(distance * 0.6 - phase * 1.5)
             level = int((wave + 1.0) * 2.0)
             level = min(ramp_length - 1, max(0, level))
-            spans.append(CellSpan(text=glyphs[level], color=ramp[level]))
+            spans.append(CellSpan(text=glyphs[level], foreground=ramp[level]))
         rows.append(tuple(spans))
     return CellCanvas(rows=tuple(rows), width=width, height=height)
 
@@ -286,7 +290,7 @@ def build_aurora_frame(
             elif index > top:
                 index = top
             glyph = glyphs[min(4, index * 5 // (top + 1))]
-            spans.append(CellSpan(text=glyph, color=ramp[index]))
+            spans.append(CellSpan(text=glyph, foreground=ramp[index]))
         rows.append(tuple(spans))
     return CellCanvas(rows=tuple(rows), width=width, height=height)
 
@@ -324,7 +328,9 @@ def build_ink_frame(
             glyph = glyphs[int(norm * glyph_top)]
             foreground = ramp[min(top, index + 2)]
             spans.append(
-                CellSpan(text=glyph, color=foreground, background=ramp[index])
+                CellSpan(
+                    text=glyph, foreground=foreground, background=ramp[index]
+                )
             )
         rows.append(tuple(spans))
     return CellCanvas(rows=tuple(rows), width=width, height=height)
@@ -363,7 +369,7 @@ def build_flow_frame(
             spans.append(
                 CellSpan(
                     text=glyph,
-                    color=ramp[index],
+                    foreground=ramp[index],
                     background=ramp[max(0, index - 3)],
                 )
             )
@@ -425,7 +431,7 @@ def _overlay_centered(
         column = left + offset
         if character != " " and 0 <= column < width:
             rows[row_index][column] = CellSpan(
-                text=character, color=color, modifiers=modifiers
+                text=character, foreground=color, modifiers=modifiers
             )
 
 
@@ -451,7 +457,7 @@ def build_title_frame(
             column = left + column_offset
             if character != " " and 0 <= column < width:
                 rows[target][column] = CellSpan(
-                    text="█", color=glow, modifiers=("bold",)
+                    text="█", foreground=glow, modifiers=("bold",)
                 )
     _overlay_centered(
         rows, width, height - 2, "press any key to begin", "#9a9ac0"
@@ -931,7 +937,7 @@ def _build_palette_canvas(width: int, height: int) -> CellCanvas:
                 f"{int(green * 255):02x}"
                 f"{int(blue * 255):02x}"
             )
-            spans.append(CellSpan(text="█", color=color))
+            spans.append(CellSpan(text="█", foreground=color))
         rows.append(tuple(spans))
     return CellCanvas(rows=tuple(rows), width=width, height=height)
 
@@ -1260,7 +1266,7 @@ class Showcase(BaseGrid, direction="vertical", gap=0):
         index = getattr(self, "_effect_index", 0)
         kind = _EFFECTS[index % len(_EFFECTS)]
         self._effect_index = index + 1
-        parent.grid_play_effect(kind, duration_ms=420, fields=[field_name])
+        parent.grid_effect(kind, duration_ms=420, fields=[field_name])
         self._log(f"{group}: effect {kind}")
 
     @on_keyboard("p", "space")

--- a/xnano/core/interface.py
+++ b/xnano/core/interface.py
@@ -8,22 +8,23 @@ Track dirty state for named fields shared by grids and hosts.
 from __future__ import annotations
 
 from xnano.fields import FieldState
+from xnano.utils.deprecation import warn_renamed_attribute
 
 
 class AbstractInterface:
     """Provide per-instance state for declared grid fields.
 
     Example:
-        ``grid.get_field_state("status")``
+        ``grid.grid_get_field_state("status")``
 
     Attributes:
-        _field_states: Mutable field state keyed by declared field name.
+        _grid_field_states: Mutable field state keyed by declared name.
     """
 
-    _field_states: dict[str, FieldState]
+    _grid_field_states: dict[str, FieldState]
     """Mutable field state keyed by declared field name."""
 
-    def _init_field_states(self) -> None:
+    def _grid_init_field_states(self) -> None:
         """Allocate state for every declared layout and state field."""
         names = (
             *getattr(type(self), "_grid_fields", {}),
@@ -31,11 +32,11 @@ class AbstractInterface:
         )
         object.__setattr__(
             self,
-            "_field_states",
+            "_grid_field_states",
             {name: FieldState(name=name) for name in names},
         )
 
-    def get_field_state(self, name: str) -> FieldState | None:
+    def grid_get_field_state(self, name: str) -> FieldState | None:
         """Return tracked state for a field.
 
         Args:
@@ -44,18 +45,34 @@ class AbstractInterface:
         Returns:
             Its state, or ``None`` for an unknown field.
         """
-        return getattr(self, "_field_states", {}).get(name)
+        return getattr(self, "_grid_field_states", {}).get(name)
 
-    def mark_field_dirty(self, name: str) -> None:
+    def grid_mark_field_dirty(self, name: str) -> None:
         """Mark a field as changed.
 
         Args:
             name: Field attribute name.
         """
-        state = self.get_field_state(name)
+        state = self.grid_get_field_state(name)
         if state is not None:
             state.mark_dirty()
             state.value = getattr(self, name, None)
+
+    @warn_renamed_attribute(
+        "AbstractInterface.get_field_state",
+        "AbstractInterface.grid_get_field_state",
+    )
+    def get_field_state(self, name: str) -> FieldState | None:
+        """Deprecated alias for ``grid_get_field_state``."""
+        return self.grid_get_field_state(name)
+
+    @warn_renamed_attribute(
+        "AbstractInterface.mark_field_dirty",
+        "AbstractInterface.grid_mark_field_dirty",
+    )
+    def mark_field_dirty(self, name: str) -> None:
+        """Deprecated alias for ``grid_mark_field_dirty``."""
+        self.grid_mark_field_dirty(name)
 
 
 __all__ = ("AbstractInterface",)

--- a/xnano/core/rendering.py
+++ b/xnano/core/rendering.py
@@ -108,7 +108,7 @@ def _line_from_runs(runs: tuple[Run, ...]) -> core.IrLine:
         [
             (
                 run.text,
-                get_native_color(run.color),
+                get_native_color(run.foreground),
                 get_native_color(run.background),
                 _native_modifiers(run.modifiers),
             )
@@ -126,7 +126,7 @@ def _line_from_value(value: Any) -> core.IrLine:
             return _line_from_runs(value.lines[0])
         return core.IrLine.styled(
             value.text,
-            get_native_color(value.color),
+            get_native_color(value.foreground),
             get_native_color(value.background),
             _native_modifiers(value.modifiers),
         )
@@ -143,14 +143,14 @@ def _table_row(row: TableRow) -> tuple[list[Any], Any, Any, int]:
             cells.append(
                 (
                     _line_from_value(cell.content),
-                    get_native_color(cell.color),
+                    get_native_color(cell.foreground),
                     get_native_color(cell.background),
                     _native_modifiers(cell.modifiers),
                 )
             )
     return (
         cells,
-        get_native_color(row.color),
+        get_native_color(row.foreground),
         get_native_color(row.background),
         row.height,
     )
@@ -234,7 +234,7 @@ def _canvas_shape(shape: Any) -> tuple[Any, ...]:
             runs = (
                 Run(
                     text=value.text,
-                    color=value.color,
+                    foreground=value.foreground,
                     background=value.background,
                     modifiers=value.modifiers,
                 ),
@@ -244,7 +244,7 @@ def _canvas_shape(shape: Any) -> tuple[Any, ...]:
         spans = [
             (
                 run.text,
-                get_native_color(run.color),
+                get_native_color(run.foreground),
                 get_native_color(run.background),
                 _native_modifiers(run.modifiers),
             )
@@ -283,7 +283,7 @@ def _cell_canvas_ir(content: CellCanvas) -> Any:
             [
                 (
                     span.text,
-                    get_native_color(span.color),
+                    get_native_color(span.foreground),
                     get_native_color(span.background),
                     _native_modifiers(span.modifiers),
                 )
@@ -358,9 +358,9 @@ def lower_content(content: Any) -> core.CoreRenderNode:
         )
     compose = getattr(content, "compose", None)
     if callable(compose):
+        from xnano.area import Area
         from xnano.components.component import ComponentRenderContext
         from xnano.core.runtime import get_active_runtime
-        from xnano.types import Area
 
         runtime = get_active_runtime()
         # A component with responsive compose variants swaps in the one
@@ -391,7 +391,7 @@ def lower_content(content: Any) -> core.CoreRenderNode:
     if isinstance(content, Run):
         render_ir = core.CoreRenderIR.span(
             content.text,
-            get_native_color(content.color),
+            get_native_color(content.foreground),
             get_native_color(content.background),
             _native_modifiers(content.modifiers),
         )
@@ -399,33 +399,33 @@ def lower_content(content: Any) -> core.CoreRenderNode:
         if content.lines:
             render_ir = core.CoreRenderIR.paragraph_lines(
                 [_line_from_runs(line) for line in content.lines],
-                get_native_color(content.color),
+                get_native_color(content.foreground),
                 get_native_color(content.background),
                 _native_modifiers(content.modifiers),
-                _ALIGNMENTS[content.align],
+                _ALIGNMENTS[content.horizontal_align],
                 content.wrap,
             )
         else:
             render_ir = core.CoreRenderIR.paragraph_raw(
                 content.text,
-                get_native_color(content.color),
+                get_native_color(content.foreground),
                 get_native_color(content.background),
                 _native_modifiers(content.modifiers),
-                _ALIGNMENTS[content.align],
+                _ALIGNMENTS[content.horizontal_align],
                 content.wrap,
             )
     elif isinstance(content, Gauge):
         render_ir = core.CoreRenderIR.progress_bar(
             content.progress,
             content.label,
-            get_native_color(content.color),
+            get_native_color(content.foreground),
             get_native_color(content.background),
         )
     elif isinstance(content, LineGauge):
         render_ir = core.CoreRenderIR.line_gauge(
             content.progress,
             content.label,
-            get_native_color(content.color),
+            get_native_color(content.foreground),
             get_native_color(content.background),
             get_native_color(content.filled_color),
             get_native_color(content.unfilled_color),
@@ -466,7 +466,7 @@ def lower_content(content: Any) -> core.CoreRenderNode:
         render_ir = core.CoreRenderIR.sparkline(
             list(content.data),
             content.max_value,
-            get_native_color(content.color),
+            get_native_color(content.foreground),
             get_native_color(content.background),
             get_native_color(content.absent_value_color),
             content.absent_value_symbol,
@@ -475,7 +475,7 @@ def lower_content(content: Any) -> core.CoreRenderNode:
         render_ir = core.CoreRenderIR.list(
             [_line_from_value(item) for item in content.items],
             content.selected,
-            get_native_color(content.color),
+            get_native_color(content.foreground),
             get_native_color(content.background),
             get_native_color(content.highlight_color),
             get_native_color(content.highlight_background),
@@ -560,7 +560,7 @@ def lower_content(content: Any) -> core.CoreRenderNode:
             gap=content.gap,
         )
     elif isinstance(content, Panel):
-        from xnano.types import Padding
+        from xnano.area import Padding
 
         block = native.Block.default()
         sides = content.border_sides

--- a/xnano/core/runtime.py
+++ b/xnano/core/runtime.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Generic, Sequence, TypeVar
 from xnano_core.core import CoreSession
 
 from xnano.actions import Actions
+from xnano.area import Alignment, PaddingLike, VerticalAlignment
 from xnano.colors import ColorLike
 from xnano.core.content import Panel, Stack, TextBlock
 from xnano.core.frame import Frame
@@ -27,13 +28,16 @@ from xnano.cursor import Cursor
 from xnano.device import Device
 from xnano.events import event_from_core
 from xnano.types import (
-    Alignment,
     Border,
     CharacterModifier,
     Direction,
     FrameTitlePosition,
-    PaddingLike,
     Side,
+    is_grid,
+)
+from xnano.utils.deprecation import (
+    resolve_color_alias,
+    resolve_renamed_alias,
 )
 
 StateT = TypeVar("StateT")
@@ -341,10 +345,11 @@ class Runtime(Generic[StateT]):
     def _render(
         self,
         *renderables: Any,
-        color: ColorLike | None = None,
+        foreground: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
-        align: Alignment | None = None,
+        horizontal_align: Alignment | None = None,
+        vertical_align: VerticalAlignment | None = None,
         border: Border | None = None,
         border_sides: Sequence[Side] | None = None,
         border_color: ColorLike | None = None,
@@ -359,10 +364,11 @@ class Runtime(Generic[StateT]):
         Args:
             *renderables: Grids, components, content primitives, or plain
                 values to paint.
-            color: Foreground color applied to plain values.
+            foreground: Foreground color applied to plain values.
             background: Background color for the rendered area.
             modifiers: Character modifiers applied to plain values.
-            align: Horizontal alignment applied to plain values.
+            horizontal_align: Horizontal alignment applied to plain values.
+        vertical_align: Vertical alignment applied to plain values.
             border: Border style around the rendered area.
             border_sides: Border sides to draw.
             border_color: Border foreground color.
@@ -386,11 +392,9 @@ class Runtime(Generic[StateT]):
             dispatch_post_init(self._root, self)
             ensure_default_field_focus(self)
             dispatch_frame(self._root, self)
-        if len(items) == 1 and isinstance(
-            getattr(type(items[0]), "_grid_fields", None), dict
-        ):
+        if len(items) == 1 and is_grid(items[0]):
+            from xnano.area import Area
             from xnano.core.controller import TerminalController
-            from xnano.types import Area
 
             self._stage.areas.clear()
             controller = TerminalController(self)
@@ -415,10 +419,11 @@ class Runtime(Generic[StateT]):
         styled_items = tuple(
             TextBlock(
                 text=item,
-                color=color,
+                foreground=foreground,
                 background=background,
                 modifiers=tuple(modifiers or ()),
-                align=align,
+                horizontal_align=horizontal_align,
+                vertical_align=vertical_align,
             )
             if isinstance(item, str)
             else item
@@ -433,9 +438,9 @@ class Runtime(Generic[StateT]):
             # the remainder left blank at the end.
             # ponytail: bordered/paneled multi-render still uses the fill path
             # below — revisit if a framed multi-render needs content packing.
+            from xnano.area import Area
             from xnano.core.controller import TerminalController
             from xnano.core.layout import LayoutConstraint
-            from xnano.types import Area
 
             self._stage.areas.clear()
             controller = TerminalController(self)
@@ -490,10 +495,11 @@ class Runtime(Generic[StateT]):
     def render(
         self,
         *renderables: Any,
-        color: ColorLike | None = None,
+        foreground: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
-        align: Alignment | None = None,
+        horizontal_align: Alignment | None = None,
+        vertical_align: VerticalAlignment | None = None,
         border: Border | None = None,
         border_sides: Sequence[Side] | None = None,
         border_color: ColorLike | None = None,
@@ -502,14 +508,25 @@ class Runtime(Generic[StateT]):
         padding: PaddingLike | None = None,
         gap: int = 0,
         direction: Direction = "vertical",
+        color: ColorLike | None = None,
+        align: Alignment | None = None,
     ) -> Frame:
         """Render one frame and return its immutable snapshot."""
+        foreground = resolve_color_alias(foreground, color, stacklevel=3)
+        horizontal_align = resolve_renamed_alias(
+            horizontal_align,
+            align,
+            old="align",
+            new="horizontal_align",
+            stacklevel=3,
+        )
         self._render(
             *renderables,
-            color=color,
+            foreground=foreground,
             background=background,
             modifiers=modifiers,
-            align=align,
+            horizontal_align=horizontal_align,
+            vertical_align=vertical_align,
             border=border,
             border_sides=border_sides,
             border_color=border_color,
@@ -602,7 +619,7 @@ class Runtime(Generic[StateT]):
         handle = hit.grid._grid_scroll_handle(hit.field_name)
         delta = -self._WHEEL_STEP if kind == "scroll_up" else self._WHEEL_STEP
         handle.scroll(delta)
-        hit.grid.mark_field_dirty(hit.field_name)
+        hit.grid.grid_mark_field_dirty(hit.field_name)
 
     def _click_to_focus(self, hit: Any, field: Any, kind: str) -> None:
         """Focus a focusable field when it is clicked.
@@ -714,28 +731,47 @@ class Runtime(Generic[StateT]):
         effect: Any,
         *,
         fields: list[str] | None = None,
-    ) -> bool:
+        repeat: bool = False,
+    ) -> list[str]:
         """Play an effect over fields recorded by the latest render.
 
         Args:
             effect: Effect description.
             fields: Field names whose rendered areas receive the effect.
+            repeat: Loop the effect until it is cancelled, instead of
+                running once for its duration.
 
         Returns:
-            Whether at least one named field had a rendered area.
+            The session keys registered, one per field that had a
+            rendered area. Empty when nothing was targeted.
         """
+        import xnano_core.rust.native as native
+
         from xnano.core.effects import resolve_native_effect
 
-        played = False
+        keys: list[str] = []
+        lowered = None
         for field in fields or ():
             area = self._session.effect_area_for(field)
             if area is None:
                 continue
-            native_effect = resolve_native_effect(effect).with_area(area)
+            if lowered is None:
+                # Lower once, not once per target field.
+                lowered = resolve_native_effect(effect)
+                if repeat:
+                    lowered = native.repeating_effect(lowered)
             key = f"{getattr(effect, 'key', None) or field}:{field}"
-            self._session.add_unique_effect(key, native_effect)
-            played = True
-        return played
+            self._session.add_unique_effect(key, lowered.with_area(area))
+            keys.append(key)
+        return keys
+
+    def cancel_effect(self, key: str) -> None:
+        """Stop the effect registered under ``key``."""
+        self._session.cancel_effect(key)
+
+    def is_animating(self) -> bool:
+        """Whether any effect is currently running in this session."""
+        return bool(self._session.is_animating())
 
     def perform(self, action: Any) -> None:
         """Perform a synthetic action through its event representation."""

--- a/xnano/core/stage.py
+++ b/xnano/core/stage.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Sequence
 
+from xnano.area import Area
 from xnano.colors import ColorLike
-from xnano.types import Area, CharacterModifier
+from xnano.types import CharacterModifier
+from xnano.utils.deprecation import resolve_color_alias
 
 
 @dataclasses.dataclass(slots=True)
@@ -19,7 +21,7 @@ class Stage:
     """Store named layout areas and frame-local paint requests.
 
     Example:
-        ``stage.paint_cell(2, 1, "!", color="yellow")``
+        ``stage.paint_cell(2, 1, "!", foreground="yellow")``
 
     Attributes:
         areas: Areas keyed by field or effect name.
@@ -52,9 +54,10 @@ class Stage:
         y: int,
         value: str,
         *,
-        color: ColorLike | None = None,
+        foreground: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
+        color: ColorLike | None = None,
     ) -> None:
         """Queue one styled cell write for the current frame.
 
@@ -62,16 +65,18 @@ class Stage:
             x: Cell column.
             y: Cell row.
             value: Character or grapheme to paint.
-            color: Foreground color.
+            foreground: Foreground color.
             background: Background color.
             modifiers: Character modifiers.
+            color: Deprecated alias for ``foreground``.
         """
+        foreground = resolve_color_alias(foreground, color, stacklevel=3)
         self._commands.append(
             {
                 "x": x,
                 "y": y,
                 "value": value,
-                "color": color,
+                "foreground": foreground,
                 "background": background,
                 "modifiers": tuple(modifiers or ()),
             },

--- a/xnano/cursor.py
+++ b/xnano/cursor.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Literal, TypeAlias, cast
 
 import xnano_core.rust.native as native
 
-from xnano.types import Coordinate
+from xnano.area import Coordinate
 
 if TYPE_CHECKING:
     from xnano.core.runtime import Runtime

--- a/xnano/device.py
+++ b/xnano/device.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 import xnano_core.rust.native as native
 
-from xnano.types import Size
+from xnano.area import Size
 
 if TYPE_CHECKING:
     from xnano.core.runtime import Runtime

--- a/xnano/effects.py
+++ b/xnano/effects.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import abc
 import dataclasses
-from typing import Literal, Sequence, TypeAlias, overload
+from typing import Any, Literal, Sequence, TypeAlias, overload
 
 from xnano.colors import ColorLike
 
@@ -163,7 +163,7 @@ class AbstractEffect(abc.ABC):
     Examples:
         ```python
         effect = FadeEffect(color="violet", duration_ms=250)
-        context.play_effect("content", effect)
+        self.grid_effect(effect, fields=["content"])
         ```
     """
 
@@ -740,6 +740,71 @@ def Effect(
     )
 
 
+@dataclasses.dataclass(slots=True)
+class EffectHandle:
+    """A running effect, per target field.
+
+    Truthy when at least one target field had a rendered area, so
+    ``if self.grid_effect(...)`` keeps working. Also a context manager:
+    the effect is cancelled on exit, which is how an effect is scoped to a
+    block rather than to a duration.
+
+    Example:
+        ```python
+        with self.grid_effect("pulse", fields=["body"]):
+            do_slow_work()
+        ```
+    """
+
+    keys: tuple[str, ...] = ()
+    """Session keys this handle cancels, one per target field."""
+    runtime: Any = None
+    """Runtime that registered the effect."""
+    effect: "AbstractEffect | None" = None
+    """Resolved effect, replayed on ``__enter__`` when looping."""
+    fields: tuple[str, ...] = ()
+    """Target field names, for replay."""
+    loop_in_context: bool = False
+    """Whether entering a ``with`` block should loop the effect."""
+    _cancelled: bool = dataclasses.field(default=False, init=False)
+
+    def __bool__(self) -> bool:
+        return bool(self.keys)
+
+    @property
+    def active(self) -> bool:
+        """Whether the effect is still animating.
+
+        ``False`` once cancelled. Otherwise reflects the session's own
+        animation state, which is shared across effects — see
+        ``Runtime.is_animating``.
+        """
+        if self._cancelled or not self.keys or self.runtime is None:
+            return False
+        return bool(self.runtime.is_animating())
+
+    def cancel(self) -> None:
+        """Stop the effect on every target field. Idempotent."""
+        if self._cancelled or self.runtime is None:
+            return
+        for key in self.keys:
+            self.runtime.cancel_effect(key)
+        self._cancelled = True
+
+    def __enter__(self) -> "EffectHandle":
+        # A block-scoped effect with no explicit duration should last as
+        # long as the block, so re-register it looping. The session keys
+        # are unchanged, so this replaces rather than stacks.
+        if self.loop_in_context and self.keys and self.runtime is not None:
+            self.runtime.play_effect(
+                self.effect, fields=list(self.fields), repeat=True
+            )
+        return self
+
+    def __exit__(self, *exception: Any) -> None:
+        self.cancel()
+
+
 __all__ = (
     "AbstractEffect",
     "CoalesceEffect",
@@ -748,6 +813,7 @@ __all__ = (
     "DissolveEffect",
     "Effect",
     "EffectColorSpace",
+    "EffectHandle",
     "EffectCellFilter",
     "EffectInterpolation",
     "EffectMotion",

--- a/xnano/fields.py
+++ b/xnano/fields.py
@@ -20,11 +20,16 @@ from typing import (
     overload,
 )
 
-from xnano import types
+from xnano import area, types
 from xnano.colors import ColorLike
 from xnano.tailwind import Style
 from xnano.types import FrameTitlePosition, Sizing, SizingLike
-from xnano.utils.deprecation import warn_color_alias
+from xnano.utils.deprecation import (
+    align_alias_dataclass,
+    color_alias_dataclass,
+    resolve_renamed_alias,
+    warn_color_alias,
+)
 
 if TYPE_CHECKING:
     from xnano.tailwind import TailwindClass
@@ -65,6 +70,8 @@ def _normalize_slide_axes(
     return axes
 
 
+@align_alias_dataclass
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class GridFieldInfo:
     """Descriptor class for layout, frame and additional rendering metadata for
@@ -107,7 +114,10 @@ class GridFieldInfo:
             shrinks the slot along the cross axis otherwise.
         gap: The gap between fields in this field or area.
         direction: The direction in which content within this field or area should be laid out.
-        align: The horizontal alignment of content within this field's area.
+        horizontal_align: The horizontal alignment of content within this
+            field's area.
+        vertical_align: The vertical alignment of content within this
+            field's area.
         border: A border style to be applied onto the outer frame of the rectangular area this
             field occupies.
         border_sides: The sides of the border to be applied onto the outer frame of the area
@@ -154,7 +164,7 @@ class GridFieldInfo:
         - ``"rapid_blink"``: Causes the content to blink rapidly.
         - ``"reversed"``: Swaps foreground and background colors.
     """
-    color: ColorLike | None = None
+    foreground: ColorLike | None = None
     """The foreground color of content within this field."""
     background: ColorLike | None = None
     """The background color of content within this field.
@@ -191,8 +201,10 @@ class GridFieldInfo:
     """The direction in which content within this field or area should be
     laid out.
     """
-    align: types.Alignment | None = None
+    horizontal_align: area.Alignment | None = None
     """The horizontal alignment of content within this field's area."""
+    vertical_align: area.VerticalAlignment | None = None
+    """The vertical alignment of content within this field's area."""
     border: types.Border | None = None
     """A border style to be applied onto the outer frame of the rectangular area
     this field occupies.
@@ -207,7 +219,7 @@ class GridFieldInfo:
     """A title to be displayed around the outer frame of this field's area."""
     title_position: FrameTitlePosition | None = None
     """The alignment of the title within the outer frame of this field's area."""
-    padding: types.PaddingLike | None = None
+    padding: area.PaddingLike | None = None
     """The padding to be applied around the content area of this field."""
     slide: list[str] | None = None
     """The axes along which this field may slide within its parent grid."""
@@ -240,7 +252,7 @@ class GridFieldInfo:
     backend emits these classes verbatim; the terminal backend renders
     through the lowered attributes instead.
     """
-    margin: types.PaddingLike | None = None
+    margin: area.PaddingLike | None = None
     """The margin to be applied around the outer area of this field.
 
     Also populated by Tailwind ``m*-{n}`` classes through
@@ -283,28 +295,28 @@ class GridFieldInfo:
         )
         classes = self.class_name if self.class_name is not None else ()
         return Style(
-            color=self.color,
+            foreground=self.foreground,
             background=self.background,
             border=self.border,
             border_color=self.border_color,
             border_sides=border_sides,
             padding=(
-                types.Padding.parse(self.padding)
+                area.Padding.parse(self.padding)
                 if self.padding is not None
-                and not isinstance(self.padding, types.Padding)
+                and not isinstance(self.padding, area.Padding)
                 else self.padding  # type: ignore[arg-type]
             ),
             margin=(
-                types.Padding.parse(self.margin)
+                area.Padding.parse(self.margin)
                 if self.margin is not None
-                and not isinstance(self.margin, types.Padding)
+                and not isinstance(self.margin, area.Padding)
                 else self.margin  # type: ignore[arg-type]
             ),
             gap=self.gap,
             width=self.width,
             height=self.height,
             modifiers=modifiers,
-            align=self.align,
+            horizontal_align=self.horizontal_align,
             direction=self.direction,
             title=self.title,
             title_position=self.title_position,
@@ -339,7 +351,7 @@ class FieldState:
         Inspect live state without changing the field descriptor:
 
         ```python
-        state = grid.get_field_state("search")
+        state = grid.grid_get_field_state("search")
         if state.focused:
             ...
         ```
@@ -355,7 +367,7 @@ class FieldState:
     """Whether a pointer is over this field's slot."""
     dirty: bool = False
     """Whether the value or overrides changed since last paint."""
-    slide_position: types.Coordinate | None = None
+    slide_position: area.Coordinate | None = None
     """Optional drag offset for slidable fields."""
     overrides: dict[str, Any] = dataclasses.field(default_factory=dict)
     """Per-instance style/layout overrides."""
@@ -387,14 +399,15 @@ def Field(
     height: SizingLike | None = None,
     gap: int | None = None,
     direction: types.Direction | None = None,
-    align: types.Alignment | None = None,
+    horizontal_align: area.Alignment | None = None,
+    vertical_align: area.VerticalAlignment | None = None,
     border: types.Border | None = None,
     border_sides: Sequence[types.Side] | None = None,
     border_color: ColorLike | None = None,
     title: str | None = None,
     title_position: FrameTitlePosition | None = None,
-    padding: types.PaddingLike | None = None,
-    margin: types.PaddingLike | None = None,
+    padding: area.PaddingLike | None = None,
+    margin: area.PaddingLike | None = None,
     z: int | None = None,
     overlay: bool = False,
     slide: Sequence[types.Axis] | None = None,
@@ -403,6 +416,7 @@ def Field(
     scroll: types.ScrollLike | None = None,
     wireframe: bool | None = None,
     class_name: ClassNameLike | None = None,
+    align: area.Alignment | None = None,
 ) -> Any: ...
 
 
@@ -424,14 +438,15 @@ def Field(
     height: SizingLike | None = None,
     gap: int | None = None,
     direction: types.Direction | None = None,
-    align: types.Alignment | None = None,
+    horizontal_align: area.Alignment | None = None,
+    vertical_align: area.VerticalAlignment | None = None,
     border: types.Border | None = None,
     border_sides: Sequence[types.Side] | None = None,
     border_color: ColorLike | None = None,
     title: str | None = None,
     title_position: FrameTitlePosition | None = None,
-    padding: types.PaddingLike | None = None,
-    margin: types.PaddingLike | None = None,
+    padding: area.PaddingLike | None = None,
+    margin: area.PaddingLike | None = None,
     z: int | None = None,
     overlay: bool = False,
     slide: Sequence[types.Axis] | None = None,
@@ -440,6 +455,7 @@ def Field(
     scroll: types.ScrollLike | None = None,
     wireframe: bool | None = None,
     class_name: ClassNameLike | None = None,
+    align: area.Alignment | None = None,
 ) -> _T: ...
 
 
@@ -460,14 +476,15 @@ def Field(
     height: SizingLike | None = None,
     gap: int | None = None,
     direction: types.Direction | None = None,
-    align: types.Alignment | None = None,
+    horizontal_align: area.Alignment | None = None,
+    vertical_align: area.VerticalAlignment | None = None,
     border: types.Border | None = None,
     border_sides: Sequence[types.Side] | None = None,
     border_color: ColorLike | None = None,
     title: str | None = None,
     title_position: FrameTitlePosition | None = None,
-    padding: types.PaddingLike | None = None,
-    margin: types.PaddingLike | None = None,
+    padding: area.PaddingLike | None = None,
+    margin: area.PaddingLike | None = None,
     z: int | None = None,
     overlay: bool = False,
     slide: Sequence[types.Axis] | None = None,
@@ -476,6 +493,7 @@ def Field(
     scroll: types.ScrollLike | None = None,
     wireframe: bool | None = None,
     class_name: ClassNameLike | None = None,
+    align: area.Alignment | None = None,
 ) -> _T: ...
 
 
@@ -497,14 +515,15 @@ def Field(
     height: SizingLike | None = None,
     gap: int | None = None,
     direction: types.Direction | None = None,
-    align: types.Alignment | None = None,
+    horizontal_align: area.Alignment | None = None,
+    vertical_align: area.VerticalAlignment | None = None,
     border: types.Border | None = None,
     border_sides: Sequence[types.Side] | None = None,
     border_color: ColorLike | None = None,
     title: str | None = None,
     title_position: FrameTitlePosition | None = None,
-    padding: types.PaddingLike | None = None,
-    margin: types.PaddingLike | None = None,
+    padding: area.PaddingLike | None = None,
+    margin: area.PaddingLike | None = None,
     z: int | None = None,
     overlay: bool = False,
     slide: Sequence[types.Axis] | None = None,
@@ -513,6 +532,7 @@ def Field(
     scroll: types.ScrollLike | None = None,
     wireframe: bool | None = None,
     class_name: ClassNameLike | None = None,
+    align: area.Alignment | None = None,
 ) -> Any: ...
 
 
@@ -533,14 +553,15 @@ def Field(
     height: SizingLike | None = None,
     gap: int | None = None,
     direction: types.Direction | None = None,
-    align: types.Alignment | None = None,
+    horizontal_align: area.Alignment | None = None,
+    vertical_align: area.VerticalAlignment | None = None,
     border: types.Border | None = None,
     border_sides: Sequence[types.Side] | None = None,
     border_color: ColorLike | None = None,
     title: str | None = None,
     title_position: FrameTitlePosition | None = None,
-    padding: types.PaddingLike | None = None,
-    margin: types.PaddingLike | None = None,
+    padding: area.PaddingLike | None = None,
+    margin: area.PaddingLike | None = None,
     z: int | None = None,
     overlay: bool = False,
     slide: Sequence[types.Axis] | None = None,
@@ -549,6 +570,7 @@ def Field(
     scroll: types.ScrollLike | None = None,
     wireframe: bool | None = None,
     class_name: ClassNameLike | None = None,
+    align: area.Alignment | None = None,
 ) -> GridFieldInfo:
     """Create a new grid field info instance.
 
@@ -580,7 +602,10 @@ def Field(
             shrinks the slot along the cross axis otherwise.
         gap: The gap between fields in this field or area.
         direction: The direction in which content within this field or area should be laid out.
-        align: The horizontal alignment of content within this field's area.
+        horizontal_align: The horizontal alignment of content within this
+            field's area.
+        vertical_align: The vertical alignment of content within this
+            field's area.
         border: A border style to be applied onto the outer frame of the rectangular area this
             field occupies.
         border_sides: The sides of the border to be applied onto the outer frame of the area
@@ -614,6 +639,13 @@ def Field(
         warn_color_alias(stacklevel=2)
         if foreground is None:
             foreground = color
+    horizontal_align = resolve_renamed_alias(
+        horizontal_align,
+        align,
+        old="align",
+        new="horizontal_align",
+        stacklevel=2,
+    )
     tokens: tuple[str, ...] | None = None
     if class_name is not None:
         from xnano.tailwind import (
@@ -624,7 +656,7 @@ def Field(
         tokens = normalize_tailwind_classes(class_name)
         resolved = resolve_tailwind_classes(tokens)
         if foreground is None:
-            foreground = resolved.color
+            foreground = resolved.foreground
         if background is None:
             background = resolved.background
         if border is None:
@@ -645,8 +677,8 @@ def Field(
             height = resolved.height
         if modifiers is None and resolved.modifiers:
             modifiers = resolved.modifiers
-        if align is None:
-            align = resolved.align
+        if horizontal_align is None:
+            horizontal_align = resolved.horizontal_align
         if direction is None:
             direction = resolved.direction
 
@@ -657,7 +689,7 @@ def Field(
         strict=strict,
         init=init,
         visible=visible,
-        color=foreground,
+        foreground=foreground,
         modifiers=modifiers,
         background=background,
         fill=fill,
@@ -665,7 +697,8 @@ def Field(
         height=Sizing.parse(height),
         gap=gap,
         direction=direction,
-        align=align,
+        horizontal_align=horizontal_align,
+        vertical_align=vertical_align,
         border=border,
         border_sides=border_sides,
         border_color=border_color,

--- a/xnano/grids.py
+++ b/xnano/grids.py
@@ -33,6 +33,14 @@ if sys.version_info < (3, 11):
 else:
     from typing import NotRequired, Unpack, dataclass_transform
 
+from xnano.area import (
+    Alignment,
+    Area,
+    Padding,
+    PaddingLike,
+    VerticalAlignment,
+    align_area,
+)
 from xnano.colors import ColorLike
 from xnano.core.interface import AbstractInterface
 from xnano.core.layout import LayoutConstraint
@@ -44,19 +52,21 @@ from xnano.fields import (
     _normalize_slide_axes,
 )
 from xnano.types import (
-    Alignment,
-    Area,
     Axis,
     Border,
     CharacterModifier,
     Direction,
     Frame,
     FrameTitlePosition,
-    Padding,
-    PaddingLike,
     Side,
     SizingLike,
     frame_from_field,
+)
+from xnano.utils.deprecation import (
+    resolve_color_alias,
+    resolve_renamed_alias,
+    warn_color_alias,
+    warn_renamed_attribute,
 )
 from xnano.utils.responsive import (
     breakpoint_for_width,
@@ -67,6 +77,7 @@ from xnano.utils.responsive import (
 if TYPE_CHECKING:
     from xnano.effects import (
         AbstractEffect,
+        EffectHandle,
         EffectInterpolation,
         EffectMotion,
         KnownEffectKind,
@@ -110,14 +121,15 @@ _GRID_FIELD_CONFIG_KEYS: frozenset[str] = frozenset(
         "visible",
         "z",
         "wireframe",
-        "color",
+        "foreground",
         "background",
         "fill",
         "width",
         "height",
         "gap",
         "direction",
-        "align",
+        "horizontal_align",
+        "vertical_align",
         "border",
         "border_sides",
         "border_color",
@@ -177,7 +189,7 @@ class GridSettings(TypedDict, total=False):
     """Rendering, layout, and frame settings for a ``BaseGrid`` subclass.
 
     Attributes:
-        color: Foreground color of rendered content.
+        foreground: Foreground color of rendered content.
         background: Background color of the grid frame.
         direction: Direction used to lay out fields.
         gap: Cells between fields.
@@ -197,7 +209,7 @@ class GridSettings(TypedDict, total=False):
         strict: Whether field assignments are validated.
     """
 
-    color: NotRequired[ColorLike]
+    foreground: NotRequired[ColorLike]
     """The foreground color of the grid's content."""
     background: NotRequired[ColorLike]
     """The background color of the grid's frame area."""
@@ -236,12 +248,31 @@ class GridSettings(TypedDict, total=False):
     type annotations during grid construction."""
 
 
+def _resolve_settings_color_alias(
+    settings: GridSettings | None,
+) -> Any:
+    """Map a deprecated ``color`` grid setting onto ``foreground``.
+
+    ``foreground`` wins when both are given, matching every other
+    ``color`` alias in the library.
+    """
+    if not settings or "color" not in settings:
+        return settings
+    resolved = dict(settings)
+    color = resolved.pop("color")
+    warn_color_alias(stacklevel=4)
+    resolved.setdefault("foreground", color)
+    return resolved
+
+
 def _merge_grid_settings(
     bases: tuple[type, ...],
     class_kwargs: GridSettings,
     declared: GridSettings | None = None,
 ) -> GridSettings:
     """Merge grid settings from bases, class-header kwargs, and body dict."""
+    class_kwargs = _resolve_settings_color_alias(class_kwargs)
+    declared = _resolve_settings_color_alias(declared)
     merged: GridSettings = {}
     for base in bases:
         if base is object:
@@ -370,7 +401,7 @@ def _expand_field_class_name_config(
     expanded = dict(field_config)
     expanded["class_name"] = tokens
     derived_keys = (
-        "color",
+        "foreground",
         "background",
         "border",
         "border_color",
@@ -380,7 +411,7 @@ def _expand_field_class_name_config(
         "gap",
         "width",
         "height",
-        "align",
+        "horizontal_align",
         "direction",
     )
     for key in derived_keys:
@@ -524,17 +555,17 @@ def _resolve_slot_area(
     if length >= available:
         return slot_area
     if horizontal:
-        return Area(
-            x=slot_area.x,
-            y=slot_area.y,
-            width=length,
-            height=slot_area.height,
+        return align_area(
+            slot_area,
+            length,
+            slot_area.height,
+            horizontal=field.horizontal_align,
         )
-    return Area(
-        x=slot_area.x,
-        y=slot_area.y,
-        width=slot_area.width,
-        height=length,
+    return align_area(
+        slot_area,
+        slot_area.width,
+        length,
+        vertical=field.vertical_align,
     )
 
 
@@ -551,11 +582,12 @@ def _grid_overlay_area(inner: Area, field: GridFieldInfo) -> Area:
         width = max(1, min(field.width.resolve(inner.width), inner.width))
     if field.height is not None and not field.height.is_fill:
         height = max(1, min(field.height.resolve(inner.height), inner.height))
-    return Area(
-        x=inner.x + (inner.width - width) // 2,
-        y=inner.y + (inner.height - height) // 2,
-        width=width,
-        height=height,
+    return align_area(
+        inner,
+        width,
+        height,
+        horizontal=field.horizontal_align or "center",
+        vertical=field.vertical_align or "middle",
     )
 
 
@@ -680,7 +712,7 @@ def _build_grid_init(
                 setattr(self, name, defaults[name])
             else:
                 setattr(self, name, None)
-        self._init_field_states()
+        self._grid_init_field_states()
         self._grid_validate_init()
         self.__post_init__()
 
@@ -1033,6 +1065,13 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
     _grid_field_frames: ClassVar[dict[str, Frame | None]] = {}
     _grid_responsive_renders: ClassVar[dict[str, str]] = {}
 
+    __xnano_grid__: ClassVar[bool] = True
+    """Marks this class as a grid, for cheap identity checks.
+
+    Faster and clearer than duck-typing ``_grid_fields``, and usable from
+    layers that must not import ``BaseGrid`` — see ``is_grid``.
+    """
+
     visible: bool = True
     """Whether this grid is rendered in the live session."""
     z: int = 0
@@ -1043,7 +1082,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
     """Terminal rows available to this grid — set by the session each frame."""
 
     def __init__(self) -> None:
-        self._init_field_states()
+        self._grid_init_field_states()
         self.__post_init__()
 
     def __post_init__(self) -> None:
@@ -1068,11 +1107,11 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         """
 
     @property
-    def focused(self) -> bool:
+    def grid_focused(self) -> bool:
         """Whether any of this grid's fields currently holds field focus.
 
         Live alongside per-component ``focused``: derived from the same
-        per-frame focus flags, so ``self.focused`` in a hook and
+        per-frame focus flags, so ``self.grid_focused`` in a hook and
         ``@on_field("focused")`` both read the current state.
         """
         return any(
@@ -1142,17 +1181,29 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         object.__setattr__(self, name, value)
         # Live FieldState dirty bit + host notification (skip private attrs
         # and fields not yet tracked during construction).
-        if not name.startswith("_") and hasattr(self, "_field_states"):
-            if name in self._field_states or name in self._grid_fields:
-                self.mark_field_dirty(name)
+        if not name.startswith("_") and hasattr(self, "_grid_field_states"):
+            if name in self._grid_field_states or name in self._grid_fields:
+                self.grid_mark_field_dirty(name)
 
     @property
-    def state(self) -> Any:
+    def grid_state(self) -> Any:
         """Return the active terminal's shared state, or ``None``."""
         from xnano.core.runtime import get_active_runtime
 
         runtime = get_active_runtime()
         return None if runtime is None else runtime.state
+
+    @property
+    @warn_renamed_attribute("BaseGrid.focused", "BaseGrid.grid_focused")
+    def focused(self) -> bool:
+        """Deprecated alias for ``grid_focused``."""
+        return self.grid_focused
+
+    @property
+    @warn_renamed_attribute("BaseGrid.state", "BaseGrid.grid_state")
+    def state(self) -> Any:
+        """Deprecated alias for ``grid_state``."""
+        return self.grid_state
 
     def _grid_call_render(self) -> None:
         """Invoke ``grid_render`` with the arity the subclass declared.
@@ -1269,6 +1320,9 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         key: str | None = None,
     ) -> bool: ...
 
+    @warn_renamed_attribute(
+        "BaseGrid.grid_play_effect", "BaseGrid.grid_effect"
+    )
     def grid_play_effect(
         self,
         effect: KnownEffectKind | AbstractEffect,
@@ -1319,15 +1373,94 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             ``True`` when at least one field area was found and an effect
             started.
         """
+        return bool(
+            self.grid_effect(
+                effect,
+                duration_ms=duration_ms,
+                color=color,
+                background=background,
+                direction=direction,
+                gradient_length=gradient_length,
+                randomness=randomness,
+                interpolation=interpolation,
+                effects=effects,
+                child=child,
+                times=times,
+                fields=fields,
+                key=key,
+            )
+        )
+
+    def grid_effect(
+        self,
+        effect: KnownEffectKind | AbstractEffect,
+        *,
+        duration_ms: int | None = None,
+        color: ColorLike | None = None,
+        background: ColorLike | None = None,
+        direction: EffectMotion | None = None,
+        gradient_length: int | None = None,
+        randomness: int | None = None,
+        interpolation: EffectInterpolation | None = None,
+        effects: Sequence[AbstractEffect] | None = None,
+        child: AbstractEffect | None = None,
+        times: int | None = None,
+        fields: list[str] | None = None,
+        key: str | None = None,
+    ) -> "EffectHandle":
+        """Run a visual effect on one or more layout field areas.
+
+        Returns an ``EffectHandle``: truthy when at least one field was
+        targeted, with ``.active`` and ``.cancel()``, and usable as a
+        context manager that cancels the effect on exit.
+
+        Starting an effect never blocks. ``duration_ms`` is the animation
+        length handed to the renderer, not a sleep — the effect advances
+        one frame at a time, so hooks keep running while it plays. Omit it
+        inside a ``with`` block and the effect repeats until the block
+        exits.
+
+        Args:
+            effect: A built effect instance or a known effect kind string.
+            duration_ms: Animation length in milliseconds. Defaults to
+                300; omitted inside a ``with`` block the effect repeats
+                until exit.
+            color: Foreground or accent color for color-driven effects.
+            background: Background color for two-color effects.
+            direction: Motion direction for slide and sweep effects.
+            gradient_length: Gradient length for slide and sweep effects.
+            randomness: Randomness for slide and sweep effects.
+            interpolation: Interpolation curve for the effect.
+            effects: Child effects for sequence and parallel composition.
+            child: Child effect for repeat and delay composition.
+            times: Repeat count for repeat effects.
+            fields: Layout field names to target. When omitted or empty,
+                no effect is started.
+            key: Identity used to de-duplicate this effect per target
+                field — see ``AbstractEffect.key``. Calling with the same
+                ``key`` every tick replaces the running effect rather than
+                stacking new ones.
+
+        Returns:
+            A handle for the started effect.
+
+        Examples:
+            ```python
+            self.grid_effect("fade", fields=["body"])
+
+            with self.grid_effect("pulse", fields=["body"]):
+                do_slow_work()
+            ```
+        """
         from xnano.core.runtime import get_active_runtime
-        from xnano.effects import resolve_effect
+        from xnano.effects import EffectHandle, resolve_effect
 
         runtime = get_active_runtime()
         if runtime is None:
-            return False
+            return EffectHandle()
         resolved_effect = resolve_effect(
             effect,
-            duration_ms=duration_ms,
+            duration_ms=300 if duration_ms is None else duration_ms,
             color=color,
             background=background,
             direction=direction,
@@ -1339,10 +1472,14 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             times=times,
             key=key,
         )
-        play_effect = getattr(runtime, "play_effect", None)
-        if not callable(play_effect):
-            return False
-        return bool(play_effect(resolved_effect, fields=fields))
+        keys = runtime.play_effect(resolved_effect, fields=fields)
+        return EffectHandle(
+            keys=tuple(keys),
+            runtime=runtime,
+            effect=resolved_effect,
+            fields=tuple(fields or ()),
+            loop_in_context=duration_ms is None,
+        )
 
     def _grid_field_info(self, name: str) -> GridFieldInfo:
         overrides = getattr(self, "_grid_field_overrides", None)
@@ -1559,14 +1696,15 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         slide: Sequence[Axis] | None = UNSET,
         visible: bool | None = UNSET,
         wireframe: bool | None = UNSET,
-        color: ColorLike | None = UNSET,
+        foreground: ColorLike | None = UNSET,
         background: ColorLike | None = UNSET,
         fill: bool | None = UNSET,
         width: SizingLike | None = UNSET,
         height: SizingLike | None = UNSET,
         gap: int | None = UNSET,
         direction: Direction | None = UNSET,
-        align: Alignment | None = UNSET,
+        horizontal_align: Alignment | None = UNSET,
+        vertical_align: VerticalAlignment | None = UNSET,
         border: Border | None = UNSET,
         border_sides: Sequence[Side] | None = UNSET,
         border_color: ColorLike | None = UNSET,
@@ -1584,6 +1722,8 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         slow_blink: bool = UNSET,
         rapid_blink: bool = UNSET,
         reversed: bool = UNSET,
+        color: ColorLike | None = UNSET,
+        align: Alignment | None = UNSET,
     ) -> None:
         """Set a layout field's runtime value and/or per-instance field metadata.
 
@@ -1593,7 +1733,20 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         For frequent, value-free style ticks (e.g. from ``on_tick`` or an
         effect callback), prefer ``grid_update_field`` — it skips the
         value/position handling this method carries for the general case.
+
+        ``color`` is a deprecated alias for ``foreground``.
         """
+        foreground = resolve_color_alias(
+            foreground, color, unset=UNSET, stacklevel=3
+        )
+        horizontal_align = resolve_renamed_alias(
+            horizontal_align,
+            align,
+            old="align",
+            new="horizontal_align",
+            unset=UNSET,
+            stacklevel=3,
+        )
         field_config: dict[str, Any] = {
             key: option
             for key, option in {
@@ -1601,14 +1754,15 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
                 "slide": slide,
                 "visible": visible,
                 "wireframe": wireframe,
-                "color": color,
+                "foreground": foreground,
                 "background": background,
                 "fill": fill,
                 "width": width,
                 "height": height,
                 "gap": gap,
                 "direction": direction,
-                "align": align,
+                "horizontal_align": horizontal_align,
+                "vertical_align": vertical_align,
                 "border": border,
                 "border_sides": border_sides,
                 "border_color": border_color,
@@ -1662,14 +1816,15 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         slide: Sequence[Axis] | None = UNSET,
         visible: bool | None = UNSET,
         wireframe: bool | None = UNSET,
-        color: ColorLike | None = UNSET,
+        foreground: ColorLike | None = UNSET,
         background: ColorLike | None = UNSET,
         fill: bool | None = UNSET,
         width: SizingLike | None = UNSET,
         height: SizingLike | None = UNSET,
         gap: int | None = UNSET,
         direction: Direction | None = UNSET,
-        align: Alignment | None = UNSET,
+        horizontal_align: Alignment | None = UNSET,
+        vertical_align: VerticalAlignment | None = UNSET,
         border: Border | None = UNSET,
         border_sides: Sequence[Side] | None = UNSET,
         border_color: ColorLike | None = UNSET,
@@ -1687,6 +1842,8 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         slow_blink: bool = UNSET,
         rapid_blink: bool = UNSET,
         reversed: bool = UNSET,
+        color: ColorLike | None = UNSET,
+        align: Alignment | None = UNSET,
     ) -> None:
         """Update a layout field's style/layout attributes, live, in-place.
 
@@ -1698,21 +1855,35 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
         patches never raise: a missing or state-only ``name`` is a no-op
         (no ``try``/``except`` needed), though unknown keyword arguments
         still raise as a programming error.
+
+        ``color`` is a deprecated alias for ``foreground``.
         """
+        foreground = resolve_color_alias(
+            foreground, color, unset=UNSET, stacklevel=3
+        )
+        horizontal_align = resolve_renamed_alias(
+            horizontal_align,
+            align,
+            old="align",
+            new="horizontal_align",
+            unset=UNSET,
+            stacklevel=3,
+        )
         field_config: dict[str, Any] = {
             key: option
             for key, option in {
                 "slide": slide,
                 "visible": visible,
                 "wireframe": wireframe,
-                "color": color,
+                "foreground": foreground,
                 "background": background,
                 "fill": fill,
                 "width": width,
                 "height": height,
                 "gap": gap,
                 "direction": direction,
-                "align": align,
+                "horizontal_align": horizontal_align,
+                "vertical_align": vertical_align,
                 "border": border,
                 "border_sides": border_sides,
                 "border_color": border_color,
@@ -1737,7 +1908,7 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             name, field_config, caller="grid_update_field", missing="ignore"
         )
 
-    def set_frame(
+    def grid_set_frame(
         self,
         frame: Frame | None = UNSET,
         *,
@@ -1784,15 +1955,15 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             self, "_grid_frame", None if updated.is_empty() else updated
         )
 
-    def set_background(self, background: ColorLike | None) -> None:
+    def grid_set_background(self, background: ColorLike | None) -> None:
         """Fill this grid instance's whole area with ``background``.
 
-        Shorthand for ``set_frame(background=...)`` — the ergonomic path for
+        Shorthand for ``grid_set_frame(background=...)`` — the path for
         theming a nested grid, replacing private ``_grid_frame`` mutation.
         """
-        self.set_frame(background=background)
+        self.grid_set_frame(background=background)
 
-    def schedule_update(
+    def grid_schedule_update(
         self,
         callback: Callable[[], Any] | None = None,
         *,
@@ -1813,12 +1984,36 @@ class BaseGrid(AbstractInterface, metaclass=_GridMeta):
             if callback is not None:
                 callback()
             if field is not None:
-                self.mark_field_dirty(field)
+                self.grid_mark_field_dirty(field)
 
         if runtime is None:
             _apply()
         else:
             runtime.call_soon(_apply)
+
+    @warn_renamed_attribute("BaseGrid.set_frame", "BaseGrid.grid_set_frame")
+    def set_frame(self, *args: Any, **kwargs: Any) -> None:
+        """Deprecated alias for ``grid_set_frame``."""
+        self.grid_set_frame(*args, **kwargs)
+
+    @warn_renamed_attribute(
+        "BaseGrid.set_background", "BaseGrid.grid_set_background"
+    )
+    def set_background(self, background: ColorLike | None) -> None:
+        """Deprecated alias for ``grid_set_background``."""
+        self.grid_set_background(background)
+
+    @warn_renamed_attribute(
+        "BaseGrid.schedule_update", "BaseGrid.grid_schedule_update"
+    )
+    def schedule_update(
+        self,
+        callback: Callable[[], Any] | None = None,
+        *,
+        field: str | None = None,
+    ) -> None:
+        """Deprecated alias for ``grid_schedule_update``."""
+        self.grid_schedule_update(callback, field=field)
 
     def _grid_resolve_visible(self, field: GridFieldInfo, value: Any) -> bool:
         if field.visible is None:

--- a/xnano/markdown.py
+++ b/xnano/markdown.py
@@ -619,7 +619,7 @@ class MarkdownViewport(Markdown):
                 Run(
                     text=text,
                     modifiers=("dim",),
-                    color=self.foreground,
+                    foreground=self.foreground,
                     background=self.background,
                 ),
             ),
@@ -635,10 +635,10 @@ class MarkdownViewport(Markdown):
         visible_rows: int,
     ) -> Any:
         """Compose one image block's visible slice (body + caption + gap)."""
+        from xnano.area import Area
         from xnano.components.component import ComponentRenderContext
         from xnano.core.content import CellCanvas
         from xnano.core.rendering import lower_content
-        from xnano.types import Area
 
         body_cols, body_rows = self._image_body_size(
             block,
@@ -780,10 +780,10 @@ class MarkdownViewport(Markdown):
                 node = lower_content(
                     TextBlock(
                         lines=tuple(window),
-                        color=self.foreground,
+                        foreground=self.foreground,
                         background=self.background,
                         modifiers=self.modifiers,
-                        align=self.align,
+                        horizontal_align=self.horizontal_align,
                         wrap=self.wrap,
                     )
                 )
@@ -924,7 +924,7 @@ def _create_markdown_document(
         @hooks.on_keyboard("q", "esc", "ctrl+c")
         def _quit(self, ctx: Any) -> None:
             # Esc collapses a pinned image first; a second press quits.
-            keyboard = getattr(ctx, "keyboard", None)
+            keyboard = getattr(ctx, "keyboard_event", None)
             if (
                 keyboard is not None
                 and keyboard.matches("esc")

--- a/xnano/rendering.py
+++ b/xnano/rendering.py
@@ -12,15 +12,18 @@ import shutil
 import sys
 from typing import IO, Any, Sequence, TextIO
 
+from xnano.area import Alignment, PaddingLike, VerticalAlignment
 from xnano.colors import ColorLike
 from xnano.types import (
-    Alignment,
     Border,
     CharacterModifier,
     Direction,
     FrameTitlePosition,
-    PaddingLike,
     Side,
+)
+from xnano.utils.deprecation import (
+    resolve_color_alias,
+    resolve_renamed_alias,
 )
 
 
@@ -88,7 +91,7 @@ def _plain_render_size(
         width = max(widths, default=1)
         height = sum(heights) + max(0, len(groups) - 1) * gap
 
-    from xnano.types import Padding
+    from xnano.area import Padding
 
     parsed_padding = Padding.parse(padding)
     width += parsed_padding.left + parsed_padding.right
@@ -133,10 +136,11 @@ def get_stream_content(stream: str | bool = True) -> str:
 def render(
     *renderables: Any,
     direction: Direction = "vertical",
-    color: ColorLike | None = None,
+    foreground: ColorLike | None = None,
     background: ColorLike | None = None,
     modifiers: Sequence[CharacterModifier] | None = None,
-    align: Alignment | None = None,
+    horizontal_align: Alignment | None = None,
+    vertical_align: VerticalAlignment | None = None,
     border: Border | None = None,
     border_sides: Sequence[Side] | None = None,
     border_color: ColorLike | None = None,
@@ -150,6 +154,8 @@ def render(
     flush: bool = False,
     stream: str | bool | None = None,
     update: bool = False,
+    color: ColorLike | None = None,
+    align: Alignment | None = None,
 ) -> None:
     """Display renderables as print-like terminal output.
 
@@ -160,10 +166,11 @@ def render(
     Args:
         *renderables: Grids, components, content primitives, or plain values.
         direction: Direction used to lay out multiple renderables.
-        color: Foreground color applied to plain values.
+        foreground: Foreground color applied to plain values.
         background: Background color for the rendered area.
         modifiers: Character modifiers applied to plain values.
-        align: Horizontal alignment applied to plain values.
+        horizontal_align: Horizontal alignment applied to plain values.
+        vertical_align: Vertical alignment applied to plain values.
         border: Border style around the rendered area.
         border_sides: Border sides to draw.
         border_color: Border foreground color.
@@ -178,6 +185,14 @@ def render(
         stream: Named append-or-replace output region.
         update: Replace the named stream instead of appending to it.
     """
+    foreground = resolve_color_alias(foreground, color, stacklevel=3)
+    horizontal_align = resolve_renamed_alias(
+        horizontal_align,
+        align,
+        old="align",
+        new="horizontal_align",
+        stacklevel=3,
+    )
     from xnano.core.runtime import get_active_runtime
 
     runtime = get_active_runtime()
@@ -186,10 +201,11 @@ def render(
         runtime.render(
             *renderables,
             direction=direction,
-            color=color,
+            foreground=foreground,
             background=background,
             modifiers=modifiers,
-            align=align,
+            horizontal_align=horizontal_align,
+            vertical_align=vertical_align,
             border=border,
             border_sides=border_sides,
             border_color=border_color,
@@ -227,10 +243,11 @@ def render(
         frame = terminal.render(
             *values,
             direction=direction,
-            color=color,
+            foreground=foreground,
             background=background,
             modifiers=modifiers,
-            align=align,
+            horizontal_align=horizontal_align,
+            vertical_align=vertical_align,
             border=border,
             border_sides=border_sides,
             border_color=border_color,
@@ -250,7 +267,7 @@ def render(
     styled = any(
         value is not None
         for value in (
-            color,
+            foreground,
             background,
             modifiers,
             border,

--- a/xnano/requests.py
+++ b/xnano/requests.py
@@ -450,6 +450,19 @@ class RequestEvent:
     """Payload category."""
 
 
+def _resolve_context_state(runtime: Any, grid: Any) -> Any:
+    """Return the shared state for a request context.
+
+    A grid may stand in for the runtime (``runtime=grid``), and grids
+    expose their state as ``grid_state``.
+    """
+    from xnano.types import is_grid
+
+    if runtime is not None and not is_grid(runtime):
+        return getattr(runtime, "state", None)
+    return getattr(grid, "grid_state", None)
+
+
 def dispatch_request(
     grid: Any,
     method: str,
@@ -488,7 +501,7 @@ def dispatch_request(
     ctx = Context(
         event=Event.from_data(AbstractEventData()),
         terminal=facade,
-        state=getattr(runtime, "state", getattr(grid, "state", None)),
+        state=_resolve_context_state(runtime, grid),
         request=request_obj,
     )
 

--- a/xnano/tailwind.py
+++ b/xnano/tailwind.py
@@ -11,16 +11,10 @@ import dataclasses
 import math
 from typing import Sequence, TypeAlias
 
+from xnano.area import Alignment, Padding
 from xnano.colors import ColorLike
-from xnano.types import (
-    Alignment,
-    Border,
-    CharacterModifier,
-    Direction,
-    Padding,
-    Side,
-    Sizing,
-)
+from xnano.types import Border, CharacterModifier, Direction, Side, Sizing
+from xnano.utils.deprecation import color_alias_dataclass
 
 TailwindClass: TypeAlias = str
 """A Tailwind utility class understood by xnano or passed through to web."""
@@ -50,6 +44,7 @@ KNOWN_TAILWIND_CLASSES: frozenset[str] = frozenset()
 """Known classes are resolved by grammar, so this set is intentionally lazy."""
 
 
+@color_alias_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class Style:
     """Style derived from Tailwind utility classes.
@@ -66,7 +61,7 @@ class Style:
         width: Horizontal size.
         height: Vertical size.
         modifiers: Text modifiers.
-        align: Horizontal alignment.
+        horizontal_align: Horizontal alignment.
         direction: Child layout direction.
         title: Optional frame title.
         title_position: Alignment of the frame title.
@@ -81,7 +76,7 @@ class Style:
         ```
     """
 
-    color: ColorLike | None = None
+    foreground: ColorLike | None = None
     """Foreground color."""
     background: ColorLike | None = None
     """Background color."""
@@ -103,7 +98,7 @@ class Style:
     """Vertical size."""
     modifiers: tuple[CharacterModifier, ...] = ()
     """Character modifiers."""
-    align: Alignment | None = None
+    horizontal_align: Alignment | None = None
     """Horizontal alignment."""
     direction: Direction | None = None
     """Child layout direction."""
@@ -214,11 +209,11 @@ def resolve_tailwind_classes(class_name: str | Sequence[str]) -> Style:
         if token.startswith("text-"):
             suffix = token[5:]
             if suffix in _TEXT_ALIGNMENTS:
-                values["align"] = suffix
+                values["horizontal_align"] = suffix
             elif suffix in _TEXT_MODIFIER_SUFFIXES:
                 modifiers.append(_TEXT_MODIFIER_SUFFIXES[suffix])
             else:
-                values["color"] = suffix
+                values["foreground"] = suffix
         elif token.startswith("bg-"):
             values["background"] = token[3:]
         elif token in _MODIFIER_CLASSES:

--- a/xnano/terminal.py
+++ b/xnano/terminal.py
@@ -10,17 +10,20 @@ from __future__ import annotations
 import sys
 from typing import Any, Generic, Sequence, TypeVar
 
+from xnano.area import Alignment, PaddingLike, VerticalAlignment
 from xnano.colors import ColorLike
 from xnano.core.frame import Frame
 from xnano.core.runtime import Runtime
 from xnano.types import (
-    Alignment,
     Border,
     CharacterModifier,
     Direction,
     FrameTitlePosition,
-    PaddingLike,
     Side,
+)
+from xnano.utils.deprecation import (
+    resolve_color_alias,
+    resolve_renamed_alias,
 )
 
 StateT = TypeVar("StateT")
@@ -178,10 +181,11 @@ class Terminal(Generic[StateT]):
     def render(
         self,
         *renderables: Any,
-        color: ColorLike | None = None,
+        foreground: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
-        align: Alignment | None = None,
+        horizontal_align: Alignment | None = None,
+        vertical_align: VerticalAlignment | None = None,
         border: Border | None = None,
         border_sides: Sequence[Side] | None = None,
         border_color: ColorLike | None = None,
@@ -190,16 +194,19 @@ class Terminal(Generic[StateT]):
         padding: PaddingLike | None = None,
         gap: int = 0,
         direction: Direction = "vertical",
+        color: ColorLike | None = None,
+        align: Alignment | None = None,
     ) -> Frame:
         """Paint one frame and return its immutable snapshot.
 
         Args:
             *renderables: Grids, components, content primitives, or plain
                 values to paint.
-            color: Foreground color applied to plain values.
+            foreground: Foreground color applied to plain values.
             background: Background color for the rendered area.
             modifiers: Character modifiers applied to plain values.
-            align: Horizontal alignment applied to plain values.
+            horizontal_align: Horizontal alignment applied to plain values.
+        vertical_align: Vertical alignment applied to plain values.
             border: Border style around the rendered area.
             border_sides: Border sides to draw.
             border_color: Border foreground color.
@@ -212,15 +219,24 @@ class Terminal(Generic[StateT]):
         Returns:
             A snapshot of the rendered terminal frame.
         """
+        foreground = resolve_color_alias(foreground, color, stacklevel=3)
+        horizontal_align = resolve_renamed_alias(
+            horizontal_align,
+            align,
+            old="align",
+            new="horizontal_align",
+            stacklevel=3,
+        )
         runtime = self._ensure_runtime()
         if renderables:
             runtime.set_root(renderables[0] if len(renderables) == 1 else None)
         return runtime.render(
             *renderables,
-            color=color,
+            foreground=foreground,
             background=background,
             modifiers=modifiers,
-            align=align,
+            horizontal_align=horizontal_align,
+            vertical_align=vertical_align,
             border=border,
             border_sides=border_sides,
             border_color=border_color,
@@ -234,10 +250,11 @@ class Terminal(Generic[StateT]):
     def run(
         self,
         *renderables: Any,
-        color: ColorLike | None = None,
+        foreground: ColorLike | None = None,
         background: ColorLike | None = None,
         modifiers: Sequence[CharacterModifier] | None = None,
-        align: Alignment | None = None,
+        horizontal_align: Alignment | None = None,
+        vertical_align: VerticalAlignment | None = None,
         border: Border | None = None,
         border_sides: Sequence[Side] | None = None,
         border_color: ColorLike | None = None,
@@ -246,16 +263,19 @@ class Terminal(Generic[StateT]):
         padding: PaddingLike | None = None,
         gap: int = 0,
         direction: Direction = "vertical",
+        color: ColorLike | None = None,
+        align: Alignment | None = None,
     ) -> None:
         """Render and dispatch events until an exit is requested.
 
         Args:
             *renderables: Grids, components, content primitives, or plain
                 values to paint.
-            color: Foreground color applied to plain values.
+            foreground: Foreground color applied to plain values.
             background: Background color for the rendered area.
             modifiers: Character modifiers applied to plain values.
-            align: Horizontal alignment applied to plain values.
+            horizontal_align: Horizontal alignment applied to plain values.
+        vertical_align: Vertical alignment applied to plain values.
             border: Border style around the rendered area.
             border_sides: Border sides to draw.
             border_color: Border foreground color.
@@ -265,6 +285,14 @@ class Terminal(Generic[StateT]):
             gap: Cells between multiple renderables.
             direction: Direction used to lay out multiple renderables.
         """
+        foreground = resolve_color_alias(foreground, color, stacklevel=3)
+        horizontal_align = resolve_renamed_alias(
+            horizontal_align,
+            align,
+            old="align",
+            new="horizontal_align",
+            stacklevel=3,
+        )
         runtime = self._ensure_runtime(live=True)
         if renderables:
             runtime.set_root(renderables[0] if len(renderables) == 1 else None)
@@ -274,10 +302,11 @@ class Terminal(Generic[StateT]):
             while True:
                 render_frame(
                     *renderables,
-                    color=color,
+                    foreground=foreground,
                     background=background,
                     modifiers=modifiers,
-                    align=align,
+                    horizontal_align=horizontal_align,
+                    vertical_align=vertical_align,
                     border=border,
                     border_sides=border_sides,
                     border_color=border_color,

--- a/xnano/types.py
+++ b/xnano/types.py
@@ -3,25 +3,30 @@
 ---
 
 Type aliases and values for layout, input, styling, charts, and components.
+
+The geometry primitives (``Area``, ``Size``, ``Padding``, ``align_area``,
+and the alignment aliases) live in `xnano.area`. They are re-exported here,
+deprecated, for the previous import path.
 """
 
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, Union
+
+from xnano.area import (
+    Alignment,
+    Area,
+    Coordinate,
+    Padding,
+    PaddingLike,
+    Size,
+    VerticalAlignment,
+    align_area,
+)
 
 if TYPE_CHECKING:
     from xnano.colors import ColorLike
-
-Alignment: TypeAlias = Literal["left", "right", "center"]
-"""Horizontal (x-axis) alignment of a grid field or area.
-
-Values:
-    ``"left"``: Aligned to the left.
-    ``"right"``: Aligned to the right.
-    ``"center"``: Centered.
-"""
-
 
 ScrollLike: TypeAlias = "bool | Literal['vertical', 'horizontal', 'auto']"
 """``Field(scroll=...)`` value. ``True`` scrolls along the field's
@@ -56,10 +61,6 @@ Values:
     ``"quadrant_inside"``: Quadrant-style inner division. (``▛▀▀▀▀▀▜``)
     ``"quadrant_outside"``: Quadrant-style outer corners. (``▗▄▄▄▄▄▖``)
 """
-
-
-Coordinate: TypeAlias = tuple[int, int]
-"""A single ``(x, y)`` cell coordinate within the terminal grid."""
 
 
 Corner: TypeAlias = Literal[
@@ -100,21 +101,6 @@ Values:
     ``"slow_blink"``: Slow blink.
     ``"rapid_blink"``: Rapid blink.
     ``"reversed"``: Swapped foreground/background colors.
-"""
-
-
-PaddingLike: TypeAlias = Union[
-    int,
-    tuple[int, int],
-    tuple[int | None, int | None, int | None, int | None],
-    "Padding",
-]
-"""Padding around a rectangular area, in any accepted input form:
-
-    - A single integer, applied to all four sides.
-    - A ``(vertical, horizontal)`` tuple of two integers.
-    - A ``(top, right, bottom, left)`` tuple of four integers.
-    - A ``Padding`` instance.
 """
 
 
@@ -226,153 +212,6 @@ def resolve_flex_weight(flex: Flex | None) -> int | None:
     if isinstance(flex, int):
         return max(0, flex)
     return _FLEX_CLASS_WEIGHTS.get(flex)
-
-
-@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-class Padding:
-    """Padding around a rectangular area.
-
-    Attributes:
-        top: Cells above the content.
-        right: Cells to the right of the content.
-        bottom: Cells below the content.
-        left: Cells to the left of the content.
-
-    Examples:
-        ```python
-        padding = Padding.parse((1, 2))
-        ```
-    """
-
-    top: int = 0
-    """Cells above the content."""
-    right: int = 0
-    """Cells to the right of the content."""
-    bottom: int = 0
-    """Cells below the content."""
-    left: int = 0
-    """Cells to the left of the content."""
-
-    @classmethod
-    def parse(cls, padding: PaddingLike | None) -> "Padding":
-        """Normalize a padding value."""
-        if padding is None:
-            return cls()
-        if isinstance(padding, cls):
-            return padding
-        if isinstance(padding, int):
-            return cls(
-                top=padding,
-                right=padding,
-                bottom=padding,
-                left=padding,
-            )
-        values = cast(
-            tuple[int, int]
-            | tuple[int | None, int | None, int | None, int | None],
-            padding,
-        )
-        if len(values) == 2:
-            vertical, horizontal = values
-            return cls(
-                top=vertical or 0,
-                right=horizontal or 0,
-                bottom=vertical or 0,
-                left=horizontal or 0,
-            )
-        top, right, bottom, left = values
-        return cls(
-            top=top or 0,
-            right=right or 0,
-            bottom=bottom or 0,
-            left=left or 0,
-        )
-
-    @property
-    def horizontal(self) -> int:
-        """Total horizontal padding."""
-        return self.left + self.right
-
-    @property
-    def vertical(self) -> int:
-        """Total vertical padding."""
-        return self.top + self.bottom
-
-
-@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-class Size:
-    """Resolved width and height in cells.
-
-    Attributes:
-        width: Width in cells.
-        height: Height in cells.
-    """
-
-    width: int
-    """Width in cells."""
-    height: int
-    """Height in cells."""
-
-    @classmethod
-    def from_tuple(cls, size: tuple[int, int]) -> "Size":
-        """Create a size from ``(width, height)``."""
-        return cls(width=size[0], height=size[1])
-
-    @classmethod
-    def from_int(cls, size: int) -> "Size":
-        """Create a square size."""
-        return cls(width=size, height=size)
-
-
-@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-class Area:
-    """Rectangular region of a cell grid.
-
-    Attributes:
-        x: Left column.
-        y: Top row.
-        width: Width in cells.
-        height: Height in cells.
-    """
-
-    x: int
-    """Left column."""
-    y: int
-    """Top row."""
-    width: int
-    """Width in cells."""
-    height: int
-    """Height in cells."""
-
-    @property
-    def size(self) -> Size:
-        """Width and height of this area."""
-        return Size(width=self.width, height=self.height)
-
-    def contains(self, coordinate: Coordinate) -> bool:
-        """Return whether ``coordinate`` lies inside this area."""
-        column, row = coordinate
-        return (
-            self.x <= column < self.x + self.width
-            and self.y <= row < self.y + self.height
-        )
-
-    def fit_content(self, content: Size, align: Alignment = "left") -> "Area":
-        """Fit a measured size inside this area."""
-        width = min(self.width, max(content.width, 1))
-        height = min(self.height, max(content.height, 1))
-        if align == "right":
-            x = self.x + self.width - width
-        elif align == "center":
-            x = self.x + (self.width - width) // 2
-        else:
-            x = self.x
-        return Area(
-            x=x,
-            y=self.y + (self.height - height) // 2,
-            width=width,
-            height=height,
-        )
 
 
 SizingKind: TypeAlias = Literal[
@@ -900,6 +739,16 @@ class ScrollHandle:
         self.follow = True
 
 
+def is_grid(value: Any) -> bool:
+    """Return whether a value is a grid instance.
+
+    Reads the ``__xnano_grid__`` marker rather than importing
+    ``BaseGrid``, so layers below the public DSL can ask this without a
+    circular import.
+    """
+    return bool(getattr(type(value), "__xnano_grid__", False))
+
+
 def is_component(value: Any) -> bool:
     """Return whether a value follows the component contract."""
     return bool(getattr(type(value), "_xnano_component_base", False))
@@ -920,6 +769,7 @@ def is_focusable_component(value: Any) -> bool:
 __all__ = (
     "Alignment",
     "Area",
+    "align_area",
     "Axis",
     "Border",
     "CanvasMarkerLike",
@@ -947,6 +797,7 @@ __all__ = (
     "Size",
     "SizePercentage",
     "Sizing",
+    "VerticalAlignment",
     "SizingKeyword",
     "SizingKind",
     "SizingLike",
@@ -955,6 +806,7 @@ __all__ = (
     "field_has_frame_chrome",
     "frame_from_field",
     "is_component",
+    "is_grid",
     "is_focusable_component",
     "resolve_flex_weight",
     "uses_default_component_size",

--- a/xnano/utils/deprecation.py
+++ b/xnano/utils/deprecation.py
@@ -16,7 +16,7 @@ import warnings
 from typing import Any, Callable, TypeVar
 
 if sys.version_info >= (3, 13):
-    from warnings import deprecated as _deprecated
+    _deprecated = warnings.deprecated
 else:
     from typing_extensions import deprecated as _deprecated
 
@@ -65,6 +65,42 @@ def resolve_color_alias(
     return foreground
 
 
+def resolve_renamed_alias(
+    new_value: Any,
+    old_value: Any,
+    *,
+    old: str,
+    new: str,
+    unset: Any = None,
+    stacklevel: int = 3,
+) -> Any:
+    """Return ``new_value``, honoring a deprecated ``old_value`` alias.
+
+    The generic form of `resolve_color_alias` for any renamed keyword.
+    The new name wins when both are supplied.
+
+    Args:
+        new_value: Canonical argument.
+        old_value: Deprecated alias argument.
+        old: Deprecated parameter name, for the message.
+        new: Replacement parameter name, for the message.
+        unset: Sentinel meaning "argument not supplied".
+        stacklevel: Frames to skip so the warning points at caller code.
+
+    Returns:
+        The resolved value (may be ``unset``).
+    """
+    if old_value is not unset:
+        warnings.warn(
+            f"The '{old}' parameter is deprecated; use '{new}' instead.",
+            DeprecationWarning,
+            stacklevel=stacklevel,
+        )
+        if new_value is unset:
+            return old_value
+    return new_value
+
+
 def warn_renamed_attribute(
     old: str, new: str
 ) -> Callable[[_CallableT], _CallableT]:
@@ -86,47 +122,65 @@ def warn_renamed_attribute(
     return _deprecated(message)  # ty: ignore[invalid-argument-type]
 
 
-def color_alias_dataclass(cls: _ClassT) -> _ClassT:
-    """Add a deprecated ``color`` alias for a dataclass ``foreground`` field.
+def renamed_alias_dataclass(
+    old: str, new: str
+) -> Callable[[_ClassT], _ClassT]:
+    """Add a deprecated ``old`` keyword alias for a dataclass ``new`` field.
 
-    The class must already declare a ``foreground`` field. The decorator
-    wraps ``__init__`` to accept a ``color`` keyword (deprecated,
-    ``foreground`` wins when both are given) and installs a ``color``
-    property mapped to ``foreground`` so existing ``self.color`` code and
-    external reads keep working.
+    Wraps ``__init__`` to accept ``old`` (deprecated, ``new`` wins when
+    both are given) and installs an ``old`` property mapped to ``new`` so
+    existing attribute reads keep working.
 
     Args:
-        cls: The dataclass to augment.
+        old: Deprecated field name.
+        new: Replacement field name, which the class must declare.
 
     Returns:
-        The same class, augmented in place.
+        A decorator augmenting the dataclass in place.
     """
-    original_init = cls.__init__
 
-    @functools.wraps(original_init)
-    def __init__(self: Any, *args: Any, **kwargs: Any) -> None:
-        if "color" in kwargs:
-            warn_color_alias(stacklevel=2)
-            color = kwargs.pop("color")
-            kwargs.setdefault("foreground", color)
-        original_init(self, *args, **kwargs)
+    def decorate(cls: _ClassT) -> _ClassT:
+        original_init = cls.__init__
 
-    cls.__init__ = __init__  # ty: ignore[invalid-assignment]
+        @functools.wraps(original_init)
+        def __init__(self: Any, *args: Any, **kwargs: Any) -> None:
+            if old in kwargs:
+                warnings.warn(
+                    f"The '{old}' parameter is deprecated; "
+                    f"use '{new}' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                kwargs.setdefault(new, kwargs.pop(old))
+                kwargs.pop(old, None)
+            original_init(self, *args, **kwargs)
 
-    def _get_color(self: Any) -> Any:
-        return self.foreground
+        cls.__init__ = __init__  # ty: ignore[invalid-assignment]
+        setattr(
+            cls,
+            old,
+            property(
+                lambda self: getattr(self, new),
+                lambda self, value: setattr(self, new, value),
+            ),
+        )
+        return cls
 
-    def _set_color(self: Any, value: Any) -> None:
-        self.foreground = value
+    return decorate
 
-    cls.color = property(  # ty: ignore[unresolved-attribute]
-        _get_color, _set_color
-    )
-    return cls
+
+color_alias_dataclass = renamed_alias_dataclass("color", "foreground")
+"""Deprecated ``color`` alias for a dataclass ``foreground`` field."""
+
+align_alias_dataclass = renamed_alias_dataclass("align", "horizontal_align")
+"""Deprecated ``align`` alias for a ``horizontal_align`` field."""
 
 
 __all__ = (
+    "align_alias_dataclass",
     "color_alias_dataclass",
+    "renamed_alias_dataclass",
+    "resolve_renamed_alias",
     "resolve_color_alias",
     "warn_color_alias",
     "warn_renamed_attribute",

--- a/xnano/utils/focus.py
+++ b/xnano/utils/focus.py
@@ -14,6 +14,7 @@ from xnano.types import (
     ScrollHandle,
     is_component,
     is_focusable_component,
+    is_grid,
     uses_default_component_size,
 )
 
@@ -32,7 +33,7 @@ def field_group(grid: Any, field_name: str) -> str | None:
 
 def _walk_grids(root: Any):
     """Yield a grid and its nested grid field values."""
-    if not isinstance(getattr(type(root), "_grid_fields", None), dict):
+    if not is_grid(root):
         return
     yield root
     for name in root._grid_fields:
@@ -152,7 +153,7 @@ def sync_input_focus_flags(terminal: Any) -> None:
         component = getattr(target.grid, target.field_name, None)
         if is_component(component):
             setattr(component, "_input_focused", focused)
-        state = target.grid.get_field_state(target.field_name)
+        state = target.grid.grid_get_field_state(target.field_name)
         if state is not None:
             state.focused = focused
 

--- a/xnano/utils/markup.py
+++ b/xnano/utils/markup.py
@@ -164,7 +164,7 @@ def parse_ansi_lines(content: str) -> tuple[tuple[Run, ...], ...]:
                 runs.append(
                     Run(
                         text=segment,
-                        color=color,
+                        foreground=color,
                         background=background,
                         modifiers=modifiers,
                     )
@@ -246,7 +246,7 @@ def highlight_lines(
                 runs.clear()
             if segment:
                 runs.append(
-                    Run(text=segment, color=color, modifiers=modifiers)
+                    Run(text=segment, foreground=color, modifiers=modifiers)
                 )
     if runs:
         lines.append(tuple(runs))
@@ -291,7 +291,7 @@ def _markdown_inline_runs(
             runs.append(
                 Run(
                     text=child.content,
-                    color=color,
+                    foreground=color,
                     modifiers=(*active, "reversed"),
                 )
             )
@@ -301,7 +301,7 @@ def _markdown_inline_runs(
                 runs.append(
                     Run(
                         text=text,
-                        color=color,
+                        foreground=color,
                         modifiers=tuple(dict.fromkeys(active)),
                     )
                 )
@@ -321,7 +321,7 @@ def _markdown_inline_line(
         return (
             Run(
                 text="#" * heading_level + " ",
-                color=_HEADING_COLOR,
+                foreground=_HEADING_COLOR,
                 modifiers=("dim",),
             ),
             *_markdown_inline_runs(
@@ -335,7 +335,7 @@ def _markdown_inline_line(
             return (
                 Run(
                     text=f"▌ {match.group(1).title()}  ",
-                    color=_HEADING_COLOR,
+                    foreground=_HEADING_COLOR,
                     modifiers=("bold",),
                 ),
                 *(


### PR DESCRIPTION
## Summary

- add non-blocking grid effects, consistent grid API namespacing, and two-axis alignment
- standardize foreground naming with deprecated compatibility aliases
- replace the deleted sandbox-specific docs test with coverage for all runnable Pyodide docs
- update documentation, examples, generators, and regression coverage

## Validation

- `uv run pytest`
- `uv run prek run --all-files`

Closes #135
Closes #136
Closes #138
Closes #139
Closes #141

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hsaeed3/xnano/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

