### PR TITLE
chore: add xnano skills

### DIFF
--- a/.agents/skills/xnano-core-development/SKILL.md
+++ b/.agents/skills/xnano-core-development/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: xnano-core-development
+description: Develop and test xnano-core Rust/PyO3 bindings and engine behavior. Use for CoreSession, render tree/content/IR, native events, key bindings, editors, and Rust changes under xnano-core/.
+---
+
+# xnano-core development
+
+Use this skill for native engine work. The package-distributed skill lives at
+`xnano-core/python/xnano_core/.agents/skills/xnano-core`; this root skill adds
+repository development and verification workflow.
+
+## Boundaries
+
+- Rust bindings live in `xnano-core/rust/src/bindings/`; engine code is under
+  `rust/src/bindings/engine/`.
+- Python consumers use `xnano_core.core`, whose public engine types retain the
+  `Core*` names: `CoreSession`, `CoreRenderNode`, `CoreRenderContent`,
+  `CoreRenderIR`, events, key bindings, editor, and terminal reference.
+- Register every new PyO3 type in the engine module and preserve the Python
+  barrel export. Keep binding policy separate from `xnano` grid/component
+  policy.
+- `CoreSession` and pointer-backed handles are unsendable and thread-bound.
+  Create, render, poll, and restore them on their owning thread.
+- Keep `session.rs` and `session_stub.rs` API-compatible across terminal and
+  reduced/wasm builds. Preserve feature gates for terminal and editor support.
+
+## Native rules
+
+- `CoreSession.init(...)` is for a live terminal; `CoreSession.offscreen(...)`
+  is for buffer-backed tests and non-terminal builds.
+- Use `CoreRenderNode` for scene-graph layout and z-order, and
+  `CoreRenderContent`/`CoreRenderIR` for the rendering payload. Prefer IR for
+  framework-generated widgets to minimize Python/Rust crossings.
+- Keep terminal initialization, restoration, and event ownership behind
+  `xnano.Runtime`/`Terminal`; application code must not call raw crossterm
+  lifecycle functions.
+- Validate Python inputs at the binding boundary and return useful `PyResult`
+  errors. Do not leak Rust panics or unsafe lifetime assumptions.
+
+## Verification
+
+After any change under `xnano-core/`, rebuild the extension before testing:
+
+```bash
+cd xnano-core
+cargo clean
+maturin develop --uv
+cd ..
+uv run pytest tests/core -q
+uv run prek run --all-files
+uv run ty check
+```
+
+Add focused coverage under `tests/core` for imports, offscreen sessions,
+rendering, events, layout, or the changed binding. Run the full suite when the
+change crosses the public runtime boundary.

--- a/.agents/skills/xnano-development/SKILL.md
+++ b/.agents/skills/xnano-development/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: xnano-development
+description: Develop and test the public xnano Python library. Use for changes under xnano/, public DSL behavior, components, hooks, rendering, runtime, and Python tests.
+---
+
+# xnano development
+
+Use this skill for the Python library, not native Rust binding changes or docs-only work.
+
+## Before editing
+
+- Read the repository `AGENTS.md` and inspect the complete path from public API
+  to runtime/controller before choosing a fix.
+- Preserve unrelated dirty-worktree changes. Do not reintroduce `xnano.beta` or
+  a `Grid` alias.
+- Search all callers before changing shared dispatch, rendering, field, hook,
+  or runtime behavior; fix the shared path rather than patching one caller.
+
+## Public design rules
+
+- Use `BaseGrid` with annotated `Field(...)` declarations. Prefer a typed
+  `grid_settings: GridSettings` class attribute over class-header settings
+  keywords when declaring layout configuration.
+- Use `Field(state=True)` for non-rendered application state and
+  `default_factory` for mutable values. Keep rendering policy in grids and
+  components, not in native bindings.
+- Use `@on_tick` for field-specific periodic changes and `grid_render()` for
+  whole-grid work that must run before every frame. `grid_render()` is not a
+  timer.
+- Use xnano `ColorLike` values (`foreground`, `background`, `border_color`,
+  `tailwind_color(...)`, hex, RGB/RGBA tuples, or known color names). Never
+  pass Rich `Color`, `Text`, or `Style` objects.
+- Import concrete internal modules, for example
+  `from xnano.components.text import Text`; do not rely on package barrels in
+  library code.
+- Use `Terminal.offscreen(...)` for deterministic tests. Do not initialize
+  crossterm directly or make `Terminal` serve HTTP.
+
+## Implementation patterns
+
+Prefer the smallest existing abstraction that fits. Components return
+interface-neutral content from `compose()`; hooks may accept zero arguments or
+one `Context`; actions centralize synthetic event matching. Keep one behavior
+per hook and one HTTP operation per request handler.
+
+For a rendering change, add the narrowest regression test that exercises the
+public result: an offscreen `Frame`, dispatched event, field mutation, or
+component content tree. Test edge cases at trust boundaries and preserve
+backward-compatible aliases only when the public contract requires them.
+
+## Verification
+
+Run the relevant focused tests first, then the repository checks required by
+`AGENTS.md`:
+
+```bash
+uv run pytest
+uv run prek run --all-files
+uv run ty check
+```
+
+Do not run the Rust rebuild for Python-only changes. Native changes belong to
+the `xnano-core-development` skill.

--- a/.agents/skills/xnano-docs-examples/SKILL.md
+++ b/.agents/skills/xnano-docs-examples/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: xnano-docs-examples
+description: Update xnano documentation, examples, API pages, and generated demos. Use when docs or examples change, or when library files are added, renamed, or removed.
+---
+
+# xnano docs and examples
+
+Use this skill for documentation and runnable examples. Treat docs and examples
+as part of the public API: they must use the current stable `xnano` namespace
+and concrete import paths.
+
+## Workflow
+
+- Read the implementation and its tests before documenting behavior. Do not
+  invent options, aliases, component names, or host arguments.
+- Keep examples minimal, runnable, and representative. Prefer `BaseGrid`,
+  `Field`, `Component`, `Terminal.offscreen`, and `Web` patterns already used
+  in the repository.
+- Update nearby conceptual docs and API references when a public symbol,
+  behavior, or import path changes. Remove stale `Grid`, `xnano.beta`, and
+  obsolete color/API examples.
+- For native changes, document the public Python-facing behavior rather than
+  exposing internal Rust implementation details.
+
+## Generated documentation and demos
+
+If any new, renamed, or removed file is added under `xnano/` or `xnano-core/`,
+inspect and run the repository's documentation update scripts before handoff.
+Use any branch-specific `update_docs` script when present. In this repository,
+the relevant generators include:
+
+```bash
+uv run python scripts/generate_api_docs.py
+uv run python scripts/generate_component_demos.py
+uv run python scripts/generate_hook_demos.py
+uv run python scripts/generate_tutorial_demos.py
+uv run python scripts/generate_showcase_demos.py
+uv run python scripts/generate_readme_demos.py
+```
+
+Run only the generators affected by the change; use `--check` where supported.
+Do not hand-edit generated output when the source generator is the source of
+truth. Check generated assets and links into the same diff.
+
+## Verification
+
+- Run the focused documentation/example tests, especially Pyodide documentation
+  and rendering tests when examples are embedded or browser-compatible.
+- Confirm every code block imports from the current public API and uses valid
+  `ColorLike`, `grid_settings`, hook, host, and component conventions.
+- Run the repository's required checks after implementation when the change is
+  code-affecting: `uv run pytest`, `uv run prek run --all-files`, and
+  `uv run ty check`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,8 @@ dev = [
     "mkdocs-click",
     "mkdocstrings-python",
     "markdown-exec[ansi]",
-
+    # fancy new @tianglo dependency for agent skills
+    "library-skills>=0.0.19",
     # test-related dependencies
     "pydantic>=2.0.0",
     "httpx>=0.28.1",

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,15 @@ members = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -636,6 +645,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "library-skills"
+version = "0.0.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "rich-toolkit" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/4b/fb85dd4c93a8ec99b0e04d12ca81fc08a755ee43c2061069e1d87f6abb66/library_skills-0.0.19.tar.gz", hash = "sha256:fe58b3a06e9ba757f1b48113199a6af93fc15008c9d0a3add543f508576a8516", size = 44098, upload-time = "2026-06-21T16:16:25.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/e5/d8ab3376068360b6e9dc65fb66c52d5b2d5f2b60e34f51aa2e5cf64c5f26/library_skills-0.0.19-py3-none-any.whl", hash = "sha256:99cc10b900860bd354f1ca4a1724f0ce51f5b40246775c1db63567c91e920c6e", size = 25050, upload-time = "2026-06-21T16:16:24.928Z" },
 ]
 
 [[package]]
@@ -1918,6 +1942,20 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-toolkit"
+version = "0.20.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/3a/a258c2fbc6c6bdf428611388f5698ba5d57ffdf0755e1cab474d9cc47813/rich_toolkit-0.20.3.tar.gz", hash = "sha256:223dd2cfba325ed55e94933b9e53f3aca13e9fdf76622bd564c18109a2273c1b", size = 205355, upload-time = "2026-07-13T14:38:06.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/ce/639d0d0ce3d25c5edbd1afecd308bb35dc04883a45ac9f0855c8aee4e919/rich_toolkit-0.20.3-py3-none-any.whl", hash = "sha256:419aa87516d5f3849cca553c6dcf707c02a36d508fcf996946606725d34a3002", size = 36195, upload-time = "2026-07-13T14:38:05.687Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1953,6 +1991,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -2094,6 +2141,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/89/44cc276ea6ca0245495014758ffeadde1798fb0b5840c9cf36d8d2ed3250/ty-0.0.64-py3-none-win32.whl", hash = "sha256:d0676ab0e0935795e5843baa28dd5e366dc343d7c0945a996df9eab8e0644885", size = 11545474, upload-time = "2026-07-27T18:32:39.389Z" },
     { url = "https://files.pythonhosted.org/packages/01/7e/d1c8a871a38d17c8f168b9a6975f6247f7660f8334e517656a5e4b4a4858/ty-0.0.64-py3-none-win_amd64.whl", hash = "sha256:dcb9bd31f54097e362b776c26ab4564d4564cdd1355cb883481167a26c03cc3f", size = 12542987, upload-time = "2026-07-27T18:32:41.412Z" },
     { url = "https://files.pythonhosted.org/packages/35/4d/6d18640d0204cacd69abbaca95ad6a34c6d7e9169e9051d0117b17b827ec/ty-0.0.64-py3-none-win_arm64.whl", hash = "sha256:82cc34c1ad9a8feb6059aef193bebcecc656e548f6fab3d518bcd8b57d198d39", size = 11899263, upload-time = "2026-07-27T18:32:43.366Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
 ]
 
 [[package]]
@@ -2401,6 +2463,7 @@ dev = [
     { name = "griffe-typingdoc" },
     { name = "httpx" },
     { name = "isort" },
+    { name = "library-skills" },
     { name = "logfire" },
     { name = "marimo" },
     { name = "markdown-exec", extra = ["ansi"] },
@@ -2442,6 +2505,7 @@ dev = [
     { name = "griffe-typingdoc" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "isort" },
+    { name = "library-skills", specifier = ">=0.0.19" },
     { name = "logfire" },
     { name = "marimo" },
     { name = "markdown-exec", extras = ["ansi"] },

--- a/xnano/.agents/skills/xnano/SKILL.md
+++ b/xnano/.agents/skills/xnano/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: xnano
+description: Best practices for building and changing xnano applications with BaseGrid, Field, components, hooks, Terminal, Web, and the shared runtime.
+---
+
+# xnano
+
+Use this skill for work in the public `xnano` Python package. Keep application
+code interface-neutral: grids, fields, components, hooks, and actions describe
+the app; `Terminal` and `Web` choose where it is presented.
+
+## Core rules
+
+- Use `BaseGrid`, never `Grid`. Declare layout with annotated `Field(...)` values.
+- Use `Field(state=True)` for application data that is not rendered. Use
+  `default_factory` for mutable defaults.
+- Prefer concrete imports such as `from xnano.components.text import Text`.
+  The package root and barrels are for public user imports, not internal code.
+- Compose custom components through `Component.compose()` and the content
+  primitives in `xnano.core.content`; do not call ratatui or crossterm directly.
+- Bind behavior with `xnano.hooks` or `Action` objects. Hooks may take no
+  context argument or one `Context`; keep them synchronous unless the runtime
+  is deliberately run from a compatible synchronous context.
+- Use `Terminal.offscreen(...)` for deterministic rendering tests. `Terminal`
+  owns the runtime and does not accept web host/port arguments; use `Web` or
+  `xnano.server` for HTTP.
+- Keep terminal and web behavior in the shared grid/component path. Do not
+  introduce an `xnano.beta` surface or bypass `Runtime` for terminal lifecycle.
+
+## Common patterns
+
+Use `@on_tick` for a field-specific periodic update. Use `grid_render()` when
+the whole grid should refresh before every frame; it is not a timer.
+
+```python
+import time
+
+from xnano import BaseGrid, Field
+from xnano.hooks import on_tick
+
+
+class Clock(BaseGrid):
+    clock: str = Field(default="")
+
+    @on_tick(1000)
+    def update_clock(self) -> None:
+        self.clock = time.strftime("%H:%M:%S")
+```
+
+```python
+class Dashboard(BaseGrid):
+    header: str = Field(default="")
+    body: str = Field(default="")
+
+    def grid_render(self) -> None:
+        self.header = self.get_header_text()
+        self.body = self.get_body_text()
+```
+
+Prefer the typed `grid_settings` class attribute over `BaseGrid` class-header
+keywords when declaring layout settings. The class-header form is supported,
+but `GridSettings` gives type checkers a precise place to validate the options.
+
+```python
+from xnano.grids import BaseGrid, GridSettings
+
+
+class Dashboard(BaseGrid):
+    grid_settings: GridSettings = {
+        "direction": "vertical",
+        "gap": 1,
+        "title": "Dashboard",
+    }
+```
+
+Keep application data in state fields and render it through ordinary fields.
+This separates state from layout and lets hooks watch the value cleanly.
+
+```python
+from xnano import BaseGrid, Field
+from xnano.hooks import on_keyboard
+
+
+class Counter(BaseGrid):
+    label: str = Field(default="Count: 0")
+    count: int = Field(default=0, state=True)
+
+    @on_keyboard("up")
+    def increment(self) -> None:
+        self.count += 1
+        self.label = f"Count: {self.count}"
+```
+
+Play effects from a grid after its target field has rendered. Target specific
+fields instead of animating the whole session:
+
+```python
+from xnano import BaseGrid, Field
+from xnano.hooks import on_keyboard
+
+
+class Panel(BaseGrid):
+    body: str = Field(default="Ready")
+
+    @on_keyboard("enter")
+    def play_intro(self) -> None:
+        self.grid_play_effect("fade", duration_ms=300, fields=["body"])
+```
+
+Use xnano's `ColorLike` values everywhere a color is accepted. Do not import
+Rich color, text, or style objects. Plain color names, hex strings, RGB/RGBA
+tuples, `Color`, and Tailwind palette values are all valid xnano colors; use
+`foreground` for text, `background` for fills, and `border_color` for borders.
+`color` is a deprecated alias for `foreground` in compatible dataclasses.
+
+```python
+from xnano.colors import tailwind_color
+from xnano.components.text import Text
+from xnano.grids import BaseGrid, Field
+
+
+class Status(BaseGrid):
+    title: Text = Field(
+        default=Text(
+            content="Ready",
+            foreground=tailwind_color("emerald", 400),
+        ),
+        background=tailwind_color("slate", 900),
+        border_color=tailwind_color("slate", 700),
+    )
+```
+
+When styling a field with utilities, use xnano Tailwind classes such as
+`class_name="text-emerald-400 bg-slate-900"`; do not pass a Rich `Style` or a
+CSS/Tailwind object where a `ColorLike` is expected.
+
+Prefer the built-in components, content primitives, `Action`, `Context`,
+`Request`, and `Response` types over custom wrappers. Use synchronous hooks by
+default; an async hook must not hide blocking work.
+
+## Choose a reference
+
+- Layout, fields, state, sizing, styling, focus, and scrolling: [grids](references/grids.md)
+- Built-in and custom components: [components](references/components.md)
+- Event hooks, actions, and context: [hooks](references/hooks.md)
+- Rendering, terminal, runtime, and web hosts: [hosts](references/hosts.md)
+- HTTP request hooks and servers: [server](references/server.md)
+
+## Verification
+
+Prefer a focused test using an offscreen terminal for rendering and dispatch.
+Run the repository checks required by `AGENTS.md` after implementation:
+`uv run pytest`, `uv run prek run --all-files`, and `uv run ty check`.

--- a/xnano/.agents/skills/xnano/references/components.md
+++ b/xnano/.agents/skills/xnano/references/components.md
@@ -1,0 +1,45 @@
+# Components
+
+## Use built-ins first
+
+Import built-ins from their concrete modules inside library code. The main
+families are:
+
+- `Text`, `Input`, and `Markdown` for text and editing.
+- `Button`, `Link`, `Dropdown`, and `Options`/`Select` for interaction.
+- `Table`, `Chart`, `Bar`, `Loader`, `Scrollbar`, and `Image` for data and
+  feedback.
+
+Check the component's module and tests before inventing a wrapper. Components
+are dataclasses with live attributes; changing an attribute changes the next
+frame.
+
+## Custom components
+
+Subclass `Component` and implement the smallest relevant method:
+
+```python
+from xnano.components.component import Component, ComponentRenderContext
+from xnano.core.content import TextBlock
+
+
+class Status(Component):
+    text: str = "Ready"
+
+    def compose(self, ctx: ComponentRenderContext) -> TextBlock:
+        return TextBlock(text=self.text)
+```
+
+`compose()` returns interface-neutral `Content` or `None`. Use
+`ComponentRenderContext` for the assigned area, runtime, state, and component.
+Use `get_size()` when natural size matters, `before_render()`/`after_render()`
+for paint hooks, and `handle_keyboard()` or `handle_paste()` only for focused
+interactive behavior. The `focused`, `visible`, and `z` attributes are runtime
+state; `fit_content` controls natural-size preference.
+
+For responsive components, override only the needed `compose_extra_small`,
+`compose_small`, `compose_medium`, `compose_large`, or `compose_extra_large`
+variant. Keep shared logic in `compose()`.
+
+Use `Field` to place a component in a grid. Components do not own terminal
+initialization, event polling, or HTTP serving.

--- a/xnano/.agents/skills/xnano/references/grids.md
+++ b/xnano/.agents/skills/xnano/references/grids.md
@@ -1,0 +1,58 @@
+# Grids and Fields
+
+## Declare layout
+
+Subclass `BaseGrid` and annotate every layout slot:
+
+```python
+from xnano import BaseGrid, Field
+from xnano.components.text import Text
+
+
+class Dashboard(BaseGrid, direction="vertical", gap=1):
+    title: Text = Field(default=Text("Dashboard"), height=1)
+    count: int = Field(default=0, state=True)
+```
+
+`BaseGrid` lays out rendered fields and nested grids/components. Grid class
+keywords and `grid_settings` configure direction, gap, border, title, padding,
+colors, modifiers, and strict validation.
+
+## Rendered fields versus state
+
+- A normal `Field` is a rendered slot whose value may be text, a component, a
+  nested grid, or supported content.
+- `Field(state=True)` is non-rendered application state. It is still reactive
+  and can be watched with `@on_field`.
+- Use `default_factory` for lists, dictionaries, grids, and components that
+  must not be shared between instances.
+- `strict=True` validates state assignments against annotations. Keep trust
+  boundary validation explicit; do not weaken it to make a type error vanish.
+
+Field metadata includes `width`, `height`, `visible`, `z`, `overlay`, `margin`,
+`padding`, `border`, `title`, `align`, `class_name`, `scroll`, `group`, and
+`autofocus`. Sizing accepts cells, percentages, ratios such as `"1fr"`, and
+`"fit"`. `overlay=True` removes a field from normal flow; pair it with `z` for
+popups or modals.
+
+## Live updates
+
+Prefer direct assignment for values:
+
+```python
+self.count += 1
+self.title = Text(f"Count: {self.count}")
+```
+
+Use `grid_set_field(name, value=..., ...)` when changing a value and/or runtime
+field metadata. Use `grid_update_field(name, ...)` for metadata-only updates.
+These methods cannot change a field's `state`, default, or constructor status.
+
+Fields sharing `group` provide terminal-wide focus, click, and scroll identity.
+Use `ctx.focus("group")`, `ctx.blur()`, `ctx.is_focused("group")`, and
+`ctx.scroll("group")` from hooks. A scroll field is driven by its scroll handle;
+do not guess offsets from terminal dimensions.
+
+Override `grid_render()` for per-frame value refresh and use
+`grid_render_<breakpoint>()` only for breakpoint-specific setup. Keep layout
+policy in grids and paint lowering in the framework.

--- a/xnano/.agents/skills/xnano/references/hooks.md
+++ b/xnano/.agents/skills/xnano/references/hooks.md
@@ -1,0 +1,60 @@
+# Hooks and Actions
+
+Hooks are decorators on methods of a `BaseGrid` subclass. A handler may be
+defined as `method(self)` or `method(self, ctx)`; `ctx` is the current
+`Context`, including event data, shared state, runtime controls, focus, stage,
+and viewport information.
+
+## Event hooks
+
+Use the narrowest hook that expresses the behavior:
+
+- `@on_keyboard("ctrl+s", kind="press")` for key bindings.
+- `@on_mouse(button="left", kind="press", field="name")` for mouse events.
+- `@on_click("name")` or `@on_click(group="toolbar")` for activation.
+- `@on_focus(field=..., group=..., kind="gained"|"lost")` for focus changes.
+- `@on_clipboard`, `@on_resize`, and `@on_event` for their corresponding events.
+- `@on_tick(1000)` for periodic work in milliseconds.
+- `@on_poll(when="idle"|"frame")` for polling at the selected runtime point.
+
+Keyboard and mouse filters accept multiple bindings/buttons where supported.
+Enable `Terminal(mouse_events=True)` when clicks, drags, hover, or wheel input
+must be received; mouse capture is off by default.
+
+## State and field watchers
+
+`@on_state("count > 0")` fires while the expression is truthy against shared
+state. A bare reference such as `@on_state("count")` fires when that value
+changes. `@on_field` applies the same rule to fields on the grid:
+
+```python
+@on_field("count")
+def refresh_label(self):
+    self.label = f"Count: {self.count}"
+```
+
+Keep watcher work small and idempotent; mutations can cause another render.
+
+## Actions
+
+Use `Action` when the trigger should be named, reused, or synthesized:
+
+```python
+from xnano import Action
+from xnano.hooks import on_action
+
+SAVE = Action.keyboard("ctrl+s")
+
+
+@on_action(SAVE)
+def save(self, ctx):
+    ...
+```
+
+Available action constructors cover keyboard, mouse, click, focus, clipboard,
+tick, resize, and request events. Runtime code can synthesize supported input
+with `ctx.actions` or `terminal.actions`; event matching remains centralized in
+`Action.matches`.
+
+Prefer one hook per behavior. Do not mix HTTP request handling with terminal
+event hooks; use the request decorators described in [server](server.md).

--- a/xnano/.agents/skills/xnano/references/hosts.md
+++ b/xnano/.agents/skills/xnano/references/hosts.md
@@ -1,0 +1,47 @@
+# Hosts and Rendering
+
+## One-shot rendering
+
+Use `from xnano import render` for print-like output with no event loop. It is
+not a terminal host and does not dispatch hooks.
+
+## Terminal
+
+`Terminal` owns a `Runtime` and selects a live session when a usable TTY is
+available; otherwise it uses an offscreen session. Use `Terminal.offscreen(cols,
+rows, state=...)` in tests and inspect the returned immutable `Frame` (`text`,
+`ansi`, `width`, `height`, `rows`, and `contains()`).
+
+```python
+from xnano.terminal import Terminal
+
+terminal = Terminal.offscreen(cols=40, rows=12)
+frame = terminal.render("Ready")
+terminal.close()
+```
+
+Use `with Terminal(...) as terminal` for live ownership. `Terminal.run(...)`
+paints and pumps events until exit. It does not accept `host` or `port`.
+`Runtime` is the lower-level choice when explicit session ownership, state,
+focus, cursor, device, actions, or stage access is required.
+
+Never initialize or restore crossterm directly in application code.
+
+## Web
+
+`Web` serves the same grid/component through an offscreen runtime and the
+native cell-frame browser server:
+
+```python
+from xnano.web import Web
+
+Web(title="Status", width=80, height=24).run(App, port=8000)
+```
+
+`Web.run()` accepts a grid/component instance, a `BaseGrid` class, or a factory.
+The shared DSL and hook dispatch are reused; only presentation and input
+transport differ. Web request routes are handled by `xnano.server`.
+
+Keep rendering policy in grids/components, frame lowering in
+`TerminalController`/`xnano.core`, and session mechanics in `Runtime` and
+`xnano-core`.

--- a/xnano/.agents/skills/xnano/references/server.md
+++ b/xnano/.agents/skills/xnano/references/server.md
@@ -1,0 +1,43 @@
+# Server and HTTP Requests
+
+Declare routes on a grid or component with request hooks from
+`xnano.requests`:
+
+```python
+from xnano import BaseGrid
+from xnano.requests import Request, Response, on_get_request, on_post_request
+
+
+class App(BaseGrid):
+    @on_get_request("/health")
+    def health(self) -> Response:
+        return Response.json({"ok": True})
+
+    @on_post_request("/message")
+    def message(self, request: Request) -> Response:
+        return Response.json({"message": request.json()})
+```
+
+Handlers may use the supported zero/context/request signatures; inspect the
+request dispatch path when adding a less common shape. `Request` exposes the
+uppercase method, normalized path, multi-value query mapping, headers, and raw
+body, with `.text()` and `.json()` helpers. `Response` can return text, bytes,
+or JSON with explicit status and headers.
+
+Use the named decorators for `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`,
+`OPTIONS`, `TRACE`, `PATCH`, and `QUERY`, or `request(method, path)` for a
+supported method. Paths are normalized to a leading slash.
+
+## Serving
+
+- `Web.run(...)` serves the browser shell, `/xnano/frame`, browser events, and
+  declared request hooks from one offscreen runtime.
+- `xnano.server.start_request_server(...)` / `serve_requests(...)` serves
+  request hooks through the standard-library threaded HTTP server.
+- `RequestServer` accepts a grid instance or class and may expose a runtime to
+  request contexts.
+
+Request bodies are limited to 1 MiB by default. Keep request validation and
+authentication in the handler or a shared application boundary; never treat a
+request hook as a trusted internal call. Do not add a second web framework or
+duplicate native server routing for ordinary routes.


### PR DESCRIPTION
## Summary

- add repository development skills for xnano, documentation/examples, and xnano-core
- package the public xnano application skill and focused references
- add the `library-skills` development dependency and lockfile entries

## Validation

- `uv build --wheel` (verified `xnano/.agents/skills` in the wheel)
- `uv run prek run --all-files` (package/type checks pass; import-policy has one unchanged main-branch violation in `xnano/utils/deprecation.py`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hsaeed3/xnano/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

