### PR TITLE
perf: avoid deprecated alias wrapper overhead

### DIFF
--- a/tests/test_color_alias_and_text_default.py
+++ b/tests/test_color_alias_and_text_default.py
@@ -157,10 +157,10 @@ def test_content_primitive_color_alias_round_trips() -> None:
     with pytest.warns(DeprecationWarning):
         run = Run(
             text="x",
-            color="cyan",  # ty: ignore[unknown-argument]
+            color="cyan",
         )
     assert run.foreground == "cyan"
-    assert run.color == "cyan"  # ty: ignore[unresolved-attribute]
+    assert run.color == "cyan"
 
     # Classmethod constructors carry the alias too — the dataclass
     # decorator only wraps ``__init__``.

--- a/xnano/core/content.py
+++ b/xnano/core/content.py
@@ -25,9 +25,11 @@ from xnano.types import (
     Side,
 )
 from xnano.utils.deprecation import (
-    align_alias_dataclass,
+    _ALIAS_UNSET,
     color_alias_dataclass,
+    renamed_alias_property,
     resolve_color_alias,
+    resolve_init_alias,
 )
 
 
@@ -52,7 +54,7 @@ class ContentBase:
 AbstractContent = ContentBase
 
 
-@color_alias_dataclass
+@renamed_alias_property("color", "foreground")
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class Run(ContentBase):
     """One styled text run.
@@ -75,6 +77,12 @@ class Run(ContentBase):
     """Background color."""
     modifiers: tuple[CharacterModifier, ...] = ()
     """Character modifiers."""
+    color: dataclasses.InitVar[Any] = _ALIAS_UNSET
+    """Deprecated alias for ``foreground``."""
+
+    def __post_init__(self, color: Any) -> None:
+        """Apply the deprecated constructor alias."""
+        resolve_init_alias(self, color, old="color", new="foreground")
 
     @classmethod
     def plain(
@@ -116,8 +124,8 @@ class Run(ContentBase):
         )
 
 
-@align_alias_dataclass
-@color_alias_dataclass
+@renamed_alias_property("align", "horizontal_align")
+@renamed_alias_property("color", "foreground")
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class TextBlock(ContentBase):
     """Wrapped plain text or lines of styled runs.
@@ -152,6 +160,15 @@ class TextBlock(ContentBase):
     """Vertical alignment within the painted area."""
     wrap: bool = True
     """Whether long lines wrap."""
+    color: dataclasses.InitVar[Any] = _ALIAS_UNSET
+    """Deprecated alias for ``foreground``."""
+    align: dataclasses.InitVar[Any] = _ALIAS_UNSET
+    """Deprecated alias for ``horizontal_align``."""
+
+    def __post_init__(self, color: Any, align: Any) -> None:
+        """Apply deprecated constructor aliases."""
+        resolve_init_alias(self, color, old="color", new="foreground")
+        resolve_init_alias(self, align, old="align", new="horizontal_align")
 
     @classmethod
     def from_plain(

--- a/xnano/utils/deprecation.py
+++ b/xnano/utils/deprecation.py
@@ -26,6 +26,7 @@ _CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
 _COLOR_MESSAGE = (
     "The 'color' parameter is deprecated; use 'foreground' instead."
 )
+_ALIAS_UNSET = object()
 
 
 def warn_color_alias(stacklevel: int = 3) -> None:
@@ -169,6 +170,49 @@ def renamed_alias_dataclass(
     return decorate
 
 
+def renamed_alias_property(
+    old: str, new: str
+) -> Callable[[_ClassT], _ClassT]:
+    """Install a deprecated alias property on a dataclass.
+
+    Use with a dataclass ``InitVar`` when the alias is on a hot constructor;
+    this keeps the generated initializer instead of wrapping it with
+    ``*args``/``**kwargs``.
+    """
+
+    def decorate(cls: _ClassT) -> _ClassT:
+        setattr(
+            cls,
+            old,
+            property(
+                lambda self: getattr(self, new),
+                lambda self, value: setattr(self, new, value),
+            ),
+        )
+        return cls
+
+    return decorate
+
+
+def resolve_init_alias(
+    instance: Any,
+    value: Any,
+    *,
+    old: str,
+    new: str,
+) -> None:
+    """Apply a deprecated dataclass ``InitVar`` alias in ``__post_init__``."""
+    if value is _ALIAS_UNSET:
+        return
+    warnings.warn(
+        f"The '{old}' parameter is deprecated; use '{new}' instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    if getattr(instance, new) is None:
+        object.__setattr__(instance, new, value)
+
+
 color_alias_dataclass = renamed_alias_dataclass("color", "foreground")
 """Deprecated ``color`` alias for a dataclass ``foreground`` field."""
 
@@ -180,6 +224,8 @@ __all__ = (
     "align_alias_dataclass",
     "color_alias_dataclass",
     "renamed_alias_dataclass",
+    "renamed_alias_property",
+    "resolve_init_alias",
     "resolve_renamed_alias",
     "resolve_color_alias",
     "warn_color_alias",


### PR DESCRIPTION
## Summary

- keep dataclass-generated constructors for hot `Run` and `TextBlock` content
- preserve deprecated `color`/`align` compatibility via `InitVar` aliases
- remove the per-construction `*args`/`**kwargs` wrapper from these paths

## Validation

- `uv run pytest tests/test_color_alias_and_text_default.py tests/test_utils.py tests/components/test_text.py -q`
- `uv run ty check`
- 200k `Run(...)` constructions: 0.150s → 0.134s locally

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hsaeed3/xnano/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

