### PR TITLE
release: xnano 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Furthermore, `xnano` itself uses the [`pydantic-core`](https://github.com/pydant
 ## Installation
 
 ```bash
-pip install "xnano>=1.2.3b2"
+pip install "xnano>=1.2.3"
 ```
 
 Or use ``uv``:
 
 ```bash
-uv add "xnano>=1.2.3b2"
+uv add "xnano>=1.2.3"
 ```
 
 > [!TIP]

--- a/docs/core-concepts/actions.md
+++ b/docs/core-concepts/actions.md
@@ -157,7 +157,7 @@ ctx.actions.perform(Action.clipboard("pasted text"))
     - Change the initial `count` default.
     - Perform `INCREMENT` a third time before the final render.
 
-```pyodide install="xnano>=1.2.3b2" height="12"
+```pyodide install="xnano>=1.2.3" height="12"
 from xnano import Action, BaseGrid, Field, Terminal, on_action
 
 INCREMENT = Action.keyboard("right")

--- a/docs/core-concepts/components.md
+++ b/docs/core-concepts/components.md
@@ -81,7 +81,7 @@ whatever the component paints. See [Fields](fields.md) and [State](state.md).
     - Change `value=` on the `Loader` (0.0–1.0).
     - Change `style` to `"line"` or `"spinner"`.
 
-```pyodide install="xnano>=1.2.3b2" height="11"
+```pyodide install="xnano>=1.2.3" height="11"
 from xnano import BaseGrid, Field, render
 from xnano.components.loader import Loader
 
@@ -129,7 +129,7 @@ Text([
     - Change a nested `foreground`.
     - Change the status string.
 
-```pyodide install="xnano>=1.2.3b2" height="8"
+```pyodide install="xnano>=1.2.3" height="8"
 from xnano import render
 from xnano.components.text import Text
 

--- a/docs/core-concepts/fields.md
+++ b/docs/core-concepts/fields.md
@@ -92,7 +92,7 @@ The full keyword list is on the [Field]{data-preview} API page.
     - Change `foreground` on `heading` (e.g. `"emerald-400"`).
     - Change `border` to `"double"` or `"plain"`.
 
-```pyodide install="xnano>=1.2.3b2" height="12"
+```pyodide install="xnano>=1.2.3" height="12"
 from xnano import BaseGrid, Field, render
 
 class Card(BaseGrid, direction="vertical"):
@@ -147,7 +147,7 @@ attribute when you do not need that.
     - Change `heading`'s `default=`.
     - Add another entry to the `tags` list (it still will not paint).
 
-```pyodide install="xnano>=1.2.3b2" height="8"
+```pyodide install="xnano>=1.2.3" height="8"
 from xnano import BaseGrid, Field, render
 
 class Card(BaseGrid, direction="vertical"):

--- a/docs/core-concepts/grids.md
+++ b/docs/core-concepts/grids.md
@@ -174,7 +174,7 @@ with [`Field`](fields.md){data-preview}.
     - Change `direction` between `"vertical"` and `"horizontal"`.
     - Change the `title` field's `default=`.
 
-```pyodide install="xnano>=1.2.3b2" height="8"
+```pyodide install="xnano>=1.2.3" height="8"
 from xnano import BaseGrid, Field, render
 
 class App(BaseGrid, direction="vertical"):
@@ -211,7 +211,7 @@ are separate from individual fields.
     - Change `gap` (e.g. `0` or `2`).
     - Change `direction` to `"vertical"`.
 
-```pyodide install="xnano>=1.2.3b2" height="7"
+```pyodide install="xnano>=1.2.3" height="7"
 from xnano import BaseGrid, Field, render
 
 class Dashboard(BaseGrid, direction="horizontal", gap=1, border="rounded", title=" Dashboard "):

--- a/docs/core-concepts/markdown.md
+++ b/docs/core-concepts/markdown.md
@@ -127,7 +127,7 @@ print(frame.text)
     - Change the heading text.
     - Add a second paragraph to the string.
 
-```pyodide install="xnano>=1.2.3b2" height="12"
+```pyodide install="xnano>=1.2.3" height="12"
 from xnano.markdown import render_markdown
 
 frame = render_markdown("# Hello\n\nA single frame from Markdown.")

--- a/docs/core-concepts/overview.md
+++ b/docs/core-concepts/overview.md
@@ -107,7 +107,7 @@ writes them out. It does not start an event loop.
     - Change `foreground` on the `Text`.
     - Change `modifiers` (e.g. `["bold", "italic"]`).
 
-```pyodide install="xnano>=1.2.3b2" height="8"
+```pyodide install="xnano>=1.2.3" height="8"
 from xnano import render
 from xnano.components.text import Text
 

--- a/docs/core-concepts/styling.md
+++ b/docs/core-concepts/styling.md
@@ -60,7 +60,7 @@ weights `50`–`950`.
     - Change any `background=` value.
     - Change a `foreground=` value.
 
-```pyodide install="xnano>=1.2.3b2" height="8"
+```pyodide install="xnano>=1.2.3" height="8"
 from xnano import render
 from xnano.components.text import Text
 
@@ -101,7 +101,7 @@ Border styles include `"plain"`, `"rounded"`, `"double"`, `"thick"`,
     - Change `border` on the field.
     - Change `modifiers` (e.g. add `"underline"`).
 
-```pyodide install="xnano>=1.2.3b2" height="6"
+```pyodide install="xnano>=1.2.3" height="6"
 from xnano import BaseGrid, Field, render
 
 class Card(BaseGrid):

--- a/docs/core-concepts/terminal.md
+++ b/docs/core-concepts/terminal.md
@@ -84,7 +84,7 @@ control. It does not run the event loop.
     - Change the string.
     - Change `color` (e.g. `"emerald-400"`).
 
-```pyodide install="xnano>=1.2.3b2" height="3"
+```pyodide install="xnano>=1.2.3" height="3"
 from xnano import render
 
 render("hello, terminal!", foreground="blue")
@@ -142,7 +142,7 @@ terminal.run(App()) # (1)!
     - Change `title`'s `default=`.
     - Change `border` on the title field.
 
-```pyodide install="xnano>=1.2.3b2" height="9"
+```pyodide install="xnano>=1.2.3" height="9"
 from xnano import BaseGrid, Field, render
 
 class App(BaseGrid, direction="vertical"):

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,13 +32,13 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "pip"
 
     ```bash title="Install with pip"
-    pip install "xnano>=1.2.3b2"
+    pip install "xnano>=1.2.3"
     ```
 
 === "uv"
 
     ```bash title="Install with uv"
-    uv pip install "xnano>=1.2.3b2"
+    uv pip install "xnano>=1.2.3"
 
     # or add to your project's dependencies
     # uv add xnano
@@ -47,7 +47,7 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "poetry"
 
     ```bash title="Install with poetry"
-    poetry install "xnano>=1.2.3b2"
+    poetry install "xnano>=1.2.3"
 
     # or add to your project's dependencies
     # poetry add xnano
@@ -56,7 +56,7 @@ You can install [xnano]{data-preview} with your favorite package manager on pyth
 === "conda"
 
     ```bash title="Install with conda"
-    conda install "xnano>=1.2.3b2"
+    conda install "xnano>=1.2.3"
     ```
 
 ## Notetaking Application
@@ -120,7 +120,7 @@ With placeholder labels filled in, the same layout paints as a single frame:
     - Change `saved_notes` `width` (e.g. `"30%"`).
     - Change a panel `default=` string.
 
-```pyodide install="xnano>=1.2.3b2" height="12"
+```pyodide install="xnano>=1.2.3" height="12"
 from xnano import BaseGrid, Field, render
 
 class Dashboard(BaseGrid):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ members = [
 
 [project]
 name = "xnano"
-version = "1.2.3b2"
+version = "1.2.3"
 authors = [{ name = "Hammad Saeed", email = "hammad@supportvectors.com" }]
 description = "A simple python **tui** framework built on top of the ``[ratatui](https://ratatui.rs)`` and ``[tachyonfx](https://github.com/ratatui/tachyonfx)`` rust crates."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2439,7 +2439,7 @@ wheels = [
 
 [[package]]
 name = "xnano"
-version = "1.2.3b2"
+version = "1.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },

--- a/xnano/__init__.py
+++ b/xnano/__init__.py
@@ -16,7 +16,7 @@ try:
 except (
     importlib.metadata.PackageNotFoundError
 ):  # pragma: no cover - editable / source trees
-    __version__ = "1.2.3b2"
+    __version__ = "1.2.3"
 
 if TYPE_CHECKING:
     from xnano import cli, components, core, events, hooks, requests


### PR DESCRIPTION
## Summary

- bump xnano to v1.2.3
- synchronize package, documentation, README, and Pyodide install pins